### PR TITLE
fix(remove-validation)

### DIFF
--- a/view/app/self-host/components/create-form/deploy-form.tsx
+++ b/view/app/self-host/components/create-form/deploy-form.tsx
@@ -47,7 +47,7 @@ export const DeployForm = ({
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
   const canCreate = hasPermission(user, 'deploy', 'create', activeOrg?.id);
 
-  const { validateEnvVar, form, onSubmit, parsePort, validateDomain } = useCreateDeployment({
+  const { validateEnvVar, form, onSubmit, parsePort } = useCreateDeployment({
     application_name,
     environment,
     branch,


### PR DESCRIPTION

_because user experience is frustrating when user has to go to domain section if validation fails, let user add whatever they want, we need to verify whether it belongs to their server or not with another api endpoint instead_