### PR TITLE
Fix Port Confliction in Self Hosted Appications

### DIFF
--- a/api/internal/features/deploy/types/init.go
+++ b/api/internal/features/deploy/types/init.go
@@ -94,6 +94,7 @@ var (
 	ErrDockerComposeFileNotFound    = errors.New("docker-compose file not found")
 	ErrDockerComposeCommandFailed   = errors.New("docker-compose command failed")
 	ErrDockerComposeInvalidConfig   = errors.New("invalid docker-compose configuration")
+	ErrFailedToGetAvailablePort     = errors.New("failed to get available port")
 )
 
 const (


### PR DESCRIPTION
### Port Configuration Update

`Nixopus` now randomly assigns a port for self-hosted applications by default.  
However, users **must specify which port is exposed from within the container**

 (i.e., the internal port your application listens on) to ensure proper routing.

For example, if your container listens on port `3000` and then user must enter this port in the ui form when deploying