### PR TITLE
Dev Container : Uses localWorkspaceFolder instead of /nixopus dir

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,8 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  // Mount the /nixopus/ directory from the host to the container
   "mounts": [
-    "source=/nixopus,target=/nixopus,type=bind"
+    "source=${localWorkspaceFolder},target=/workspace,type=bind"
   ],
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Changes
This resolves the bug introduced in #90, which caused the `/nixopus` directory to appear in the root of the project. The issue stemmed from a hardcoded path. By using localWorkspaceFolder, this fix removes the need for that hardcoded value.