### PR TITLE
hot-fix: theming issue due to base path and footer preview in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Nixopus is a powerful platform designed to simplify VPS management. Whether you'
 - [Acknowledgments](#acknowledgments)
 - [About the Name](#about-the-name)
 - [Contributors](#contributors)
-- [Sponsors](#sponsors)
+- [🎗️ Sponsors](#️-sponsors)
 
 ## Demo / Screenshots
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,7 +14,7 @@ export default withMermaid(
     title: "Nixopus Docs",
     description: "documentation",
     head: [['link', { rel: 'icon', href: '/favicon.png' }]],
-    base: '/',
+    base: '/nixopus/',
     themeConfig: {
       search: {
         provider: 'local',

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,8 +56,12 @@ export default withMermaid(
         { text: 'Blog', link: '/blog/' }
       ],
       footer: {
-        message: `<p align="center"><p align="center"><img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /></p><br>
-    Released under the Functional Source License (FSL)</p>`,
+        message: `
+          <p style="text-align:center">
+            <img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /><br/>
+            Released under the Functional Source License (FSL)
+          </p>
+        `,
         copyright: 'Copyright © 2025-present Nixopus'
       },
       sidebar: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,18 +57,12 @@ export default withMermaid(
       ],
       footer: {
         message: `
-          <p style="text-align:center">
-            <img
-              src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source"
-              alt="Made with love with Open Source"
-              style="display: block; margin: 0 auto;"
-            />
-            <br />
-            Released under the Functional Source License (FSL)
-            <br />
-            Copyright © 2025-present Nixopus
-          </p>
+          <img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open%20Source"
+               alt="Made with love"
+               style="display:block;margin:0 auto;" />
+          <br>Released under the Functional Source License (FSL)
         `,
+        copyright: 'Copyright © 2025–present Nixopus'
       },
       sidebar: [
         {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -65,9 +65,10 @@ export default withMermaid(
             />
             <br />
             Released under the Functional Source License (FSL)
+            <br />
+            Copyright © 2025-present Nixopus
           </p>
         `,
-        copyright: 'Copyright © 2025-present Nixopus'
       },
       sidebar: [
         {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,12 +56,7 @@ export default withMermaid(
         { text: 'Blog', link: '/blog/' }
       ],
       footer: {
-        message: `
-          <img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open%20Source"
-               alt="Made with love"
-               style="display:block;margin:0 auto;" />
-          <br>Released under the Functional Source License (FSL)
-        `,
+        message: `<img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open%20Source" alt="Made with love" style="display:block;margin:0 auto;" /><br>Released under the Functional Source License (FSL)`,
         copyright: 'Copyright © 2025–present Nixopus'
       },
       sidebar: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,8 +56,8 @@ export default withMermaid(
         { text: 'Blog', link: '/blog/' }
       ],
       footer: {
-        message: `<><p align="center"><img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /></p><br>
-    Released under the Functional Source License (FSL)<>`,
+        message: `<p align="center"><p align="center"><img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /></p><br>
+    Released under the Functional Source License (FSL)</p>`,
         copyright: 'Copyright © 2025-present Nixopus'
       },
       sidebar: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,8 +56,8 @@ export default withMermaid(
         { text: 'Blog', link: '/blog/' }
       ],
       footer: {
-        message: `<p align="center"><img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /></p>
-          Released under the Functional Source License (FSL)
+        message: `<><p align="center"><img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /></p><br>
+    Released under the Functional Source License (FSL)<>
         `,
         copyright: 'Copyright © 2025-present Nixopus'
       },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -58,7 +58,12 @@ export default withMermaid(
       footer: {
         message: `
           <p style="text-align:center">
-            <img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /><br/>
+            <img
+              src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source"
+              alt="Made with love with Open Source"
+              style="display: block; margin: 0 auto;"
+            />
+            <br />
             Released under the Functional Source License (FSL)
           </p>
         `,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,8 +57,7 @@ export default withMermaid(
       ],
       footer: {
         message: `<><p align="center"><img src="https://madewithlove.now.sh/in?heart=true&colorA=%23ff671f&colorB=%23046a38&text=Open Source" alt="Made with love with Open Source" /></p><br>
-    Released under the Functional Source License (FSL)<>
-        `,
+    Released under the Functional Source License (FSL)<>`,
         copyright: 'Copyright © 2025-present Nixopus'
       },
       sidebar: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the site’s base URL to '/nixopus/'.
  - Simplified and restyled the footer, including a more concise image alt text and improved layout.
  - Updated copyright formatting with an en dash.
  - Added an emoji to the "Sponsors" entry in the Table of Contents for enhanced visual appeal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->