### PR TITLE
fix: feature flags shows disabled on login until refresh

### DIFF
--- a/view/hooks/features_provider.tsx
+++ b/view/hooks/features_provider.tsx
@@ -1,5 +1,6 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useMemo, useEffect } from 'react';
 import { useGetAllFeatureFlagsQuery } from '@/redux/services/feature-flags/featureFlagsApi';
+import { useAppSelector } from '@/redux/hooks';
 import type { FeatureFlag } from '@/types/feature-flags';
 
 interface FeatureFlagsContextType {
@@ -17,7 +18,18 @@ const FeatureFlagsContext = createContext<FeatureFlagsContextType>({
 });
 
 export const FeatureFlagsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { data: features = [], isLoading, error } = useGetAllFeatureFlagsQuery();
+  const { isAuthenticated, isInitialized } = useAppSelector((state) => state.auth);
+  const activeOrganization = useAppSelector((state) => state.user.activeOrganization);
+  
+  const { data: features = [], isLoading, error, refetch } = useGetAllFeatureFlagsQuery(undefined, {
+    skip: !isAuthenticated || !isInitialized
+  });
+
+  useEffect(() => {
+    if (isAuthenticated && isInitialized) {
+      refetch();
+    }
+  }, [isAuthenticated, isInitialized, activeOrganization?.id, refetch]);
 
   const isFeatureEnabled = useMemo(() => {
     return (featureName: string): boolean => {
@@ -28,12 +40,12 @@ export const FeatureFlagsProvider: React.FC<{ children: React.ReactNode }> = ({ 
 
   const value = useMemo(
     () => ({
-      features,
-      isLoading,
-      error,
+      features: isAuthenticated ? features : [],
+      isLoading: isAuthenticated ? isLoading : false,
+      error: isAuthenticated ? error : null,
       isFeatureEnabled
     }),
-    [features, isLoading, error, isFeatureEnabled]
+    [features, isLoading, error, isFeatureEnabled, isAuthenticated]
   );
 
   return <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;

--- a/view/hooks/features_provider.tsx
+++ b/view/hooks/features_provider.tsx
@@ -20,8 +20,13 @@ const FeatureFlagsContext = createContext<FeatureFlagsContextType>({
 export const FeatureFlagsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, isInitialized } = useAppSelector((state) => state.auth);
   const activeOrganization = useAppSelector((state) => state.user.activeOrganization);
-  
-  const { data: features = [], isLoading, error, refetch } = useGetAllFeatureFlagsQuery(undefined, {
+
+  const {
+    data: features = [],
+    isLoading,
+    error,
+    refetch
+  } = useGetAllFeatureFlagsQuery(undefined, {
     skip: !isAuthenticated || !isInitialized
   });
 


### PR DESCRIPTION
Closes #172 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of feature flag loading by ensuring they are only fetched when the user is authenticated and the app is initialized.
  - Feature flags are now automatically refreshed when authentication status, initialization, or organization changes.

- **Refactor**
  - Enhanced internal logic to provide more accurate feature flag data based on user authentication state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->