### PR TITLE
feat: add input password as custom component

### DIFF
--- a/api/api/versions.json
+++ b/api/api/versions.json
@@ -3,7 +3,7 @@
     {
       "version": "v1",
       "status": "active",
-      "release_date": "2025-07-05T10:51:37.94673+05:30",
+      "release_date": "2025-07-06T19:10:33.041483+05:30",
       "end_of_life": "0001-01-01T00:00:00Z",
       "changes": [
         "Initial API version"

--- a/view/app/register/page.tsx
+++ b/view/app/register/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PasswordInput } from '@/components/ui/password-input';
 import { cn } from '@/lib/utils';
 import nixopusLogo from '@/public/nixopus_logo_transparent.png';
 import useRegister from './hooks/use-register';
@@ -67,7 +68,7 @@ export default function RegisterPage() {
                     </div>
                     <div className="grid gap-3">
                       <Label htmlFor="password">{t('auth.password')}</Label>
-                      <Input id="password" type="password" {...form.register('password')} />
+                      <PasswordInput id="password" {...form.register('password')} />
                       {form.formState.errors.password && (
                         <p className="text-sm text-destructive">
                           {form.formState.errors.password.message}
@@ -76,9 +77,8 @@ export default function RegisterPage() {
                     </div>
                     <div className="grid gap-3">
                       <Label htmlFor="confirmPassword">{t('auth.register.confirmPassword')}</Label>
-                      <Input
+                      <PasswordInput
                         id="confirmPassword"
-                        type="password"
                         {...form.register('confirmPassword')}
                       />
                       {form.formState.errors.confirmPassword && (

--- a/view/app/reset-password/components/ResetPasswordForm.tsx
+++ b/view/app/reset-password/components/ResetPasswordForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { PasswordInput } from '@/components/ui/password-input';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -104,8 +105,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
                 <FormItem>
                   <FormLabel>{t('auth.resetPassword.newPassword')}</FormLabel>
                   <FormControl>
-                    <Input
-                      type="password"
+                    <PasswordInput
                       placeholder={t('auth.resetPassword.newPassword')}
                       {...field}
                     />
@@ -121,8 +121,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
                 <FormItem>
                   <FormLabel>{t('auth.resetPassword.confirmPassword')}</FormLabel>
                   <FormControl>
-                    <Input
-                      type="password"
+                    <PasswordInput
                       placeholder={t('auth.resetPassword.confirmPassword')}
                       {...field}
                     />

--- a/view/app/settings/notifications/components/channelTab.tsx
+++ b/view/app/settings/notifications/components/channelTab.tsx
@@ -9,6 +9,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Switch } from '@/components/ui/switch';
 import {
   Form,
@@ -231,8 +232,7 @@ const ChannelTab: React.FC<ChannelTabProps> = ({
                         {t('settings.notifications.channels.email.fields.smtp_password.label')}
                       </FormLabel>
                       <FormControl>
-                        <Input
-                          type="password"
+                        <PasswordInput
                           {...field}
                           placeholder={t(
                             'settings.notifications.channels.email.fields.smtp_password.placeholder'

--- a/view/app/settings/teams/components/AddMember.tsx
+++ b/view/app/settings/teams/components/AddMember.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import {
   Dialog,
   DialogContent,
@@ -120,9 +121,8 @@ function AddMember({
             <Label htmlFor="password" className="text-right">
               {t('settings.teams.addMember.dialog.fields.password.label')}
             </Label>
-            <Input
+            <PasswordInput
               id="password"
-              type="password"
               value={newUser.password}
               onChange={(e) => setNewUser({ ...newUser, password: e.target.value })}
               className="col-span-3"

--- a/view/components/features/login-form.tsx
+++ b/view/components/features/login-form.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PasswordInput } from '@/components/ui/password-input';
 import nixopusLogo from '@/public/nixopus_logo_transparent.png';
 import { useTranslation } from '@/hooks/use-translation';
 import Link from 'next/link';
@@ -61,9 +62,8 @@ export function LoginForm({ ...props }: LoginFormProps) {
                       </a>
                     </div> */}
                     <Label htmlFor="password">{t('auth.password')}</Label>
-                    <Input
+                    <PasswordInput
                       id="password"
-                      type="password"
                       required
                       value={props.password}
                       onChange={props.handlePasswordChange}

--- a/view/components/ui/password-input.tsx
+++ b/view/components/ui/password-input.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+}
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, ...props }, ref) => {
+    const [showPassword, setShowPassword] = useState(false);
+
+    const togglePasswordVisibility = () => {
+      setShowPassword(!showPassword);
+    };
+
+    return (
+      <div className="relative">
+        <Input
+          type={showPassword ? 'text' : 'password'}
+          className={cn('pr-10', className)}
+          ref={ref}
+          {...props}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+          onClick={togglePasswordVisibility}
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+        >
+          {showPassword ? (
+            <EyeOff className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Eye className="h-4 w-4 text-muted-foreground" />
+          )}
+        </Button>
+      </div>
+    );
+  }
+);
+
+PasswordInput.displayName = 'PasswordInput';
+
+export { PasswordInput };

--- a/view/components/ui/password-input.tsx
+++ b/view/components/ui/password-input.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -17,10 +17,10 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
     };
 
     return (
-      <div className="relative">
+      <div className="relative w-full">
         <Input
           type={showPassword ? 'text' : 'password'}
-          className={cn('pr-10', className)}
+          className={cn('pr-10 w-full', className)}
           ref={ref}
           {...props}
         />
@@ -28,7 +28,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
           type="button"
           variant="ghost"
           size="sm"
-          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+          className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 p-0 hover:bg-transparent"
           onClick={togglePasswordVisibility}
           aria-label={showPassword ? 'Hide password' : 'Show password'}
         >


### PR DESCRIPTION
Description:

This PR adds a new PasswordInput component with a show/hide password toggle (in view/components/ui).
Replaces all <Input type="password"> fields with the new component.


![test](https://github.com/user-attachments/assets/2f68de7f-5c1c-4f4c-a346-aefe16d0f939)
