### PR TITLE
fix: cli performance issue and startup speed improvement

### DIFF
--- a/cli/app/main.py
+++ b/cli/app/main.py
@@ -1,47 +1,22 @@
 import os
 import time
-
-startup_time = time.time()
-DEBUG_TIMING = os.environ.get("NIXOPUS_DEBUG_TIMING", "").lower() == "true"
-
-
-# TODO: @shravan20 Keeping it for now, can remove once ince impl for lazy loading for cmd modules
-def log_timing(message):
-    if DEBUG_TIMING:
-        elapsed = time.time() - startup_time
-        print(f"[TIMING] {elapsed:.3f}s - {message}")
-
-
-log_timing("Interpreter started")
-
 import typer
-
-log_timing("Imported typer")
 
 from importlib.metadata import version as get_version
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
-log_timing("Imported core dependencies")
-
-
 from app.commands.version.command import main_version_callback
-
-log_timing("Imported version callback only")
 
 from app.utils.message import application_add_completion, application_description, application_name, application_version_help
 from app.utils.config import Config
-
-log_timing("Imported utilities")
 
 app = typer.Typer(
     name=application_name,
     help=application_description,
     add_completion=application_add_completion,
 )
-
-log_timing("Created Typer app")
 
 
 @app.callback(invoke_without_command=True)
@@ -104,8 +79,6 @@ from app.commands.test.command import test_app
 from app.commands.uninstall.command import uninstall_app
 from app.commands.version.command import version_app
 
-log_timing("Imported all command modules")
-
 app.add_typer(preflight_app, name="preflight")
 app.add_typer(clone_app, name="clone")
 app.add_typer(conf_app, name="conf")
@@ -115,14 +88,9 @@ app.add_typer(install_app, name="install")
 app.add_typer(uninstall_app, name="uninstall")
 app.add_typer(version_app, name="version")
 
-log_timing("Registered all commands")
-
 config = Config()
 if config.is_development():
     app.add_typer(test_app, name="test")
-log_timing("Config checked and app fully initialized")
 
 if __name__ == "__main__":
-    log_timing("About to run app")
     app()
-    log_timing("App finished")

--- a/cli/app/main.py
+++ b/cli/app/main.py
@@ -25,7 +25,7 @@ from rich.text import Text
 
 log_timing("Imported core dependencies")
 
-# Import only what's needed for --version callback
+
 from app.commands.version.command import main_version_callback
 
 log_timing("Imported version callback only")
@@ -40,6 +40,7 @@ app = typer.Typer(
     help=application_description,
     add_completion=application_add_completion,
 )
+
 log_timing("Created Typer app")
 
 
@@ -60,8 +61,8 @@ def main(
         ascii_art = """
   _   _ _ _                           
  | \\ | (_)                          
- |  \\| |___  _____  _ __  _   _ ___ 
- | . ` | \\ \\/ / _ \\| '_ \\| | | / __|
+ |  \\| |___  _____  _ __  _   _ ___ ____
+ | . `  | \\ \\/ / _ \\| '_ \\| | | / __|
  | |\\  | |>  < (_) | |_) | |_| \\__ \\
  |_| \\_|_/_/\\_\\___/| .__/ \\__,_|___/
                    | |              
@@ -105,7 +106,6 @@ from app.commands.version.command import version_app
 
 log_timing("Imported all command modules")
 
-# Register all commands
 app.add_typer(preflight_app, name="preflight")
 app.add_typer(clone_app, name="clone")
 app.add_typer(conf_app, name="conf")

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -145,7 +145,7 @@ build_wheel() {
 }
 
 build_binary() {
-    log_info "Building binary in directory mode for fast startup..."
+    log_info "Building binary"
     
     poetry run pyinstaller --clean --noconfirm $SPEC_FILE
     
@@ -159,20 +159,19 @@ build_binary() {
     
     BINARY_DIR_NAME="${APP_NAME}_${OS}_${ARCH}"
     
-    # PyInstaller creates a directory in dist/nixopus/
-    if [[ -d "$BUILD_DIR/$APP_NAME" ]]; then
-        # Rename the directory to include platform info
+    
+    if [[ -d "$BUILD_DIR/$APP_NAME" ]]; then        
         mv "$BUILD_DIR/$APP_NAME" "$BUILD_DIR/$BINARY_DIR_NAME"
+
         
-        # Create a wrapper script for convenience
         cat > "$BUILD_DIR/$APP_NAME" << EOF
 #!/bin/bash
-# Nixopus CLI wrapper script
+# Nixopus CLI wrapper
 SCRIPT_DIR="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 exec "\$SCRIPT_DIR/$BINARY_DIR_NAME/$APP_NAME" "\$@"
 EOF
         chmod +x "$BUILD_DIR/$APP_NAME"
-        
+
         log_success "Binary directory built: $BUILD_DIR/$BINARY_DIR_NAME/"
         log_success "Wrapper script created: $BUILD_DIR/$APP_NAME"
     else
@@ -182,9 +181,9 @@ EOF
 }
 
 test_binary() {
-    log_info "Testing binary..."
     
-    # Test the wrapper script
+    log_info "Testing binary..."
+
     WRAPPER_PATH="$BUILD_DIR/$APP_NAME"
     
     if [[ -f "$WRAPPER_PATH" ]]; then
@@ -218,17 +217,13 @@ create_release_archive() {
     
     cd $BUILD_DIR
     
-    # Archive the directory and wrapper script
-    if [[ -d "$BINARY_DIR_NAME" && -f "$APP_NAME" ]]; then
-        if [[ "$OS" == "darwin" || "$OS" == "linux" ]]; then
-            tar -czf "${ARCHIVE_NAME}.tar.gz" "$BINARY_DIR_NAME" "$APP_NAME"
-            log_success "Archive created: $BUILD_DIR/${ARCHIVE_NAME}.tar.gz"
-        elif [[ "$OS" == "mingw"* || "$OS" == "cygwin"* || "$OS" == "msys"* ]]; then
-            zip -r "${ARCHIVE_NAME}.zip" "$BINARY_DIR_NAME" "$APP_NAME"
-            log_success "Archive created: $BUILD_DIR/${ARCHIVE_NAME}.zip"
-        fi
-    else
-        log_error "Binary directory or wrapper not found for archiving"
+
+    if [[ "$OS" == "darwin" || "$OS" == "linux" ]]; then
+        tar -czf "${ARCHIVE_NAME}.tar.gz" "$BINARY_DIR_NAME" "$APP_NAME"
+        log_success "Archive created: $BUILD_DIR/${ARCHIVE_NAME}.tar.gz"
+    elif [[ "$OS" == "mingw"* || "$OS" == "cygwin"* || "$OS" == "msys"* ]]; then
+        zip -r "${ARCHIVE_NAME}.zip" "$BINARY_DIR_NAME" "$APP_NAME"
+        log_success "Archive created: $BUILD_DIR/${ARCHIVE_NAME}.zip"
     fi
     
     cd ..

--- a/cli/perf_check.sh
+++ b/cli/perf_check.sh
@@ -1,0 +1,16 @@
+# TODO: @shravan20 - Delte before merging to master or feat/dev
+echo "itr \tBinary RUN\t Poetry Run"
+
+x=()
+y=()
+
+
+for i in {1..3}; do
+    x[$i]=$( (time ./dist/nixopus --help > /dev/null 2>&1) 2>&1 | grep real | awk '{print $2}' )
+    echo  "$i\t${x[$i]}\t\t-"
+done
+
+for i in {1..3}; do
+    y[$i]=$( (time poetry run nixopus --help > /dev/null 2>&1) 2>&1 | grep real | awk '{print $2}' )
+    echo "$i\t-\t\t   ${y[$i]}"
+done


### PR DESCRIPTION
**_Issue_**: The CLI performance issue was caused by PyInstaller's single-file mode `--onefile` whuich extracts the entire Python interpreter and dependencies to a temporary directory on each run
and execs the cmd from the temp location and cleans up after exec.


**_Fix_**: Switched from single-file to directory-based distribution using PyInstaller's COLLECT mode, so modified the build configuration in build logic.

_Bfr `nixopus --help` = 2-4s vs After `nixopus --help` = -0m0.398s_ 



