### PR TITLE
fix: support older glibc versions

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-and-package:
-    runs-on: ubuntu-20
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
 
@@ -176,7 +176,7 @@ jobs:
 
   create-release:
     needs: build-and-package
-    runs-on: ubuntu-20
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to run on Ubuntu 22.04 for more consistent builds and compatibility with tooling.
  * Build, packaging, and release creation steps remain unchanged; only the execution environment was adjusted.
  * No user-facing changes or behavior impacts expected; improves predictability by reducing variability from runner updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->