### PR TITLE
fix(ci): fix format workflow auto-commit on pushes

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - feat/develop
-  pull_request:
-    branches:
-      - master
-      - feat/develop
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description:

Remove PR only guard blocking commits on pushes and use default checkout ref, commit to current branch, add [skip ci], guard against bot loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined formatting workflows across API, View, and CLI.
  * Switched to actor-based gating to prevent bot-triggered loops and reduce noise.
  * Auto-commit messages now include “[skip ci]” to avoid unnecessary rebuilds.
  * Simplified commit configuration for more reliable formatting runs.
  * Optimized CI steps by reducing redundant fetch/checkout operations, improving speed and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->