### PR TITLE
fix(cli): force reinstall didn’t refresh stack

### DIFF
--- a/api/api/versions.json
+++ b/api/api/versions.json
@@ -3,7 +3,7 @@
     {
       "version": "v1",
       "status": "active",
-      "release_date": "2025-09-07T20:07:45.474045+05:30",
+      "release_date": "2025-09-07T21:18:47.855954+05:30",
       "end_of_life": "0001-01-01T00:00:00Z",
       "changes": [
         "Initial API version"

--- a/api/api/versions.json
+++ b/api/api/versions.json
@@ -3,7 +3,7 @@
     {
       "version": "v1",
       "status": "active",
-      "release_date": "2025-09-03T02:32:19.06053+05:30",
+      "release_date": "2025-09-07T20:07:45.474045+05:30",
       "end_of_life": "0001-01-01T00:00:00Z",
       "changes": [
         "Initial API version"

--- a/cli/app/commands/install/run.py
+++ b/cli/app/commands/install/run.py
@@ -177,7 +177,9 @@ class Install:
         compose_file = self._get_config("compose_file_path")
 
         if self.dry_run:
-            self.logger.info("[dry-run] Would run: docker compose -f {compose_file} down --rmi all --volumes --remove-orphans")
+            self.logger.info(
+                f"[dry-run] Would run: docker compose -f {compose_file} down --rmi all --volumes --remove-orphans"
+            )
             return
 
         if not compose_file or not os.path.exists(compose_file):

--- a/cli/app/commands/install/run.py
+++ b/cli/app/commands/install/run.py
@@ -1,5 +1,6 @@
 import typer
 import os
+import subprocess
 import yaml
 import json
 import shutil
@@ -96,6 +97,11 @@ class Install:
             ("Starting services", self._start_services),
         ]
         
+        # If force is enabled, add a Docker cleanup step before cloning to ensure fresh images/containers
+        if self.force:
+            # Insert cleanup as the third step (index 2), right before cloning the repo
+            steps.insert(2, ("Cleaning up Docker resources", self._cleanup_docker))
+
         # Only add proxy steps if both api_domain and view_domain are provided
         if self.api_domain and self.view_domain:
             steps.append(("Loading proxy configuration", self._load_proxy))
@@ -129,6 +135,43 @@ class Install:
             self._handle_installation_error(e)
             self.logger.error(f"{installation_failed}: {str(e)}")
             raise typer.Exit(1)
+
+    def _cleanup_docker(self):
+        if self.dry_run:
+            self.logger.info("[dry-run] Would run: docker compose down --rmi all --volumes --remove-orphans")
+            return
+
+        compose_file = self._get_config('compose_file_path')
+        if not os.path.exists(compose_file):
+            # Nothing to clean specific to this deployment
+            self.logger.debug(f"Compose file not found at {compose_file}; skipping docker cleanup")
+            return
+
+        cmd = [
+            "docker", "compose",
+            "-f", compose_file,
+            "down",
+            "--rmi", "all",
+            "--volumes",
+            "--remove-orphans",
+        ]
+
+        try:
+            self.logger.debug(f"Executing docker cleanup: {' '.join(cmd)}")
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            stdout = (result.stdout or '').strip()
+            stderr = (result.stderr or '').strip()
+            if stdout:
+                self.logger.debug(stdout)
+            if stderr:
+                self.logger.debug(stderr)
+            if result.returncode == 0:
+                self.logger.info("Docker resources cleaned (images, volumes, orphans)")
+            else:
+                self.logger.warning(f"Docker cleanup exited with code {result.returncode}; continuing")
+        except Exception as e:
+            # Do not fail installation because cleanup is best-effort
+            self.logger.warning(f"Failed to cleanup docker resources: {e}")
 
     def _handle_installation_error(self, error, context=""):
         context_msg = f" during {context}" if context else ""

--- a/cli/app/commands/install/run.py
+++ b/cli/app/commands/install/run.py
@@ -213,7 +213,7 @@ class Install:
             else:
                 self.logger.warning(f"Docker cleanup exited with code {result.returncode}; continuing")
         except Exception as e:
-            # Do not fail installation because cleanup is best-effort
+            # Do not fail installation because cleanup is best effort
             self.logger.warning(f"Failed to cleanup docker resources: {e}")
 
     def _handle_installation_error(self, error, context=""):

--- a/cli/app/commands/install/run.py
+++ b/cli/app/commands/install/run.py
@@ -6,7 +6,25 @@ import json
 import shutil
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
 from app.utils.protocols import LoggerProtocol
-from app.utils.config import Config, VIEW_ENV_FILE, API_ENV_FILE, DEFAULT_REPO, DEFAULT_BRANCH, DEFAULT_PATH, NIXOPUS_CONFIG_DIR, PORTS, DEFAULT_COMPOSE_FILE, PROXY_PORT, SSH_KEY_TYPE, SSH_KEY_SIZE, SSH_FILE_PATH, VIEW_PORT, API_PORT, DOCKER_PORT, CADDY_CONFIG_VOLUME
+from app.utils.config import (
+    Config,
+    VIEW_ENV_FILE,
+    API_ENV_FILE,
+    DEFAULT_REPO,
+    DEFAULT_BRANCH,
+    DEFAULT_PATH,
+    NIXOPUS_CONFIG_DIR,
+    PORTS,
+    DEFAULT_COMPOSE_FILE,
+    PROXY_PORT,
+    SSH_KEY_TYPE,
+    SSH_KEY_SIZE,
+    SSH_FILE_PATH,
+    VIEW_PORT,
+    API_PORT,
+    DOCKER_PORT,
+    CADDY_CONFIG_VOLUME,
+)
 from app.utils.timeout import TimeoutWrapper
 from app.commands.preflight.run import PreflightRunner
 from app.commands.clone.clone import Clone, CloneConfig
@@ -17,11 +35,19 @@ from app.commands.service.up import Up, UpConfig
 from app.commands.proxy.load import Load, LoadConfig
 from .ssh import SSH, SSHConfig
 from .messages import (
-    installation_failed, installing_nixopus,
+    installation_failed,
+    installing_nixopus,
     dependency_installation_timeout,
-    clone_failed, env_file_creation_failed, env_file_permissions_failed, 
-    proxy_config_created, ssh_setup_failed, services_start_failed, proxy_load_failed,
-    operation_timed_out, created_env_file, configuration_key_has_no_default_value
+    clone_failed,
+    env_file_creation_failed,
+    env_file_permissions_failed,
+    proxy_config_created,
+    ssh_setup_failed,
+    services_start_failed,
+    proxy_load_failed,
+    operation_timed_out,
+    created_env_file,
+    configuration_key_has_no_default_value,
 )
 from .deps import install_all_deps
 
@@ -30,33 +56,43 @@ _config_dir = _config.get_yaml_value(NIXOPUS_CONFIG_DIR)
 _source_path = _config.get_yaml_value(DEFAULT_PATH)
 
 DEFAULTS = {
-    'proxy_port': _config.get_yaml_value(PROXY_PORT),
-    'ssh_key_type': _config.get_yaml_value(SSH_KEY_TYPE),   
-    'ssh_key_size': _config.get_yaml_value(SSH_KEY_SIZE),
-    'ssh_passphrase': None,
-    'service_name': 'all',
-    'service_detach': True,
-    'required_ports': [int(port) for port in _config.get_yaml_value(PORTS)],
-    'repo_url': _config.get_yaml_value(DEFAULT_REPO),
-    'branch_name': _config.get_yaml_value(DEFAULT_BRANCH),
-    'source_path': _source_path,
-    'config_dir': _config_dir,
-    'api_env_file_path': _config.get_yaml_value(API_ENV_FILE),
-    'view_env_file_path': _config.get_yaml_value(VIEW_ENV_FILE),
-    'compose_file': _config.get_yaml_value(DEFAULT_COMPOSE_FILE),
-    'full_source_path': os.path.join(_config_dir, _source_path),
-    'ssh_key_path': _config_dir + "/" + _config.get_yaml_value(SSH_FILE_PATH),
-    'compose_file_path': _config_dir + "/" + _config.get_yaml_value(DEFAULT_COMPOSE_FILE),
-    'host_os': HostInformation.get_os_name(),
-    'package_manager': HostInformation.get_package_manager(),
-    'view_port': _config.get_yaml_value(VIEW_PORT),
-    'api_port': _config.get_yaml_value(API_PORT),   
-    'docker_port': _config.get_yaml_value(DOCKER_PORT),
+    "proxy_port": _config.get_yaml_value(PROXY_PORT),
+    "ssh_key_type": _config.get_yaml_value(SSH_KEY_TYPE),
+    "ssh_key_size": _config.get_yaml_value(SSH_KEY_SIZE),
+    "ssh_passphrase": None,
+    "service_name": "all",
+    "service_detach": True,
+    "required_ports": [int(port) for port in _config.get_yaml_value(PORTS)],
+    "repo_url": _config.get_yaml_value(DEFAULT_REPO),
+    "branch_name": _config.get_yaml_value(DEFAULT_BRANCH),
+    "source_path": _source_path,
+    "config_dir": _config_dir,
+    "api_env_file_path": _config.get_yaml_value(API_ENV_FILE),
+    "view_env_file_path": _config.get_yaml_value(VIEW_ENV_FILE),
+    "compose_file": _config.get_yaml_value(DEFAULT_COMPOSE_FILE),
+    "full_source_path": os.path.join(_config_dir, _source_path),
+    "ssh_key_path": _config_dir + "/" + _config.get_yaml_value(SSH_FILE_PATH),
+    "compose_file_path": _config_dir + "/" + _config.get_yaml_value(DEFAULT_COMPOSE_FILE),
+    "host_os": HostInformation.get_os_name(),
+    "package_manager": HostInformation.get_package_manager(),
+    "view_port": _config.get_yaml_value(VIEW_PORT),
+    "api_port": _config.get_yaml_value(API_PORT),
+    "docker_port": _config.get_yaml_value(DOCKER_PORT),
 }
 
 
 class Install:
-    def __init__(self, logger: LoggerProtocol = None, verbose: bool = False, timeout: int = 300, force: bool = False, dry_run: bool = False, config_file: str = None, api_domain: str = None, view_domain: str = None):
+    def __init__(
+        self,
+        logger: LoggerProtocol = None,
+        verbose: bool = False,
+        timeout: int = 300,
+        force: bool = False,
+        dry_run: bool = False,
+        config_file: str = None,
+        api_domain: str = None,
+        view_domain: str = None,
+    ):
         self.logger = logger
         self.verbose = verbose
         self.timeout = timeout
@@ -69,22 +105,23 @@ class Install:
         self.progress = None
         self.main_task = None
         self._validate_domains()
-    
+
     def _get_config(self, key: str):
         try:
             return _config.get_config_value(key, self._user_config, DEFAULTS)
         except ValueError:
             raise ValueError(configuration_key_has_no_default_value.format(key=key))
-    
+
     def _validate_domains(self):
         if (self.api_domain is None) != (self.view_domain is None):
             raise ValueError("Both api_domain and view_domain must be provided together, or neither should be provided")
-        
+
         if self.api_domain and self.view_domain:
-            domain_pattern = re.compile(r'^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?))*$')
+            domain_pattern = re.compile(
+                r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?))*$"
+            )
             if not domain_pattern.match(self.api_domain) or not domain_pattern.match(self.view_domain):
                 raise ValueError("Invalid domain format. Domains must be valid hostnames")
-
 
     def run(self):
         steps = [
@@ -96,7 +133,7 @@ class Install:
             ("Generating SSH keys", self._setup_ssh),
             ("Starting services", self._start_services),
         ]
-        
+
         # If force is enabled, add a Docker cleanup step before cloning to ensure fresh images/containers
         if self.force:
             # Insert cleanup as the third step (index 2), right before cloning the repo
@@ -105,7 +142,7 @@ class Install:
         # Only add proxy steps if both api_domain and view_domain are provided
         if self.api_domain and self.view_domain:
             steps.append(("Loading proxy configuration", self._load_proxy))
-        
+
         try:
             with Progress(
                 SpinnerColumn(),
@@ -117,7 +154,7 @@ class Install:
             ) as progress:
                 self.progress = progress
                 self.main_task = progress.add_task(installing_nixopus, total=len(steps))
-                
+
                 for i, (step_name, step_func) in enumerate(steps):
                     progress.update(self.main_task, description=f"{installing_nixopus} - {step_name} ({i+1}/{len(steps)})")
                     try:
@@ -126,32 +163,36 @@ class Install:
                     except Exception as e:
                         progress.update(self.main_task, description=f"Failed at {step_name}")
                         raise
-                
+
                 progress.update(self.main_task, completed=True, description="Installation completed")
-            
+
             self._show_success_message()
-            
+
         except Exception as e:
             self._handle_installation_error(e)
             self.logger.error(f"{installation_failed}: {str(e)}")
             raise typer.Exit(1)
 
     def _cleanup_docker(self):
+        compose_file = self._get_config("compose_file_path")
+
         if self.dry_run:
-            self.logger.info("[dry-run] Would run: docker compose down --rmi all --volumes --remove-orphans")
+            self.logger.info("[dry-run] Would run: docker compose -f {compose_file} down --rmi all --volumes --remove-orphans")
             return
 
-        compose_file = self._get_config('compose_file_path')
-        if not os.path.exists(compose_file):
+        if not compose_file or not os.path.exists(compose_file):
             # Nothing to clean specific to this deployment
             self.logger.debug(f"Compose file not found at {compose_file}; skipping docker cleanup")
             return
 
         cmd = [
-            "docker", "compose",
-            "-f", compose_file,
+            "docker",
+            "compose",
+            "-f",
+            compose_file,
             "down",
-            "--rmi", "all",
+            "--rmi",
+            "all",
             "--volumes",
             "--remove-orphans",
         ]
@@ -159,8 +200,8 @@ class Install:
         try:
             self.logger.debug(f"Executing docker cleanup: {' '.join(cmd)}")
             result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-            stdout = (result.stdout or '').strip()
-            stderr = (result.stderr or '').strip()
+            stdout = (result.stdout or "").strip()
+            stderr = (result.stderr or "").strip()
             if stdout:
                 self.logger.debug(stdout)
             if stderr:
@@ -182,11 +223,7 @@ class Install:
 
     def _run_preflight_checks(self):
         preflight_runner = PreflightRunner(logger=self.logger, verbose=self.verbose)
-        preflight_runner.check_ports_from_config(
-            config_key='required_ports', 
-            user_config=self._user_config, 
-            defaults=DEFAULTS
-        )
+        preflight_runner.check_ports_from_config(config_key="required_ports", user_config=self._user_config, defaults=DEFAULTS)
 
     def _install_dependencies(self):
         try:
@@ -195,15 +232,15 @@ class Install:
         except TimeoutError:
             raise Exception(dependency_installation_timeout)
 
-    def _setup_clone_and_config(self):        
+    def _setup_clone_and_config(self):
         clone_config = CloneConfig(
-            repo=self._get_config('repo_url'),
-            branch=self._get_config('branch_name'),
-            path=self._get_config('full_source_path'),
+            repo=self._get_config("repo_url"),
+            branch=self._get_config("branch_name"),
+            path=self._get_config("full_source_path"),
             force=self.force,
             verbose=self.verbose,
             output="text",
-            dry_run=self.dry_run
+            dry_run=self.dry_run,
         )
         clone_service = Clone(logger=self.logger)
         try:
@@ -214,9 +251,9 @@ class Install:
         if not result.success:
             raise Exception(f"{clone_failed}: {result.error}")
 
-    def _create_env_files(self):        
-        api_env_file = self._get_config('api_env_file_path')
-        view_env_file = self._get_config('view_env_file_path')
+    def _create_env_files(self):
+        api_env_file = self._get_config("api_env_file_path")
+        view_env_file = self._get_config("view_env_file_path")
         FileManager.create_directory(FileManager.get_directory_path(api_env_file), logger=self.logger)
         FileManager.create_directory(FileManager.get_directory_path(view_env_file), logger=self.logger)
         services = [
@@ -224,54 +261,54 @@ class Install:
             ("view", "services.view.env", view_env_file),
         ]
         env_manager = BaseEnvironmentManager(self.logger)
-        
-        for i, (service_name, service_key, env_file) in enumerate(services):            
+
+        for i, (service_name, service_key, env_file) in enumerate(services):
             env_values = _config.get_service_env_values(service_key)
             updated_env_values = self._update_environment_variables(env_values)
             success, error = env_manager.write_env_file(env_file, updated_env_values)
             if not success:
-                raise Exception(f"{env_file_creation_failed} {service_name}: {error}")            
+                raise Exception(f"{env_file_creation_failed} {service_name}: {error}")
             file_perm_success, file_perm_error = FileManager.set_permissions(env_file, 0o644)
             if not file_perm_success:
-                raise Exception(f"{env_file_permissions_failed} {service_name}: {file_perm_error}")            
+                raise Exception(f"{env_file_permissions_failed} {service_name}: {file_perm_error}")
             self.logger.debug(created_env_file.format(service_name=service_name, env_file=env_file))
 
     def _setup_proxy_config(self):
-        full_source_path = self._get_config('full_source_path')
-        caddy_json_template = os.path.join(full_source_path, 'helpers', 'caddy.json')
-        
+        full_source_path = self._get_config("full_source_path")
+        caddy_json_template = os.path.join(full_source_path, "helpers", "caddy.json")
+
         if not self.dry_run:
-            with open(caddy_json_template, 'r') as f:
+            with open(caddy_json_template, "r") as f:
                 config_str = f.read()
-            
+
             host_ip = HostInformation.get_public_ip()
-            view_port = self._get_config('view_port')
-            api_port = self._get_config('api_port')
+            view_port = self._get_config("view_port")
+            api_port = self._get_config("api_port")
 
             view_domain = self.view_domain if self.view_domain is not None else host_ip
             api_domain = self.api_domain if self.api_domain is not None else host_ip
 
-            config_str = config_str.replace('{env.APP_DOMAIN}', view_domain)
-            config_str = config_str.replace('{env.API_DOMAIN}', api_domain)
-            
+            config_str = config_str.replace("{env.APP_DOMAIN}", view_domain)
+            config_str = config_str.replace("{env.API_DOMAIN}", api_domain)
+
             app_reverse_proxy_url = f"{host_ip}:{view_port}"
             api_reverse_proxy_url = f"{host_ip}:{api_port}"
-            config_str = config_str.replace('{env.APP_REVERSE_PROXY_URL}', app_reverse_proxy_url)
-            config_str = config_str.replace('{env.API_REVERSE_PROXY_URL}', api_reverse_proxy_url)
-            
+            config_str = config_str.replace("{env.APP_REVERSE_PROXY_URL}", app_reverse_proxy_url)
+            config_str = config_str.replace("{env.API_REVERSE_PROXY_URL}", api_reverse_proxy_url)
+
             caddy_config = json.loads(config_str)
-            with open(caddy_json_template, 'w') as f:
+            with open(caddy_json_template, "w") as f:
                 json.dump(caddy_config, f, indent=2)
             self._copy_caddyfile_to_target(full_source_path)
-        
+
         self.logger.debug(f"{proxy_config_created}: {caddy_json_template}")
 
     def _setup_ssh(self):
         config = SSHConfig(
-            path=self._get_config('ssh_key_path'),
-            key_type=self._get_config('ssh_key_type'),
-            key_size=self._get_config('ssh_key_size'),
-            passphrase=self._get_config('ssh_passphrase'),
+            path=self._get_config("ssh_key_path"),
+            key_type=self._get_config("ssh_key_type"),
+            key_size=self._get_config("ssh_key_size"),
+            passphrase=self._get_config("ssh_passphrase"),
             verbose=self.verbose,
             output="text",
             dry_run=self.dry_run,
@@ -291,13 +328,13 @@ class Install:
 
     def _start_services(self):
         config = UpConfig(
-            name=self._get_config('service_name'),
-            detach=self._get_config('service_detach'),
+            name=self._get_config("service_name"),
+            detach=self._get_config("service_detach"),
             env_file=None,
             verbose=self.verbose,
             output="text",
             dry_run=self.dry_run,
-            compose_file=self._get_config('compose_file_path')
+            compose_file=self._get_config("compose_file_path"),
         )
 
         up_service = Up(logger=self.logger)
@@ -310,10 +347,12 @@ class Install:
             raise Exception(services_start_failed)
 
     def _load_proxy(self):
-        proxy_port = self._get_config('proxy_port')
-        full_source_path = self._get_config('full_source_path')
-        caddy_json_config = os.path.join(full_source_path, 'helpers', 'caddy.json')
-        config = LoadConfig(proxy_port=proxy_port, verbose=self.verbose, output="text", dry_run=self.dry_run, config_file=caddy_json_config)
+        proxy_port = self._get_config("proxy_port")
+        full_source_path = self._get_config("full_source_path")
+        caddy_json_config = os.path.join(full_source_path, "helpers", "caddy.json")
+        config = LoadConfig(
+            proxy_port=proxy_port, verbose=self.verbose, output="text", dry_run=self.dry_run, config_file=caddy_json_config
+        )
 
         load_service = Load(logger=self.logger)
         try:
@@ -331,14 +370,14 @@ class Install:
 
     def _show_success_message(self):
         nixopus_accessible_at = self._get_access_url()
-        
+
         self.logger.success("Installation Complete!")
         self.logger.info(f"Nixopus is accessible at: {nixopus_accessible_at}")
         self.logger.highlight("Thank you for installing Nixopus!")
         self.logger.info("Please visit the documentation at https://docs.nixopus.com for more information.")
         self.logger.info("If you have any questions, please visit the community forum at https://discord.gg/skdcq39Wpv")
         self.logger.highlight("See you in the community!")
-    
+
     def _update_environment_variables(self, env_values: dict) -> dict:
         updated_env = env_values.copy()
         host_ip = HostInformation.get_public_ip()
@@ -349,12 +388,12 @@ class Install:
         protocol = "https" if secure else "http"
         ws_protocol = "wss" if secure else "ws"
         key_map = {
-            'ALLOWED_ORIGIN': f"{protocol}://{view_host}",
-            'SSH_HOST': host_ip,
-            'SSH_PRIVATE_KEY': self._get_config('ssh_key_path'),
-            'WEBSOCKET_URL': f"{ws_protocol}://{api_host}/ws",
-            'API_URL': f"{protocol}://{api_host}/api",
-            'WEBHOOK_URL': f"{protocol}://{api_host}/api/v1/webhook",
+            "ALLOWED_ORIGIN": f"{protocol}://{view_host}",
+            "SSH_HOST": host_ip,
+            "SSH_PRIVATE_KEY": self._get_config("ssh_key_path"),
+            "WEBSOCKET_URL": f"{ws_protocol}://{api_host}/ws",
+            "API_URL": f"{protocol}://{api_host}/api",
+            "WEBHOOK_URL": f"{protocol}://{api_host}/api/v1/webhook",
         }
 
         for key, value in key_map.items():
@@ -365,9 +404,9 @@ class Install:
 
     def _copy_caddyfile_to_target(self, full_source_path: str):
         try:
-            source_caddyfile = os.path.join(full_source_path, 'helpers', 'Caddyfile')
+            source_caddyfile = os.path.join(full_source_path, "helpers", "Caddyfile")
             target_dir = _config.get_yaml_value(CADDY_CONFIG_VOLUME)
-            target_caddyfile = os.path.join(target_dir, 'Caddyfile')
+            target_caddyfile = os.path.join(target_dir, "Caddyfile")
             FileManager.create_directory(target_dir, logger=self.logger)
             if os.path.exists(source_caddyfile):
                 shutil.copy2(source_caddyfile, target_caddyfile)
@@ -385,6 +424,6 @@ class Install:
         elif self.api_domain:
             return f"https://{self.api_domain}"
         else:
-            view_port = self._get_config('view_port')
+            view_port = self._get_config("view_port")
             host_ip = HostInformation.get_public_ip()
             return f"http://{host_ip}:{view_port}"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nixopus"
-version = "0.1.2"
+version = "0.1.3"
 description = "A CLI for Nixopus"
 authors = ["Nixopus <raghavyuva@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Description:

Remove Docker images (and orphans) on --force to ensure fresh reinstall. Fresh install will remove Docker images. Added this as force-only cleanup step to rm containers, images, volumes, and orphans before reinstalling.