### PR TITLE
chore: change redis container name 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   nixopus-redis:
     image: redis:7-alpine
-    container_name: nixopus-redis-container
+    container_name: nixopus-redis
     restart: unless-stopped
     ports:
       - "${REDIS_PORT:-6379}:6379"


### PR DESCRIPTION
Closes #407 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the Redis container’s name to “nixopus-redis” for consistent identification across environments.
  - No changes to ports, volumes, health checks, or networking; existing connections and data remain unaffected.
  - Users who interact with the container by name (e.g., via docker exec, logs, or tooling) should use the new container name.
  - Automation or scripts referencing the previous container name may need to be adjusted to reflect this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->