### PR TITLE
docs: add link to public roadmap in the readme section (#414)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,9 @@ Nixopus is derived from the combination of "octopus" and the Linux penguin (Tux)
 <a href="https://github.com/raghavyuva/nixopus/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=raghavyuva/nixopus" alt="Nixopus project contributors" />
 </a>
+
+## Roadmap
+
+Curious about what's coming next in Nixopus? Check out our planned features and roadmap in detail here:  
+[View the Roadmap](https://github.com/raghavyuva/nixopus/discussions/262)
+


### PR DESCRIPTION
### What’s new

- Added a **Roadmap** section at the end of the README.md
- Included a reference link to the discussion with planned features: [View the Roadmap](https://github.com/raghavyuva/nixopus/discussions/262)

### Why

This provides visibility into upcoming features and improvements for Nixopus, helping users and contributors track the project’s progress.

### Checklist

- [x] README.md updated
- [x] Link to roadmap verified
