### PR TITLE
fixed: Wrong date in 'created' field of containers table

### DIFF
--- a/view/app/containers/components/table.tsx
+++ b/view/app/containers/components/table.tsx
@@ -1,12 +1,12 @@
 'use client';
 import React from 'react';
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { useTranslation } from '@/hooks/use-translation';
@@ -22,134 +22,148 @@ import { Action } from './card';
 type SortField = 'name' | 'status';
 
 const ContainersTable = ({
-    containersData,
-    sortBy = 'name',
-    sortOrder = 'asc',
-    onSort,
-    onAction
+  containersData,
+  sortBy = 'name',
+  sortOrder = 'asc',
+  onSort,
+  onAction
 }: {
-    containersData: Container[];
-    sortBy?: SortField;
-    sortOrder?: 'asc' | 'desc';
-    onSort?: (field: SortField) => void;
-    onAction?: (id: string, action: Action) => void;
+  containersData: Container[];
+  sortBy?: SortField;
+  sortOrder?: 'asc' | 'desc';
+  onSort?: (field: SortField) => void;
+  onAction?: (id: string, action: Action) => void;
 }) => {
-    const { t } = useTranslation();
-    const hasContainers = containersData && containersData.length > 0;
-    const router = useRouter();
+  const { t } = useTranslation();
+  const hasContainers = containersData && containersData.length > 0;
+  const router = useRouter();
 
-    return (
-        <div className="rounded-md">
-            <Table className="border">
-                <TableHeader>
-                    <TableRow>
-                        <TableHead className="w-[100px]">
-                            <TypographySmall>{t('dashboard.containers.table.headers.id')}</TypographySmall>
-                        </TableHead>
-                        <TableHead onClick={() => onSort && onSort('name')} className={`select-none ${onSort ? 'cursor-pointer' : ''}`}>
-                            <div className="flex items-center gap-1">
-                                <TypographySmall>{t('dashboard.containers.table.headers.name')}</TypographySmall>
-                                <ArrowUpDown className={`h-3 w-3 ${sortBy === 'name' ? 'opacity-100' : 'opacity-40'}`} />
-                                <span className="sr-only">Sort</span>
-                            </div>
-                        </TableHead>
-                        <TableHead>
-                            <TypographySmall>{t('dashboard.containers.table.headers.image')}</TypographySmall>
-                        </TableHead>
-                        <TableHead onClick={() => onSort && onSort('status')} className={`select-none ${onSort ? 'cursor-pointer' : ''}`}>
-                            <div className="flex items-center gap-1">
-                                <TypographySmall>{t('dashboard.containers.table.headers.status')}</TypographySmall>
-                                <ArrowUpDown className={`h-3 w-3 ${sortBy === 'status' ? 'opacity-100' : 'opacity-40'}`} />
-                                <span className="sr-only">Sort</span>
-                            </div>
-                        </TableHead>
-                        <TableHead>
-                            <TypographySmall>{t('dashboard.containers.table.headers.ports')}</TypographySmall>
-                        </TableHead>
-                        <TableHead>
-                            <TypographySmall>{t('dashboard.containers.table.headers.created')}</TypographySmall>
-                        </TableHead>
-                        {onAction && (
-                            <TableHead>
-                                <TypographySmall>Actions</TypographySmall>
-                            </TableHead>
+  return (
+    <div className="rounded-md">
+      <Table className="border">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[100px]">
+              <TypographySmall>{t('dashboard.containers.table.headers.id')}</TypographySmall>
+            </TableHead>
+            <TableHead
+              onClick={() => onSort && onSort('name')}
+              className={`select-none ${onSort ? 'cursor-pointer' : ''}`}>
+              <div className="flex items-center gap-1">
+                <TypographySmall>{t('dashboard.containers.table.headers.name')}</TypographySmall>
+                <ArrowUpDown
+                  className={`h-3 w-3 ${sortBy === 'name' ? 'opacity-100' : 'opacity-40'}`}
+                />
+                <span className="sr-only">Sort</span>
+              </div>
+            </TableHead>
+            <TableHead>
+              <TypographySmall>{t('dashboard.containers.table.headers.image')}</TypographySmall>
+            </TableHead>
+            <TableHead
+              onClick={() => onSort && onSort('status')}
+              className={`select-none ${onSort ? 'cursor-pointer' : ''}`}>
+              <div className="flex items-center gap-1">
+                <TypographySmall>{t('dashboard.containers.table.headers.status')}</TypographySmall>
+                <ArrowUpDown
+                  className={`h-3 w-3 ${sortBy === 'status' ? 'opacity-100' : 'opacity-40'}`}
+                />
+                <span className="sr-only">Sort</span>
+              </div>
+            </TableHead>
+            <TableHead>
+              <TypographySmall>{t('dashboard.containers.table.headers.ports')}</TypographySmall>
+            </TableHead>
+            <TableHead>
+              <TypographySmall>{t('dashboard.containers.table.headers.created')}</TypographySmall>
+            </TableHead>
+            {onAction && (
+              <TableHead>
+                <TypographySmall>Actions</TypographySmall>
+              </TableHead>
+            )}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {hasContainers ? (
+            containersData.map((container) => {
+              const containerName = container.name;
+
+              const hasPorts = container.ports && container.ports.length > 0;
+              console.log(container);
+              const formattedDate = container.created
+                ? new Intl.DateTimeFormat(undefined, {
+                    day: 'numeric',
+                    month: 'short',
+                    year: 'numeric'
+                  }).format(new Date(container.created))
+                : '-';
+
+              return (
+                <TableRow
+                  key={container.id}
+                  onClick={() => router.push(`/containers/${container.id}`)}
+                  className="cursor-pointer">
+                  <TableCell>
+                    <TypographySmall>{truncateId(container.id)}</TypographySmall>
+                  </TableCell>
+                  <TableCell>
+                    <TypographySmall>{containerName}</TypographySmall>
+                  </TableCell>
+                  <TableCell className="max-w-[200px] overflow-hidden">
+                    <TypographySmall className="truncate whitespace-nowrap max-w-full block">
+                      {container.image}
+                    </TypographySmall>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={getStatusColor(container.status)}>
+                      {container.state || 'Unknown'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {hasPorts ? (
+                      <div className="flex flex-col gap-1">
+                        {container.ports.slice(0, 2).map((port, index) => (
+                          <TypographySmall key={index}>
+                            {port.private_port}
+                            {port.public_port ? `:${port.public_port}` : ''}
+                          </TypographySmall>
+                        ))}
+                        {container.ports.length > 2 && (
+                          <TypographyMuted>
+                            {t('dashboard.containers.table.morePorts').replace(
+                              '{count}',
+                              String(container.ports.length - 2)
+                            )}
+                          </TypographyMuted>
                         )}
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {hasContainers ? (
-                        containersData.map((container) => {
-                            const containerName = container.name
-
-                            const hasPorts = container.ports && container.ports.length > 0;
-                            const formattedDate = container.created
-                                ? new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'long' }).format(
-                                    new Date(parseInt(container.created) * 1000)
-                                )
-                                : '-';
-
-                            return (
-                                <TableRow key={container.id} onClick={() => router.push(`/containers/${container.id}`)}
-                                    className='cursor-pointer'
-                                >
-                                    <TableCell>
-                                        <TypographySmall>{truncateId(container.id)}</TypographySmall>
-                                    </TableCell>
-                                    <TableCell>
-                                        <TypographySmall>{containerName}</TypographySmall>
-                                    </TableCell>
-                                    <TableCell className="max-w-[200px] overflow-hidden">
-                                        <TypographySmall className='truncate whitespace-nowrap max-w-full block'>{container.image}</TypographySmall>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Badge className={getStatusColor(container.status)}>
-                                            {container.state || 'Unknown'}
-                                        </Badge>
-                                    </TableCell>
-                                    <TableCell>
-                                        {hasPorts ? (
-                                            <div className="flex flex-col gap-1">
-                                                {container.ports.slice(0, 2).map((port, index) => (
-                                                    <TypographySmall key={index}>
-                                                        {port.private_port}
-                                                        {port.public_port ? `:${port.public_port}` : ''}
-                                                    </TypographySmall>
-                                                ))}
-                                                {container.ports.length > 2 && (
-                                                    <TypographyMuted>
-                                                        {t('dashboard.containers.table.morePorts').replace(
-                                                            '{count}',
-                                                            String(container.ports.length - 2)
-                                                        )}
-                                                    </TypographyMuted>
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <TypographySmall>-</TypographySmall>
-                                        )}
-                                    </TableCell>
-                                    <TableCell>
-                                        <TypographySmall>{formattedDate}</TypographySmall>
-                                    </TableCell>
-                                    {onAction && (
-                                        <TableCell onClick={(e) => e.stopPropagation()}>
-                                            <ContainerActions container={container} onAction={onAction} />
-                                        </TableCell>
-                                    )}
-                                </TableRow>
-                            );
-                        })
+                      </div>
                     ) : (
-                        <TableRow>
-                            <TableCell colSpan={7} className="text-center py-6">
-                                <TypographyMuted>{t('dashboard.containers.table.noContainers')}</TypographyMuted>
-                            </TableCell>
-                        </TableRow>
+                      <TypographySmall>-</TypographySmall>
                     )}
-                </TableBody>
-            </Table>
-        </div>
-    );
+                  </TableCell>
+                  <TableCell>
+                    <TypographySmall>{formattedDate}</TypographySmall>
+                  </TableCell>
+                  {onAction && (
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <ContainerActions container={container} onAction={onAction} />
+                    </TableCell>
+                  )}
+                </TableRow>
+              );
+            })
+          ) : (
+            <TableRow>
+              <TableCell colSpan={7} className="text-center py-6">
+                <TypographyMuted>{t('dashboard.containers.table.noContainers')}</TypographyMuted>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
 };
 
 export default ContainersTable;


### PR DESCRIPTION
<img width="1919" height="961" alt="Screenshot 2025-10-01 173227" src="https://github.com/user-attachments/assets/2510faba-2f63-4dd7-8b7a-0da955aa957d" />

#369 

Date for container creation was coming up wrong on the frontend part (returned correct by the backend). Fixed that part on the frontend. Attached screenshot for the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ports column now displays up to two ports with a concise “+N more” summary.
- Style
  - Consistent table headers (ID, Name, Image, Status, Ports, Created, Actions).
  - Empty-state message rendered inline within the table for better readability.
- Refactor
  - Unified table structure for clearer layout; sorting and row navigation preserved.
  - Action column interactions preserved with improved click handling.
- Improvements
  - Created date now formatted as day, short month, and year, with “-” fallback when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->