### PR TITLE
bug: invalid date preview on container listing screen

### DIFF
--- a/view/app/containers/components/table.tsx
+++ b/view/app/containers/components/table.tsx
@@ -1,12 +1,12 @@
 'use client';
 import React from 'react';
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { useTranslation } from '@/hooks/use-translation';
@@ -14,6 +14,7 @@ import { TypographySmall, TypographyMuted } from '@/components/ui/typography';
 import truncateId from '@/app/dashboard/components/utils/truncate-id';
 import getStatusColor from '@/app/dashboard/components/utils/get-status-color';
 import { Container } from '@/redux/services/container/containerApi';
+import { formatDate } from '@/lib/format-date';
 import { useRouter } from 'next/navigation';
 import { ArrowUpDown } from 'lucide-react';
 import { ContainerActions } from './actions';
@@ -22,134 +23,144 @@ import { Action } from './card';
 type SortField = 'name' | 'status';
 
 const ContainersTable = ({
-    containersData,
-    sortBy = 'name',
-    sortOrder = 'asc',
-    onSort,
-    onAction
+  containersData,
+  sortBy = 'name',
+  sortOrder = 'asc',
+  onSort,
+  onAction
 }: {
-    containersData: Container[];
-    sortBy?: SortField;
-    sortOrder?: 'asc' | 'desc';
-    onSort?: (field: SortField) => void;
-    onAction?: (id: string, action: Action) => void;
+  containersData: Container[];
+  sortBy?: SortField;
+  sortOrder?: 'asc' | 'desc';
+  onSort?: (field: SortField) => void;
+  onAction?: (id: string, action: Action) => void;
 }) => {
-    const { t } = useTranslation();
-    const hasContainers = containersData && containersData.length > 0;
-    const router = useRouter();
+  const { t } = useTranslation();
+  const hasContainers = containersData && containersData.length > 0;
+  const router = useRouter();
 
-    return (
-        <div className="rounded-md">
-            <Table className="border">
-                <TableHeader>
-                    <TableRow>
-                        <TableHead className="w-[100px]">
-                            <TypographySmall>{t('dashboard.containers.table.headers.id')}</TypographySmall>
-                        </TableHead>
-                        <TableHead onClick={() => onSort && onSort('name')} className={`select-none ${onSort ? 'cursor-pointer' : ''}`}>
-                            <div className="flex items-center gap-1">
-                                <TypographySmall>{t('dashboard.containers.table.headers.name')}</TypographySmall>
-                                <ArrowUpDown className={`h-3 w-3 ${sortBy === 'name' ? 'opacity-100' : 'opacity-40'}`} />
-                                <span className="sr-only">Sort</span>
-                            </div>
-                        </TableHead>
-                        <TableHead>
-                            <TypographySmall>{t('dashboard.containers.table.headers.image')}</TypographySmall>
-                        </TableHead>
-                        <TableHead onClick={() => onSort && onSort('status')} className={`select-none ${onSort ? 'cursor-pointer' : ''}`}>
-                            <div className="flex items-center gap-1">
-                                <TypographySmall>{t('dashboard.containers.table.headers.status')}</TypographySmall>
-                                <ArrowUpDown className={`h-3 w-3 ${sortBy === 'status' ? 'opacity-100' : 'opacity-40'}`} />
-                                <span className="sr-only">Sort</span>
-                            </div>
-                        </TableHead>
-                        <TableHead>
-                            <TypographySmall>{t('dashboard.containers.table.headers.ports')}</TypographySmall>
-                        </TableHead>
-                        <TableHead>
-                            <TypographySmall>{t('dashboard.containers.table.headers.created')}</TypographySmall>
-                        </TableHead>
-                        {onAction && (
-                            <TableHead>
-                                <TypographySmall>Actions</TypographySmall>
-                            </TableHead>
+  return (
+    <div className="rounded-md">
+      <Table className="border">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[100px]">
+              <TypographySmall>{t('dashboard.containers.table.headers.id')}</TypographySmall>
+            </TableHead>
+            <TableHead
+              onClick={() => onSort && onSort('name')}
+              className={`select-none ${onSort ? 'cursor-pointer' : ''}`}
+            >
+              <div className="flex items-center gap-1">
+                <TypographySmall>{t('dashboard.containers.table.headers.name')}</TypographySmall>
+                <ArrowUpDown
+                  className={`h-3 w-3 ${sortBy === 'name' ? 'opacity-100' : 'opacity-40'}`}
+                />
+                <span className="sr-only">Sort</span>
+              </div>
+            </TableHead>
+            <TableHead>
+              <TypographySmall>{t('dashboard.containers.table.headers.image')}</TypographySmall>
+            </TableHead>
+            <TableHead
+              onClick={() => onSort && onSort('status')}
+              className={`select-none ${onSort ? 'cursor-pointer' : ''}`}
+            >
+              <div className="flex items-center gap-1">
+                <TypographySmall>{t('dashboard.containers.table.headers.status')}</TypographySmall>
+                <ArrowUpDown
+                  className={`h-3 w-3 ${sortBy === 'status' ? 'opacity-100' : 'opacity-40'}`}
+                />
+                <span className="sr-only">Sort</span>
+              </div>
+            </TableHead>
+            <TableHead>
+              <TypographySmall>{t('dashboard.containers.table.headers.ports')}</TypographySmall>
+            </TableHead>
+            <TableHead>
+              <TypographySmall>{t('dashboard.containers.table.headers.created')}</TypographySmall>
+            </TableHead>
+            {onAction && (
+              <TableHead>
+                <TypographySmall>Actions</TypographySmall>
+              </TableHead>
+            )}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {hasContainers ? (
+            containersData.map((container) => {
+              const containerName = container.name;
+
+              const hasPorts = container.ports && container.ports.length > 0;
+              const formattedDate = container.created ? formatDate(container.created) : '-';
+
+              return (
+                <TableRow
+                  key={container.id}
+                  onClick={() => router.push(`/containers/${container.id}`)}
+                  className="cursor-pointer"
+                >
+                  <TableCell>
+                    <TypographySmall>{truncateId(container.id)}</TypographySmall>
+                  </TableCell>
+                  <TableCell>
+                    <TypographySmall>{containerName}</TypographySmall>
+                  </TableCell>
+                  <TableCell className="max-w-[200px] overflow-hidden">
+                    <TypographySmall className="truncate whitespace-nowrap max-w-full block">
+                      {container.image}
+                    </TypographySmall>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={getStatusColor(container.status)}>
+                      {container.state || 'Unknown'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {hasPorts ? (
+                      <div className="flex flex-col gap-1">
+                        {container.ports.slice(0, 2).map((port, index) => (
+                          <TypographySmall key={index}>
+                            {port.private_port}
+                            {port.public_port ? `:${port.public_port}` : ''}
+                          </TypographySmall>
+                        ))}
+                        {container.ports.length > 2 && (
+                          <TypographyMuted>
+                            {t('dashboard.containers.table.morePorts').replace(
+                              '{count}',
+                              String(container.ports.length - 2)
+                            )}
+                          </TypographyMuted>
                         )}
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {hasContainers ? (
-                        containersData.map((container) => {
-                            const containerName = container.name
-
-                            const hasPorts = container.ports && container.ports.length > 0;
-                            const formattedDate = container.created
-                                ? new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'long' }).format(
-                                    new Date(parseInt(container.created) * 1000)
-                                )
-                                : '-';
-
-                            return (
-                                <TableRow key={container.id} onClick={() => router.push(`/containers/${container.id}`)}
-                                    className='cursor-pointer'
-                                >
-                                    <TableCell>
-                                        <TypographySmall>{truncateId(container.id)}</TypographySmall>
-                                    </TableCell>
-                                    <TableCell>
-                                        <TypographySmall>{containerName}</TypographySmall>
-                                    </TableCell>
-                                    <TableCell className="max-w-[200px] overflow-hidden">
-                                        <TypographySmall className='truncate whitespace-nowrap max-w-full block'>{container.image}</TypographySmall>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Badge className={getStatusColor(container.status)}>
-                                            {container.state || 'Unknown'}
-                                        </Badge>
-                                    </TableCell>
-                                    <TableCell>
-                                        {hasPorts ? (
-                                            <div className="flex flex-col gap-1">
-                                                {container.ports.slice(0, 2).map((port, index) => (
-                                                    <TypographySmall key={index}>
-                                                        {port.private_port}
-                                                        {port.public_port ? `:${port.public_port}` : ''}
-                                                    </TypographySmall>
-                                                ))}
-                                                {container.ports.length > 2 && (
-                                                    <TypographyMuted>
-                                                        {t('dashboard.containers.table.morePorts').replace(
-                                                            '{count}',
-                                                            String(container.ports.length - 2)
-                                                        )}
-                                                    </TypographyMuted>
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <TypographySmall>-</TypographySmall>
-                                        )}
-                                    </TableCell>
-                                    <TableCell>
-                                        <TypographySmall>{formattedDate}</TypographySmall>
-                                    </TableCell>
-                                    {onAction && (
-                                        <TableCell onClick={(e) => e.stopPropagation()}>
-                                            <ContainerActions container={container} onAction={onAction} />
-                                        </TableCell>
-                                    )}
-                                </TableRow>
-                            );
-                        })
+                      </div>
                     ) : (
-                        <TableRow>
-                            <TableCell colSpan={7} className="text-center py-6">
-                                <TypographyMuted>{t('dashboard.containers.table.noContainers')}</TypographyMuted>
-                            </TableCell>
-                        </TableRow>
+                      <TypographySmall>-</TypographySmall>
                     )}
-                </TableBody>
-            </Table>
-        </div>
-    );
+                  </TableCell>
+                  <TableCell>
+                    <TypographySmall>{formattedDate}</TypographySmall>
+                  </TableCell>
+                  {onAction && (
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <ContainerActions container={container} onAction={onAction} />
+                    </TableCell>
+                  )}
+                </TableRow>
+              );
+            })
+          ) : (
+            <TableRow>
+              <TableCell colSpan={7} className="text-center py-6">
+                <TypographyMuted>{t('dashboard.containers.table.noContainers')}</TypographyMuted>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
 };
 
 export default ContainersTable;


### PR DESCRIPTION
Fixes the issue where the "Created" column in the Containers table was displaying a default date (Jan 1st) instead of the actual creation date from the API response. Now, container creation dates are properly displayed in the "Month Date YYYY" format, e.g., "Sep 6 2025".

**Steps to Reproduce (Before Fix)**

> - Login as admin or general user
> - Click on the Containers menu in the sidebar
> - Run a Docker container locally and check the table under the "Created" column
> - Observe that the displayed date defaults to Jan 1st for recently created containers

**Bug Fix**

> - Corrected date extraction from the API response for containers
> - Updated formatting to use three-letter short month, date, and full year (e.g., "Sep 6 2025" instead of "Jan 1st")

**Expected Behavior**

> - Containers created on any date now preview the correct date in the "Created" column
> - Dates shown in three-letter short form month, date, and year format as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified containers table rendering for improved maintainability without changing behavior, sorting, or actions.

* **Style**
  * Improved readability of container creation dates with consistent formatting.
  * Refined empty-state placeholder styling for clearer feedback.
  * Minor layout and indentation adjustments with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->