### PR TITLE
fix(signup): crash on second admin signup caused by next/router in AppRouter component

### DIFF
--- a/view/app/register/components/admin-registerd-error.tsx
+++ b/view/app/register/components/admin-registerd-error.tsx
@@ -2,10 +2,9 @@
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useTranslation } from '@/hooks/use-translation';
 import { cn } from '@/lib/utils';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
 export const AdminRegisteredError = () => {
   const { t } = useTranslation();

--- a/view/app/register/components/admin-registered.tsx
+++ b/view/app/register/components/admin-registered.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { useTranslation } from '@/hooks/use-translation';
 import { LogIn } from 'lucide-react';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
 export const AdminRegistered = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
#### Issue
_Link to related issue(s):_  
N/A

---

#### Description
Fixed a crash that occurred during second admin signup by updating the router imports in signup components. The components were using `next/router` (Pages Router API) instead of `next/navigation` (App Router API), which caused runtime errors in the App Router context.

**Changes:**
- Updated `useRouter` import from `next/router` to `next/navigation` in `admin-registerd-error.tsx`
- Updated `useRouter` import from `next/router` to `next/navigation` in `admin-registered.tsx`
- Removed unused `Skeleton` import from `admin-registerd-error.tsx`

---

#### Scope of Change
_Select all applicable areas impacted by this PR:_

- [x] View (UI/UX)
- [ ] API
- [ ] CLI
- [ ] Infra / Deployment
- [ ] Docs
- [ ] Other (specify): ________

---

#### Screenshot / Video / GIF (if applicable)
_Attach or embed screenshots, screen recordings, or GIFs demonstrating the feature or fix._

---

#### Related PRs (if any)
_Link any related or dependent PRs across repos._

---

#### Additional Notes for Reviewers (optional)
This is a critical fix for App Router compatibility. The `next/navigation` package is the correct API for components within the App Router directory structure (`app/`), while `next/router` is for the legacy Pages Router (`pages/`).

---

#### Developer Checklist
_To be completed by the developer who raised the PR._

- [ ] Add valid/relevant title for the PR
- [ ] Self-review done  
- [ ] Manual dev testing done  
- [ ] No secrets exposed  
- [ ] No merge conflicts  
- [ ] Docs added/updated (if applicable)  
- [ ] Removed debug prints / secrets / sensitive data  
- [ ] Unit / Integration tests passing  
- [ ] Follows all standards defined in **Nixopus Docs**

---

#### Reviewer Checklist
_To be completed by the reviewer before merge._

- [ ] Peer review done  
- [ ] No console.logs / fmt.prints left  
- [ ] No secrets exposed  
- [ ] If any DB migrations, migration changes are verified
- [ ] Verified release changes are production-ready