### PR TITLE
fix: optimize network speed state updates to prevent unnecessary re-renders

### DIFF
--- a/view/app/dashboard/hooks/use-network-speeds.ts
+++ b/view/app/dashboard/hooks/use-network-speeds.ts
@@ -39,10 +39,11 @@ export function useNetworkSpeeds(systemStats: SystemStatsType | null) {
       const bytesUploaded = Math.max(0, bytesSent - previousNetworkStatsRef.current.bytesSent);
       const downloadSpeed = formatBytes(bytesDownloaded / timeDiff, true);
       const uploadSpeed = formatBytes(bytesUploaded / timeDiff, true);
-      setNetworkSpeeds((prev)=>{
+      setNetworkSpeeds(prev =>
         prev.downloadSpeed === downloadSpeed && prev.uploadSpeed === uploadSpeed
-        ? prev : { downloadSpeed, uploadSpeed }
-      });
+        ? prev 
+        : { downloadSpeed, uploadSpeed }
+      );
     }
 
     previousNetworkStatsRef.current = {


### PR DESCRIPTION
## Changes Implemented

- Added an equality check inside setNetworkSpeeds to compare previous and new values.
- React now skips the re-render when both download/upload speeds remain unchanged.
- This reduces unnecessary UI work and improves overall performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved network speed state handling to avoid redundant updates and unnecessary re-renders by applying conditional state updates.
  * Stopped initializing speeds to zero on first render; speeds are now set only when valid prior measurements exist, reducing noise and improving performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->