### PR TITLE
fix: close settings modal on logout

### DIFF
--- a/view/hooks/use-app-sidebar.ts
+++ b/view/hooks/use-app-sidebar.ts
@@ -17,6 +17,7 @@ import { auditApi } from '@/redux/services/audit';
 import { FeatureFlagsApi } from '@/redux/services/feature-flags/featureFlagsApi';
 import { useState, useMemo, useEffect } from 'react';
 import { Folder, Home, Package, Container, Puzzle } from 'lucide-react';
+import { useSettingsModal } from '@/hooks/use-settings-modal';
 
 const data = {
   navMain: [
@@ -64,6 +65,7 @@ export function useAppSidebar() {
   const { canAccessResource } = useRBAC();
   const router = useRouter();
   const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+  const { closeSettings } = useSettingsModal();
 
   const hasAnyPermission = useMemo(() => {
     const allowedResources = ['dashboard', 'settings', 'extensions'];
@@ -193,6 +195,7 @@ Add any other context about the problem here.`;
 
   const handleLogoutConfirm = async () => {
     setShowLogoutDialog(false);
+    closeSettings();
 
     try {
       clearLocalStorage();


### PR DESCRIPTION
### **User description**
#### Issue
_Link to related issue(s):_  

---

#### Description
_Short summary of what this PR changes or introduces._

---

#### Scope of Change
_Select all applicable areas impacted by this PR:_

- [ ] View (UI/UX)
- [ ] API
- [ ] CLI
- [ ] Infra / Deployment
- [ ] Docs
- [ ] Other (specify): ________

---

#### Screenshot / Video / GIF (if applicable)
_Attach or embed screenshots, screen recordings, or GIFs demonstrating the feature or fix._

---

#### Related PRs (if any)
_Link any related or dependent PRs across repos._

---

#### Additional Notes for Reviewers (optional)
_Anything reviewers should know before testing or merging (e.g., environment variables, setup steps)._

---

#### Developer Checklist
_To be completed by the developer who raised the PR._

- [ ] Add valid/relevant title for the PR
- [ ] Self-review done  
- [ ] Manual dev testing done  
- [ ] No secrets exposed  
- [ ] No merge conflicts  
- [ ] Docs added/updated (if applicable)  
- [ ] Removed debug prints / secrets / sensitive data  
- [ ] Unit / Integration tests passing  
- [ ] Follows all standards defined in **Nixopus Docs**

---

#### Reviewer Checklist
_To be completed by the reviewer before merge._

- [ ] Peer review done  
- [ ] No console.logs / fmt.prints left  
- [ ] No secrets exposed  
- [ ] If any DB migrations, migration changes are verified
- [ ] Verified release changes are production-ready


___

### **PR Type**
Bug fix


___

### **Description**
- Close settings modal when user logs out

- Import and use `useSettingsModal` hook in sidebar

- Call `closeSettings()` in logout confirmation handler


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks logout"] --> B["Logout dialog confirmed"]
  B --> C["closeSettings invoked"]
  C --> D["Settings modal closed"]
  B --> E["User logged out"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-app-sidebar.ts</strong><dd><code>Add settings modal closure on logout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

view/hooks/use-app-sidebar.ts

<ul><li>Import <code>useSettingsModal</code> hook from settings modal utilities<br> <li> Destructure <code>closeSettings</code> function from the hook<br> <li> Call <code>closeSettings()</code> in <code>handleLogoutConfirm</code> before logout logic<br> <li> Ensures settings modal is closed when user confirms logout</ul>


</details>


  </td>
  <td><a href="https://github.com/raghavyuva/nixopus/pull/758/files#diff-5cc993ab468bc6db041547774884cb8064e0df4c6b342416c0ae1d4d2f8c6186">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

