### PR TITLE
chore: add docker shell profiles to non interactive ssh sessions

### DIFF
--- a/api/internal/features/deploy/docker/init.go
+++ b/api/internal/features/deploy/docker/init.go
@@ -324,10 +324,14 @@ func (s *DockerService) ContainerLogs(Ctx context.Context, containerID string, o
 	return s.Cli.ContainerLogs(Ctx, containerID, opts)
 }
 
+// dockerPathPrefix returns a shell command prefix that ensures docker is in PATH
+// This is needed because SSH non-interactive sessions don't source shell profiles
+const dockerPathPrefix = "export PATH=$PATH:/usr/local/bin:/usr/bin:/snap/bin:/opt/homebrew/bin && "
+
 // ComposeUp starts the Docker Compose services defined in the specified compose file
 func (s *DockerService) ComposeUp(composeFilePath string, envVars map[string]string) error {
 	client := ssh.NewSSH()
-	envVarsStr := ""
+	envVarsStr := dockerPathPrefix
 	for k, v := range envVars {
 		envVarsStr += fmt.Sprintf("export %s=%s && ", k, v)
 	}
@@ -343,7 +347,7 @@ func (s *DockerService) ComposeUp(composeFilePath string, envVars map[string]str
 // ComposeDown stops and removes the Docker Compose services
 func (s *DockerService) ComposeDown(composeFilePath string) error {
 	client := ssh.NewSSH()
-	command := fmt.Sprintf("docker compose -f %s down", composeFilePath)
+	command := fmt.Sprintf("%sdocker compose -f %s down", dockerPathPrefix, composeFilePath)
 	output, err := client.RunCommand(command)
 	if err != nil {
 		return fmt.Errorf("failed to stop docker compose services: %v, output: %s", err, output)
@@ -354,7 +358,7 @@ func (s *DockerService) ComposeDown(composeFilePath string) error {
 // ComposeBuild builds the Docker Compose services
 func (s *DockerService) ComposeBuild(composeFilePath string, envVars map[string]string) error {
 	client := ssh.NewSSH()
-	envVarsStr := ""
+	envVarsStr := dockerPathPrefix
 	for k, v := range envVars {
 		envVarsStr += fmt.Sprintf("export %s=%s && ", k, v)
 	}


### PR DESCRIPTION
### **User description**
#### Issue
_Link to related issue(s):_  

---

#### Description
_Short summary of what this PR changes or introduces._

---

#### Scope of Change
_Select all applicable areas impacted by this PR:_

- [ ] View (UI/UX)
- [ ] API
- [ ] CLI
- [ ] Infra / Deployment
- [ ] Docs
- [ ] Other (specify): ________

---

#### Screenshot / Video / GIF (if applicable)
_Attach or embed screenshots, screen recordings, or GIFs demonstrating the feature or fix._

---

#### Related PRs (if any)
_Link any related or dependent PRs across repos._

---

#### Additional Notes for Reviewers (optional)
_Anything reviewers should know before testing or merging (e.g., environment variables, setup steps)._

---

#### Developer Checklist
_To be completed by the developer who raised the PR._

- [ ] Add valid/relevant title for the PR
- [ ] Self-review done  
- [ ] Manual dev testing done  
- [ ] No secrets exposed  
- [ ] No merge conflicts  
- [ ] Docs added/updated (if applicable)  
- [ ] Removed debug prints / secrets / sensitive data  
- [ ] Unit / Integration tests passing  
- [ ] Follows all standards defined in **Nixopus Docs**

---

#### Reviewer Checklist
_To be completed by the reviewer before merge._

- [ ] Peer review done  
- [ ] No console.logs / fmt.prints left  
- [ ] No secrets exposed  
- [ ] If any DB migrations, migration changes are verified
- [ ] Verified release changes are production-ready


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add docker PATH prefix to SSH non-interactive sessions

- Ensures docker command availability in ComposeUp, ComposeDown, ComposeBuild

- Exports multiple common docker binary locations for cross-platform compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SSH Non-Interactive Sessions"] -->|missing docker in PATH| B["Docker Commands Fail"]
  C["dockerPathPrefix constant"] -->|prepends PATH exports| D["ComposeUp/Down/Build"]
  D -->|docker command found| E["SSH Commands Execute Successfully"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init.go</strong><dd><code>Add docker PATH prefix to compose operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/internal/features/deploy/docker/init.go

<ul><li>Added <code>dockerPathPrefix</code> constant that exports docker binary paths for <br>SSH sessions<br> <li> Updated <code>ComposeUp()</code> to prepend <code>dockerPathPrefix</code> to environment <br>variables<br> <li> Updated <code>ComposeDown()</code> to prepend <code>dockerPathPrefix</code> to docker compose <br>command<br> <li> Updated <code>ComposeBuild()</code> to prepend <code>dockerPathPrefix</code> to environment <br>variables</ul>


</details>


  </td>
  <td><a href="https://github.com/raghavyuva/nixopus/pull/800/files#diff-44685601a2e89f448144701c5cfb743cf908150a22ccd662e744e64dad042025">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

