### PR TITLE
fix: run with sudo for normal users

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -427,7 +427,11 @@ main() {
         else
             log_info "Running 'nixopus install' with options: ${cli_args[*]}"
         fi
-        nixopus install "${cli_args[@]}"
+        if [ $EUID -ne 0 ]; then
+            sudo nixopus install "${cli_args[@]}"
+        else
+            nixopus install "${cli_args[@]}"
+        fi
         log_success "nixopus install completed successfully!"
     else
         log_info "Skipping 'nixopus install' as requested..."


### PR DESCRIPTION
### **User description**
#### Issue
Failed to install openssh-server error when it is already installed and running through apt #886
---

#### Description

In scripts/install.sh at line 430, the command `nixopus install "${cli_args[@]}" is executed without sudo privileges. This causes failures when installing system packages like openssh-server, even though the Python code in `deps.py uses sudo for individual package commands.

---

#### Scope of Change
_Select all applicable areas impacted by this PR:_

- [ ] View (UI/UX)
- [ ] API
- [ ] CLI
- [ ] Infra / Deployment
- [ ] Docs
- [x] Other (specify): installation

---

#### Screenshot / Video / GIF (if applicable)
before fix: 
<img width="1229" height="414" alt="image" src="https://github.com/user-attachments/assets/6c2faeb4-b11f-4a9d-857d-afb154c2fa0d" />

after fix:
<img width="948" height="253" alt="image" src="https://github.com/user-attachments/assets/7b9d4af2-70ae-4476-9637-8b291e24e8b4" />

---

#### Developer Checklist
_To be completed by the developer who raised the PR._

- [ ] Add valid/relevant title for the PR
- [ ] Self-review done  
- [ ] Manual dev testing done  
- [ ] No secrets exposed  
- [ ] No merge conflicts  
- [ ] Docs added/updated (if applicable)  
- [ ] Removed debug prints / secrets / sensitive data  
- [ ] Unit / Integration tests passing  
- [ ] Follows all standards defined in **Nixopus Docs**

---

#### Reviewer Checklist
_To be completed by the reviewer before merge._

- [ ] Peer review done  
- [ ] No console.logs / fmt.prints left  
- [ ] No secrets exposed  
- [ ] If any DB migrations, migration changes are verified
- [ ] Verified release changes are production-ready


___

### **PR Type**
Bug fix


___

### **Description**
- Add sudo privilege check for normal users in install script

- Execute nixopus install with sudo when EUID is not root

- Prevent permission failures for system package installations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check EUID"] --> B{Is root?}
  B -->|No| C["Execute with sudo"]
  B -->|Yes| D["Execute without sudo"]
  C --> E["nixopus install"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Add conditional sudo execution for install command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/install.sh

<ul><li>Added EUID check to determine if script runs as root user<br> <li> Execute <code>nixopus install</code> with <code>sudo</code> when EUID is not 0<br> <li> Maintain direct execution when already running as root<br> <li> Prevents permission errors for system package installations</ul>


</details>


  </td>
  <td><a href="https://github.com/raghavyuva/nixopus/pull/888/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation now intelligently handles permission requirements by automatically detecting your current privilege level. When elevated permissions are needed, the installer requests them automatically. When running with root access, it executes directly. This ensures a seamless setup experience for all users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->