### PR TITLE
fix: billing sweep query and lifecycle error handling

### DIFF
--- a/api/internal/features/machine/controller/lifecycle.go
+++ b/api/internal/features/machine/controller/lifecycle.go
@@ -102,14 +102,16 @@ func mapLifecycleError(l logger.Logger, err error, orgID uuid.UUID, action strin
 	case errors.Is(err, types.ErrMachineNotProvisioned):
 		return fuego.NotFoundError{Detail: err.Error()}
 	case errors.Is(err, types.ErrMachineOperationTimeout):
-		return fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusGatewayTimeout}
+		return fuego.HTTPError{Detail: "machine operation timed out, please try again", Status: http.StatusGatewayTimeout}
 	case errors.Is(err, types.ErrMachineOperationLocked):
-		return fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusConflict}
-	case errors.Is(err, types.ErrMachineNotRunning),
-		errors.Is(err, types.ErrMachineAlreadyPaused),
-		errors.Is(err, types.ErrMachineNotPaused):
-		return fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusUnprocessableEntity}
+		return fuego.HTTPError{Detail: "another operation is already in progress", Status: http.StatusConflict}
+	case errors.Is(err, types.ErrMachineNotRunning):
+		return fuego.HTTPError{Detail: "machine is not currently running", Status: http.StatusUnprocessableEntity}
+	case errors.Is(err, types.ErrMachineAlreadyPaused):
+		return fuego.HTTPError{Detail: "machine is already paused", Status: http.StatusUnprocessableEntity}
+	case errors.Is(err, types.ErrMachineNotPaused):
+		return fuego.HTTPError{Detail: "machine is not paused", Status: http.StatusUnprocessableEntity}
 	default:
-		return fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
+		return fuego.HTTPError{Detail: "machine " + action + " failed, please try again later", Status: http.StatusInternalServerError}
 	}
 }

--- a/api/internal/features/machine/storage/billing.go
+++ b/api/internal/features/machine/storage/billing.go
@@ -227,7 +227,7 @@ func (s *BillingStorage) GetDueBillings(ctx context.Context) ([]BillingWithPlan,
 		Join("INNER JOIN machine_plans AS mp ON omb.machine_plan_id = mp.id").
 		Where("omb.status = ?", types.MachineBillingStatusActive).
 		Where("omb.current_period_end <= NOW()").
-		Scan(ctx)
+		Scan(ctx, &rows)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get due billings: %w", err)
 	}
@@ -242,7 +242,7 @@ func (s *BillingStorage) GetGraceBillings(ctx context.Context) ([]BillingWithPla
 		ColumnExpr("mp.id AS mp__id, mp.tier AS mp__tier, mp.name AS mp__name, mp.ram_mb AS mp__ram_mb, mp.vcpu AS mp__vcpu, mp.storage_mb AS mp__storage_mb, mp.monthly_cost_cents AS mp__monthly_cost_cents").
 		Join("INNER JOIN machine_plans AS mp ON omb.machine_plan_id = mp.id").
 		Where("omb.status = ?", types.MachineBillingStatusGracePeriod).
-		Scan(ctx)
+		Scan(ctx, &rows)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get grace billings: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Fix GetDueBillings and GetGraceBillings passing `&rows` as scan destination instead of relying on implicit scan which returned empty results
- Sanitize error messages in machine lifecycle error mapper to avoid leaking internal error details to clients

## Test plan
- [ ] Verify billing sweep correctly picks up due and grace period billings
- [ ] Verify machine lifecycle API errors return clean user-facing messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Machine lifecycle operations now return clearer, user-friendly error messages instead of raw technical error details.
  * Introduced appropriate HTTP status codes for different machine operation scenarios (timeout, conflict, invalid state).
  * Improved machine billing query execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->