### PR TITLE
fix: apply log filters to container logs in merged view

### DIFF
--- a/view/packages/components/deployment-logs.tsx
+++ b/view/packages/components/deployment-logs.tsx
@@ -51,9 +51,24 @@ export function DeploymentLogsTable({
 
   const logs = React.useMemo(() => {
     if (!additionalLogs || additionalLogs.length === 0) return deploymentLogs;
-    const merged = [...deploymentLogs, ...additionalLogs];
+
+    const filteredAdditional = additionalLogs.filter((log) => {
+      const matchesSearch =
+        !searchTerm || log.message.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesLevel = filters.level === 'all' || log.level === filters.level;
+      const matchesDate = (() => {
+        if (!filters.startDate && !filters.endDate) return true;
+        const logDate = new Date(log.timestamp);
+        if (filters.startDate && logDate < new Date(filters.startDate)) return false;
+        if (filters.endDate && logDate > new Date(filters.endDate + 'T23:59:59')) return false;
+        return true;
+      })();
+      return matchesSearch && matchesLevel && matchesDate;
+    });
+
+    const merged = [...deploymentLogs, ...filteredAdditional];
     return merged.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-  }, [deploymentLogs, additionalLogs]);
+  }, [deploymentLogs, additionalLogs, searchTerm, filters]);
 
   const {
     hasLogs,


### PR DESCRIPTION
## Summary
- Container logs (additionalLogs) were merged into the deployment logs table without being filtered by level, search term, or date range
- Now all filters apply consistently to both deployment and container logs before merging

## Test plan
- [ ] Open application logs page with container logs present
- [ ] Click a level filter (e.g. Error) and verify container logs are also filtered
- [ ] Type in the search box and verify container log messages are filtered
- [ ] Set a date range and verify container logs outside the range are excluded
- [ ] Click "Clear filters" and verify all logs reappear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment logs filtering to properly apply search term, log level, and date range filters before merging results. Search is now case-insensitive, and date filtering now includes the complete end date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->