### PR TITLE
fix: smooth loading state transitions across pages

### DIFF
--- a/view/app/apps/application/[id]/deployments/[deployment_id]/page.tsx
+++ b/view/app/apps/application/[id]/deployments/[deployment_id]/page.tsx
@@ -12,7 +12,24 @@ function page() {
   const deploymentId = deployment_id?.toString() || '';
 
   return (
-    <ResourceGuard resource="deploy" action="read" loadingFallback={<Skeleton className="h-96" />}>
+    <ResourceGuard
+      resource="deploy"
+      action="read"
+      loadingFallback={
+        <PageLayout maxWidth="full" padding="md" spacing="lg">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-10 flex-1 max-w-sm rounded-md" />
+            <Skeleton className="h-10 w-36 rounded-md" />
+          </div>
+          <div className="space-y-2">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full rounded-md" />
+            ))}
+          </div>
+        </PageLayout>
+      }
+    >
       <PageLayout maxWidth="full" padding="md" spacing="lg">
         <DeploymentLogsTable id={deploymentId} isDeployment={true} title="Deployment Logs" />
       </PageLayout>

--- a/view/app/apps/create/[id]/page.tsx
+++ b/view/app/apps/create/[id]/page.tsx
@@ -13,7 +13,22 @@ function page() {
     <ResourceGuard
       resource="deploy"
       action="create"
-      loadingFallback={<Skeleton className="h-96" />}
+      loadingFallback={
+        <PageLayout
+          maxWidth="full"
+          padding="md"
+          spacing="lg"
+          className="justify-center items-center min-h-[80vh] flex-col flex w-full"
+        >
+          <div className="w-full max-w-2xl space-y-6">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-32 rounded-md" />
+          </div>
+        </PageLayout>
+      }
     >
       <PageLayout
         maxWidth="full"

--- a/view/app/apps/create/page.tsx
+++ b/view/app/apps/create/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import React from 'react';
-import { ListRepositories } from '@/packages/components/github-repositories';
+import {
+  ListRepositories,
+  GithubRepositoriesSkeletonLoader
+} from '@/packages/components/github-repositories';
 import { ResourceGuard } from '@/packages/components/rbac';
 import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
@@ -11,7 +14,19 @@ function page() {
     <ResourceGuard
       resource="deploy"
       action="create"
-      loadingFallback={<Skeleton className="h-96" />}
+      loadingFallback={
+        <PageLayout maxWidth="full" padding="md" spacing="lg">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex items-center justify-between gap-4 flex-wrap mb-4">
+            <Skeleton className="h-10 w-[280px] rounded-md" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-9 w-36 rounded-md" />
+              <Skeleton className="h-9 w-28 rounded-md" />
+            </div>
+          </div>
+          <GithubRepositoriesSkeletonLoader />
+        </PageLayout>
+      }
     >
       <PageLayout maxWidth="full" padding="md" spacing="lg">
         <MainPageHeader label="Repository" highlightLabel={false} />

--- a/view/app/apps/page.tsx
+++ b/view/app/apps/page.tsx
@@ -42,7 +42,7 @@ function page() {
     selfHosted
   } = useGetDeployedApplications();
 
-  if (selfHosted === null) {
+  if (selfHosted === null || isLoadingApplications || isLoading) {
     return (
       <PageLayout maxWidth="full" padding="md" spacing="lg">
         <div className="flex items-center justify-between">

--- a/view/app/charts/application/[id]/deployments/[deployment_id]/page.tsx
+++ b/view/app/charts/application/[id]/deployments/[deployment_id]/page.tsx
@@ -12,7 +12,24 @@ function page() {
   const deploymentId = deployment_id?.toString() || '';
 
   return (
-    <ResourceGuard resource="deploy" action="read" loadingFallback={<Skeleton className="h-96" />}>
+    <ResourceGuard
+      resource="deploy"
+      action="read"
+      loadingFallback={
+        <PageLayout maxWidth="full" padding="md" spacing="lg">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-10 flex-1 max-w-sm rounded-md" />
+            <Skeleton className="h-10 w-36 rounded-md" />
+          </div>
+          <div className="space-y-2">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full rounded-md" />
+            ))}
+          </div>
+        </PageLayout>
+      }
+    >
       <PageLayout maxWidth="full" padding="md" spacing="lg">
         <DeploymentLogsTable id={deploymentId} isDeployment={true} title="Deployment Logs" />
       </PageLayout>

--- a/view/app/charts/create/[id]/page.tsx
+++ b/view/app/charts/create/[id]/page.tsx
@@ -13,7 +13,22 @@ function page() {
     <ResourceGuard
       resource="deploy"
       action="create"
-      loadingFallback={<Skeleton className="h-96" />}
+      loadingFallback={
+        <PageLayout
+          maxWidth="full"
+          padding="md"
+          spacing="lg"
+          className="justify-center items-center min-h-[80vh] flex-col flex w-full"
+        >
+          <div className="w-full max-w-2xl space-y-6">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-32 rounded-md" />
+          </div>
+        </PageLayout>
+      }
     >
       <PageLayout
         maxWidth="full"

--- a/view/app/charts/create/page.tsx
+++ b/view/app/charts/create/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import React from 'react';
-import { ListRepositories } from '@/packages/components/github-repositories';
+import {
+  ListRepositories,
+  GithubRepositoriesSkeletonLoader
+} from '@/packages/components/github-repositories';
 import { ResourceGuard } from '@/packages/components/rbac';
 import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
@@ -11,7 +14,19 @@ function page() {
     <ResourceGuard
       resource="deploy"
       action="create"
-      loadingFallback={<Skeleton className="h-96" />}
+      loadingFallback={
+        <PageLayout maxWidth="full" padding="md" spacing="lg">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex items-center justify-between gap-4 flex-wrap mb-4">
+            <Skeleton className="h-10 w-[280px] rounded-md" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-9 w-36 rounded-md" />
+              <Skeleton className="h-9 w-28 rounded-md" />
+            </div>
+          </div>
+          <GithubRepositoriesSkeletonLoader />
+        </PageLayout>
+      }
     >
       <PageLayout maxWidth="full" padding="md" spacing="lg">
         <MainPageHeader label="Repository" highlightLabel={false} />

--- a/view/packages/hooks/applications/use_get_deployed_applications.ts
+++ b/view/packages/hooks/applications/use_get_deployed_applications.ts
@@ -121,16 +121,26 @@ function useGetDeployedApplications() {
   const [pendingConnectorId, setPendingConnectorId] = useState<string | null>(null);
   const processingInstallRef = useRef(false);
   const [selfHosted, setSelfHosted] = useState<boolean | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
   useEffect(() => {
     getSelfHosted().then(setSelfHosted);
   }, []);
+
+  useEffect(() => {
+    if (!isLoadingApplications) {
+      setHasLoadedOnce(true);
+    }
+  }, [isLoadingApplications]);
+
   const activeConnectorId = useAppSelector((state) => state.githubConnector.activeConnectorId);
   const code = searchParams.get('code');
   const installationId = searchParams.get('installation_id');
   const githubSetup = searchParams.get('github_setup');
   const connectorIdParam = searchParams.get('connector_id');
-  const showApplications = paginatedApplications?.length > 0 || isLoadingApplications;
+  const showApplications = hasLoadedOnce
+    ? paginatedApplications?.length > 0
+    : isLoadingApplications;
 
   useEffect(() => {
     if (code || githubSetup === 'true') {


### PR DESCRIPTION
## Summary
- Eliminate loading cascade on apps page where skeleton cards → apps UI → repository listing caused jarring layout shifts when no apps exist
- Wait for both applications and connectors to finish loading before rendering, preventing flash of GitHub setup screen
- Replace generic `h-96` Skeleton blocks in ResourceGuard loading fallbacks with layout-matching skeletons across 6 pages (repo listing, deploy form, deployment logs)

## Test plan
- [ ] Navigate to /apps with no apps and a GitHub connector — should go straight from skeleton to repository listing, no flash of apps UI or GitHub setup
- [ ] Navigate to /apps with apps — should go from skeleton to apps grid smoothly
- [ ] Navigate to /apps/create — skeleton should match repo listing layout
- [ ] Navigate to /apps/create/[id] — skeleton should match deploy form layout
- [ ] Navigate to deployment logs page — skeleton should match log rows layout
- [ ] After creating GitHub app, returning to /apps should not flash GitHub setup screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned loading screens across deployment logs, app creation, and charts pages with richer, structured skeleton elements
  * Enhanced visual feedback with detailed placeholder layouts replacing basic loading indicators
  * Improved loading state management for better user experience during data transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->