### PR TITLE
fix: allow adding new connector in managed mode when connectors exist

### DIFF
--- a/view/app/apps/page.tsx
+++ b/view/app/apps/page.tsx
@@ -65,7 +65,7 @@ function page() {
   const isManagedMode = !selfHosted;
 
   const isShowingGitHubSetup = isManagedMode
-    ? !showApplications && !connectors?.length
+    ? inGitHubFlow || (!showApplications && !connectors?.length)
     : inGitHubFlow || (!showApplications && !inGitHubFlow && !connectors?.length);
   const isShowingRepositories =
     !showApplications && !inGitHubFlow && connectors?.length && connectors.length > 0;
@@ -75,8 +75,10 @@ function page() {
       <AnyPermissionGuard permissions={['deploy:create']} loadingFallback={null}>
         {isManagedMode ? (
           <>
-            {!showApplications && !connectors?.length && <ManagedGitHubAppSetup />}
-            {!showApplications && connectors?.length && connectors.length > 0 && (
+            {(inGitHubFlow || (!showApplications && !connectors?.length)) && (
+              <ManagedGitHubAppSetup />
+            )}
+            {!inGitHubFlow && !showApplications && connectors?.length && connectors.length > 0 && (
               <ListRepositories />
             )}
           </>


### PR DESCRIPTION
## Summary
- Fixes "Add New Connector" button doing nothing in managed mode when connectors already exist
- The managed mode rendering path now checks `inGitHubFlow` state, showing `ManagedGitHubAppSetup` when the user initiates the add-connector flow

## Test plan
- [ ] In managed mode with an existing connector, open Settings and click "Add New" — verify the GitHub app installer screen appears
- [ ] Verify the page header is hidden during the setup flow
- [ ] After completing or cancelling the flow, verify the repo list is shown again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub Flow setup display logic in managed mode to properly show the appropriate configuration screens based on the current flow state and application setup status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->