### PR TITLE
fix: harden installer for reinstall, fix edge cases, and add comprehensive README

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -3,7 +3,339 @@
 One-line installer for self-hosting Nixopus.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/raghavyuva/nixopus/main/installer/get.sh | sudo bash
+curl -fsSL install.nixopus.com | sudo bash
+```
+
+> **Nixopus is in active development.** Self-hosted images are pulled as `latest` and are not pinned to a specific version. Use in production workloads at your own risk.
+
+## When to self-host
+
+**Self-host** when you need full control over your data, have specific compliance requirements, or want to run on your own infrastructure. Great for indie hackers and developers experimenting with hobby projects on their own VPS.
+
+**Use managed** for production workloads. The managed version includes security patches handled by the Nixopus team, pinned and tested image versions, automatic backups, and priority support — so you can focus on shipping instead of maintaining infrastructure.
+
+**Just want to try Nixopus?** Skip the self-host setup entirely. Sign up at [dashboard.nixopus.com](https://dashboard.nixopus.com) and get free allocated machine resources on signup to explore the platform — including agentic AI assistance for deployments. No VPS required.
+
+## Requirements
+
+Nixopus is a deployment platform that manages Docker, binds ports 80/443, and SSH-es into the host. **Use a fresh, dedicated VPS** — not a server already running other production services. Shared servers will have port conflicts, permission issues, and risk interfering with existing workloads.
+
+- **Server:** Fresh VPS from any cloud provider (Hetzner, DigitalOcean, AWS, etc.)
+- **Arch:** x86_64 (amd64) or aarch64 (arm64)
+- **RAM:** 1 GB minimum (2 GB+ recommended)
+- **Disk:** 2 GB free minimum
+- **Access:** Root (the installer must run as root)
+- **Docker:** Installed automatically if not present (Docker Engine + Compose V2)
+
+### What the installer modifies on your system
+
+The installer will ask for confirmation in interactive mode before proceeding. Here is everything it touches outside of `$NIXOPUS_HOME` (`/opt/nixopus` by default):
+
+| Change | Path | Notes |
+|---|---|---|
+| Installs prereqs if missing | System packages | `curl`, `openssl`, `openssh-client` via apt/dnf/apk |
+| Installs Docker if missing | System packages | Docker Engine + Compose V2, enabled on boot |
+| Management CLI | `/usr/local/bin/nixopus` | Overwritten on each install |
+| SSH public key | `~/.ssh/authorized_keys` | Appended once (skips if already present). Required for deployments via SSH. |
+
+Everything else (config, compose files, SSH keys, Caddyfile) is contained in `$NIXOPUS_HOME`.
+
+### Tested distributions
+
+These are tested in CI on every release:
+
+| Distribution | Version |
+|---|---|
+| Ubuntu | 22.04, 24.04 |
+| Debian | 12 |
+| Rocky Linux | 9 |
+| Alpine | 3.20 |
+
+### Should also work
+
+The installer has support paths for these but they are not tested in CI:
+
+| Distribution | Notes |
+|---|---|
+| Alma Linux | Uses the same install path as Rocky |
+| CentOS / RHEL | Uses the same install path as Rocky |
+| Fedora | Uses `dnf`, same as Rocky/Alma |
+
+Other Linux distributions may work if Docker and Compose V2 are already installed. The installer requires `/etc/os-release` to be present.
+
+## Configuration
+
+All parameters are optional. Pass them as environment variables before the install command.
+
+```bash
+DOMAIN=panel.example.com ADMIN_EMAIL=admin@example.com curl -fsSL install.nixopus.com | sudo bash
+```
+
+| Variable | Default | Description |
+|---|---|---|
+| `DOMAIN` | *(empty — IP mode)* | Domain for automatic HTTPS |
+| `HOST_IP` | *(auto-detected)* | Public IP of the server |
+| `CADDY_HTTP_PORT` | `80` | HTTP port |
+| `CADDY_HTTPS_PORT` | `443` | HTTPS port |
+| `ADMIN_EMAIL` | *(empty)* | Admin account email |
+| `SSH_HOST` | `$HOST_IP` | SSH host the API connects to |
+| `SSH_PORT` | `22` | SSH port (auto-detected from sshd_config if non-standard) |
+| `SSH_USER` | `root` | SSH user |
+| `DB_PASSWORD` | *(random)* | Postgres password |
+| `REDIS_PASSWORD` | *(random)* | Redis password |
+| `DATABASE_URL` | `postgres://nixopus:$DB_PASSWORD@nixopus-db:5432/nixopus` | Full DB connection string. Set to an external URL to skip the bundled DB |
+| `REDIS_URL` | `redis://default:$REDIS_PASSWORD@nixopus-redis:6379` | Full Redis connection string. Set to an external URL to skip bundled Redis |
+| `AUTH_SERVICE_SECRET` | *(random)* | Auth service secret |
+| `JWT_SECRET` | *(random)* | JWT signing secret |
+| `NIXOPUS_HOME` | `/opt/nixopus` | Installation directory |
+| `NIXOPUS_TELEMETRY` | `on` | Set to `off` to disable anonymous telemetry |
+| `LOG_LEVEL` | `debug` | Log level |
+
+## Ports
+
+Nixopus binds the following ports on the host:
+
+| Port | Service | Configurable | Notes |
+|---|---|---|---|
+| `80` | Caddy (HTTP) | `CADDY_HTTP_PORT` | Required for Let's Encrypt HTTPS challenges |
+| `443` | Caddy (HTTPS) | `CADDY_HTTPS_PORT` | TLS termination |
+| `2019` | Caddy admin API | No | Bound to `127.0.0.1` only (not exposed externally) |
+
+Internal services (Docker network only, not exposed to host):
+
+| Port | Service |
+|---|---|
+| `9090` | nixopus-auth |
+| `8443` | nixopus-api |
+| `7443` | nixopus-view |
+| `5432` | nixopus-db (bundled Postgres) |
+| `6379` | nixopus-redis (bundled Redis) |
+
+The SSH port on your host (default `22`) must also be accessible from the Docker network — the API connects back to the host via SSH for deployments.
+
+If ports 80/443 are already in use (Apache, Nginx, another container), either stop the conflicting service or install with custom ports:
+
+```bash
+CADDY_HTTP_PORT=8080 CADDY_HTTPS_PORT=8443 curl -fsSL install.nixopus.com | sudo bash
+```
+
+Use `docker ps --format '{{.Ports}} {{.Names}}'` to find what's using a port.
+
+### Firewall
+
+The installer warns about `ufw` and `firewalld` but does not modify firewall rules. You must open the HTTP/HTTPS ports yourself.
+
+**ufw (Ubuntu/Debian):**
+
+```bash
+sudo ufw allow 80/tcp && sudo ufw allow 443/tcp && sudo ufw reload
+```
+
+**firewalld (RHEL/Rocky/Alma/Fedora):**
+
+```bash
+sudo firewall-cmd --permanent --add-port=80/tcp && sudo firewall-cmd --permanent --add-port=443/tcp && sudo firewall-cmd --reload
+```
+
+**iptables (manual):**
+
+```bash
+sudo iptables -A INPUT -p tcp --dport 80 -j ACCEPT && sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
+```
+
+**Cloud providers:** Also open ports in your cloud firewall (AWS Security Groups, GCP Firewall Rules, Azure NSG, etc.). These are separate from the OS-level firewall.
+
+If using custom ports, replace `80`/`443` with your values in all commands above.
+
+## HTTPS
+
+When you provide a `DOMAIN`, Caddy automatically obtains and renews TLS certificates from Let's Encrypt. For this to work:
+
+1. **DNS A record** must point to your server's public IP *before* installing.
+2. **Port 80 must be open** — Let's Encrypt uses HTTP-01 challenges on port 80, even if you only serve on 443.
+3. **Not behind a proxy** — If using Cloudflare, set to "DNS only" (grey cloud) during initial setup so the challenge can reach your server directly. You can re-enable proxying after the first certificate is issued.
+
+Without a `DOMAIN`, Nixopus runs in IP mode over plain HTTP.
+
+## Management CLI
+
+After installation, the `nixopus` command is available. All commands require root (`sudo`):
+
+```bash
+sudo nixopus status
+```
+
+| Command | Description |
+|---|---|
+| `nixopus status` | Show service health |
+| `nixopus logs [service]` | Tail logs (services: `nixopus-api`, `nixopus-auth`, `nixopus-view`, `nixopus-caddy`, `nixopus-db`, `nixopus-redis`) |
+| `nixopus update` | Pull latest images and restart |
+| `nixopus restart [service]` | Restart all or a specific service |
+| `nixopus stop` | Stop all services |
+| `nixopus config` | Show current configuration |
+| `nixopus config set KEY=VALUE` | Update a config value (restart required) |
+| `nixopus domain add <domain>` | Switch to domain-based HTTPS (ensure DNS is configured first) |
+| `nixopus domain remove` | Switch back to IP-based HTTP |
+| `nixopus ip set <ip>` | Change host IP |
+| `nixopus port set <http\|https\|ssh> <port>` | Change a port |
+| `nixopus backup` | Backup database and config |
+| `nixopus uninstall` | Remove containers (keeps data) |
+| `nixopus uninstall --purge` | Remove everything including data |
+
+## Updates
+
+```bash
+nixopus update
+```
+
+This pulls the latest Docker images and restarts services. It does **not** update Docker Compose files, the Caddyfile, or the CLI itself.
+
+For a full upgrade (new compose files, CLI, etc.), re-run the installer — secrets and config are preserved automatically:
+
+```bash
+curl -fsSL install.nixopus.com | sudo bash
+```
+
+## Backup & Restore
+
+### Backup
+
+```bash
+nixopus backup
+```
+
+Saves a database dump and a copy of `.env` to `/opt/nixopus/backups/<timestamp>/`.
+
+### Restore
+
+```bash
+# 1. Restore the .env
+cp /opt/nixopus/backups/<timestamp>/env.bak /opt/nixopus/.env
+
+# 2. Restart services so the DB container is running
+nixopus restart
+
+# 3. Restore the database dump
+docker exec -i nixopus-db psql -U nixopus nixopus < /opt/nixopus/backups/<timestamp>/db.sql
+```
+
+## Troubleshooting
+
+### Services fail to start after reinstall
+
+**Symptom:** `nixopus-auth` or `nixopus-api` crash-loop with database authentication errors.
+
+**Cause:** Containers were removed but Docker volumes still hold the old database with the original password. The reinstall generated new credentials that don't match.
+
+**Fix:**
+
+```bash
+# Option 1: Check the backup for the original password
+cat /opt/nixopus/.env.bak | grep DB_PASSWORD
+# Then reinstall with it
+DB_PASSWORD=<original_password> curl -fsSL install.nixopus.com | sudo bash
+
+# Option 2: Start fresh (destroys all data)
+docker volume rm $(docker volume ls -q --filter name=nixopus)
+curl -fsSL install.nixopus.com | sudo bash
+```
+
+### Health check timeout during install
+
+**Symptom:** Installer hangs at "Waiting for services to start..." and times out after 180s.
+
+**Fix:** Check which service is unhealthy:
+
+```bash
+nixopus status
+nixopus logs
+```
+
+Common causes: port conflict (see [Ports](#ports)), DNS not configured (see [HTTPS](#https)), or insufficient resources (see [Requirements](#requirements)).
+
+### Cannot access the dashboard
+
+**Symptom:** Browser shows connection refused or timeout.
+
+**Fix:** Verify services are running with `nixopus status`, check ports with `nixopus port`, and ensure firewall rules are in place (see [Firewall](#firewall)). If behind a cloud provider, also check the security group / firewall rules in your cloud console.
+
+### Deployments failing (SSH connection errors)
+
+**Symptom:** Deploys fail with SSH connection refused or permission denied.
+
+The API container SSH-es back into the host to manage deployments. This requires:
+
+1. **SSH service running** on the host on the configured port (`SSH_PORT`, default `22`).
+2. **The Nixopus SSH public key** must be in the host's `~/.ssh/authorized_keys` (the installer adds this automatically, but it can be lost if `authorized_keys` is regenerated).
+3. **The host must be reachable** from the Docker network.
+
+**Fix:**
+
+```bash
+# Verify the key is in authorized_keys
+grep -q "$(cat /opt/nixopus/ssh/id_rsa.pub)" ~/.ssh/authorized_keys || \
+  cat /opt/nixopus/ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+
+# Test SSH from the API container
+docker exec nixopus-api ssh -i /etc/nixopus/ssh/id_rsa -p ${SSH_PORT:-22} -o StrictHostKeyChecking=no ${SSH_USER:-root}@${SSH_HOST} echo ok
+```
+
+### SELinux blocking services (RHEL/Rocky/Alma)
+
+**Symptom:** Containers fail to start or can't access mounted volumes on RHEL-based systems.
+
+**Fix:**
+
+```bash
+# Check if SELinux is enforcing
+getenforce
+
+# Option 1: Allow Docker to access the volume (recommended)
+chcon -Rt svirt_sandbox_file_t /opt/nixopus
+
+# Option 2: Set SELinux to permissive (less secure)
+setenforce 0
+# To persist: edit /etc/selinux/config and set SELINUX=permissive
+```
+
+### Disk space running out
+
+Container logs are capped at 10MB per service (30MB with rotation). If disk still fills up, check:
+
+```bash
+# Docker disk usage
+docker system df
+
+# Clean unused images and build cache
+docker system prune -f
+
+# Check Postgres data size
+docker exec nixopus-db psql -U nixopus -c "SELECT pg_size_pretty(pg_database_size('nixopus'));"
+```
+
+### Services not starting after server reboot
+
+Services use `restart: unless-stopped`, so they start automatically with Docker. If they don't:
+
+```bash
+# Ensure Docker starts on boot
+sudo systemctl enable docker
+
+# Start services manually
+nixopus restart
+```
+
+### Viewing secrets
+
+```bash
+sudo cat /opt/nixopus/.env
+```
+
+### Resetting to a clean state
+
+```bash
+nixopus uninstall --purge
+curl -fsSL install.nixopus.com | sudo bash
 ```
 
 ## Contents

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -222,6 +222,51 @@ prompt_if_tty() {
     fi
 }
 
+load_existing_config() {
+    if [ -f "$NIXOPUS_HOME/.env" ]; then
+        log_info "Existing installation detected at $NIXOPUS_HOME"
+        log_info "Preserving secrets from previous install"
+        local saved_version="$NIXOPUS_VERSION"
+        local saved_home="$NIXOPUS_HOME"
+        set -a
+        # shellcheck disable=SC1091
+        . "$NIXOPUS_HOME/.env"
+        set +a
+        NIXOPUS_VERSION="$saved_version"
+        NIXOPUS_HOME="$saved_home"
+        # Re-detect network config since the server IP may have changed
+        unset HOST_IP SSH_HOST
+        return 0
+    fi
+
+    if command -v docker &>/dev/null; then
+        local orphaned_volumes=""
+        orphaned_volumes=$(docker volume ls --quiet --filter "name=nixopus" 2>/dev/null | grep "nixopus-db-data\|nixopus-redis-data" || true)
+        if [ -n "$orphaned_volumes" ]; then
+            log_warn "Found data volumes without config:"
+            echo "$orphaned_volumes" | while read -r vol; do log_warn "  $vol"; done
+            log_warn "Containers were removed without 'nixopus uninstall --purge'"
+            log_warn "New credentials will NOT match the existing database"
+            if [ -t 0 ]; then
+                echo ""
+                echo -e "  ${BOLD}Options:${NC}"
+                echo "  1) Remove old volumes and start fresh:"
+                echo "     docker volume rm \$(docker volume ls -q --filter name=nixopus)"
+                echo "  2) Provide the original DB password:"
+                echo "     DB_PASSWORD=<old_password> sudo bash get.sh"
+                echo ""
+                read -rp "  Continue with new credentials anyway? [y/N] " confirm
+                if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                    fail "Aborted. Remove orphaned volumes or provide original credentials."
+                fi
+            else
+                log_warn "Non-interactive: proceeding, but services may fail to authenticate"
+                log_warn "Fix: remove volumes and reinstall"
+            fi
+        fi
+    fi
+}
+
 gather_config() {
     check_resources
 
@@ -292,10 +337,9 @@ gather_config() {
     prompt_if_tty ADMIN_EMAIL "Admin email" ""
 
     SSH_HOST="${SSH_HOST:-${HOST_IP:-host.docker.internal}}"
-    SSH_PORT="${SSH_PORT:-22}"
     SSH_USER="${SSH_USER:-root}"
 
-    if [ -t 0 ] && [ -z "${SSH_PORT:-}" ]; then
+    if [ -z "${SSH_PORT:-}" ] && [ -t 0 ]; then
         local current_ssh_port
         current_ssh_port=$(grep -E "^Port " /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}') || true
         if [ -n "$current_ssh_port" ] && [ "$current_ssh_port" != "22" ]; then
@@ -303,6 +347,7 @@ gather_config() {
             SSH_PORT="$current_ssh_port"
         fi
     fi
+    SSH_PORT="${SSH_PORT:-22}"
 
     DB_PASSWORD="${DB_PASSWORD:-$(gen_secret)}"
     REDIS_PASSWORD="${REDIS_PASSWORD:-$(gen_secret)}"
@@ -332,24 +377,38 @@ setup_ssh() {
     local key_path="$NIXOPUS_HOME/ssh/id_rsa"
     if [ -f "$key_path" ]; then
         chmod 755 "$NIXOPUS_HOME/ssh"
-        chmod 644 "$key_path"
+        chmod 600 "$key_path"
         log_ok "SSH key exists"
-        return
+    else
+        ssh-keygen -t rsa -b 4096 -f "$key_path" -N "" -q
+        chmod 755 "$NIXOPUS_HOME/ssh"
+        chmod 600 "$key_path"
+        chmod 644 "$key_path.pub"
+        log_ok "SSH key generated"
     fi
-    ssh-keygen -t rsa -b 4096 -f "$key_path" -N "" -q
-    chmod 755 "$NIXOPUS_HOME/ssh"
-    chmod 644 "$key_path"
-    chmod 644 "$key_path.pub"
 
     local auth_keys="${HOME}/.ssh/authorized_keys"
+    local pubkey
+    pubkey=$(cat "$key_path.pub")
+
     mkdir -p "$(dirname "$auth_keys")"
     touch "$auth_keys"
     chmod 600 "$auth_keys"
-    cat "$key_path.pub" >> "$auth_keys"
-    log_ok "SSH key generated"
+
+    if grep -qF "$pubkey" "$auth_keys" 2>/dev/null; then
+        log_ok "SSH key already in authorized_keys"
+        return
+    fi
+
+    echo "$pubkey" >> "$auth_keys"
+    log_ok "SSH public key added to authorized_keys"
 }
 
 write_env() {
+    if [ -f "$NIXOPUS_HOME/.env" ]; then
+        cp "$NIXOPUS_HOME/.env" "$NIXOPUS_HOME/.env.bak"
+        log_info "Previous .env backed up to $NIXOPUS_HOME/.env.bak"
+    fi
     cat > "$NIXOPUS_HOME/.env" << EOF
 NIXOPUS_VERSION=${NIXOPUS_VERSION}
 NIXOPUS_HOME=${NIXOPUS_HOME}
@@ -404,6 +463,10 @@ copy_compose() {
 
 write_caddyfile() {
     cat > "$NIXOPUS_HOME/Caddyfile" << 'CADDY'
+{
+    admin 0.0.0.0:2019
+}
+
 {$SITE_ADDRESS} {
     handle /api/v1/* {
         reverse_proxy nixopus-api:8443
@@ -418,7 +481,9 @@ write_caddyfile() {
     }
 
     handle {
-        reverse_proxy nixopus-view:7443
+        reverse_proxy nixopus-view:7443 {
+            flush_interval -1
+        }
     }
 }
 CADDY
@@ -490,6 +555,11 @@ install_management_script() {
 set -euo pipefail
 
 NIXOPUS_HOME="${NIXOPUS_HOME:-/opt/nixopus}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "nixopus requires root. Run: sudo nixopus $*" >&2
+    exit 1
+fi
 
 if [ ! -f "$NIXOPUS_HOME/.env" ]; then
     echo "Nixopus not found at $NIXOPUS_HOME. Is it installed?" >&2
@@ -577,11 +647,12 @@ cmd_uninstall() {
         exit 0
     fi
 
-    dc down
     if [ "${1:-}" = "--purge" ]; then
         dc down -v
         rm -rf "$NIXOPUS_HOME"
         echo "All data removed."
+    else
+        dc down
     fi
 
     rm -f /usr/local/bin/nixopus
@@ -657,18 +728,26 @@ cmd_domain() {
     fi
 
     if [ "$action" = "remove" ]; then
-        local host_ip
+        local host_ip http_port base_url
         host_ip=$(grep "^HOST_IP=" "$NIXOPUS_HOME/.env" | cut -d= -f2)
+        http_port=$(grep "^CADDY_HTTP_PORT=" "$NIXOPUS_HOME/.env" | cut -d= -f2)
+        local ip_for_url
+        ip_for_url=$(format_ip_for_url "$host_ip")
+        if [ "${http_port:-80}" = "80" ]; then
+            base_url="http://${ip_for_url}"
+        else
+            base_url="http://${ip_for_url}:${http_port}"
+        fi
 
         sedi "s|^DOMAIN=.*|DOMAIN=|" "$NIXOPUS_HOME/.env"
         sedi "s|^SITE_ADDRESS=.*|SITE_ADDRESS=:80|" "$NIXOPUS_HOME/.env"
-        sedi "s|^ALLOWED_ORIGIN=.*|ALLOWED_ORIGIN=http://${host_ip}|" "$NIXOPUS_HOME/.env"
-        sedi "s|^API_URL=.*|API_URL=http://${host_ip}/api|" "$NIXOPUS_HOME/.env"
-        sedi "s|^AUTH_PUBLIC_URL=.*|AUTH_PUBLIC_URL=http://${host_ip}|" "$NIXOPUS_HOME/.env"
+        sedi "s|^ALLOWED_ORIGIN=.*|ALLOWED_ORIGIN=${base_url}|" "$NIXOPUS_HOME/.env"
+        sedi "s|^API_URL=.*|API_URL=${base_url}/api|" "$NIXOPUS_HOME/.env"
+        sedi "s|^AUTH_PUBLIC_URL=.*|AUTH_PUBLIC_URL=${base_url}|" "$NIXOPUS_HOME/.env"
         sedi "s|^AUTH_COOKIE_DOMAIN=.*|AUTH_COOKIE_DOMAIN=|" "$NIXOPUS_HOME/.env"
         sedi "s|^AUTH_SECURE_COOKIES=.*|AUTH_SECURE_COOKIES=false|" "$NIXOPUS_HOME/.env"
 
-        echo "Switched to IP-based mode (http://${host_ip})"
+        echo "Switched to IP-based mode (${base_url})"
         echo "Restarting services..."
         dc up -d --remove-orphans
     fi
@@ -869,7 +948,9 @@ main() {
     install_docker
 
     log_step 3 "Configuring"
+    load_existing_config
     gather_config
+
 
     log_step 4 "Writing files"
     setup_directories

--- a/installer/nixopus.sh
+++ b/installer/nixopus.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 NIXOPUS_HOME="${NIXOPUS_HOME:-/opt/nixopus}"
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "nixopus requires root. Run: sudo nixopus $*" >&2
+    exit 1
+fi
+
 if [ ! -f "$NIXOPUS_HOME/.env" ]; then
     echo "Nixopus not found at $NIXOPUS_HOME. Is it installed?" >&2
     exit 1
@@ -89,11 +94,12 @@ cmd_uninstall() {
         exit 0
     fi
 
-    dc down
     if [ "${1:-}" = "--purge" ]; then
         dc down -v
         rm -rf "$NIXOPUS_HOME"
         echo "All data removed."
+    else
+        dc down
     fi
 
     rm -f /usr/local/bin/nixopus
@@ -169,20 +175,26 @@ cmd_domain() {
     fi
 
     if [ "$action" = "remove" ]; then
-        local host_ip
+        local host_ip http_port base_url
         host_ip=$(grep "^HOST_IP=" "$NIXOPUS_HOME/.env" | cut -d= -f2)
-        local http_port
         http_port=$(grep "^CADDY_HTTP_PORT=" "$NIXOPUS_HOME/.env" | cut -d= -f2)
+        local ip_for_url
+        ip_for_url=$(format_ip_for_url "$host_ip")
+        if [ "${http_port:-80}" = "80" ]; then
+            base_url="http://${ip_for_url}"
+        else
+            base_url="http://${ip_for_url}:${http_port}"
+        fi
 
         sedi "s|^DOMAIN=.*|DOMAIN=|" "$NIXOPUS_HOME/.env"
         sedi "s|^SITE_ADDRESS=.*|SITE_ADDRESS=:80|" "$NIXOPUS_HOME/.env"
-        sedi "s|^ALLOWED_ORIGIN=.*|ALLOWED_ORIGIN=http://${host_ip}|" "$NIXOPUS_HOME/.env"
-        sedi "s|^API_URL=.*|API_URL=http://${host_ip}/api|" "$NIXOPUS_HOME/.env"
-        sedi "s|^AUTH_PUBLIC_URL=.*|AUTH_PUBLIC_URL=http://${host_ip}|" "$NIXOPUS_HOME/.env"
+        sedi "s|^ALLOWED_ORIGIN=.*|ALLOWED_ORIGIN=${base_url}|" "$NIXOPUS_HOME/.env"
+        sedi "s|^API_URL=.*|API_URL=${base_url}/api|" "$NIXOPUS_HOME/.env"
+        sedi "s|^AUTH_PUBLIC_URL=.*|AUTH_PUBLIC_URL=${base_url}|" "$NIXOPUS_HOME/.env"
         sedi "s|^AUTH_COOKIE_DOMAIN=.*|AUTH_COOKIE_DOMAIN=|" "$NIXOPUS_HOME/.env"
         sedi "s|^AUTH_SECURE_COOKIES=.*|AUTH_SECURE_COOKIES=false|" "$NIXOPUS_HOME/.env"
 
-        echo "Switched to IP-based mode (http://${host_ip})"
+        echo "Switched to IP-based mode (${base_url})"
         echo "Restarting services..."
         dc up -d --remove-orphans
     fi

--- a/installer/selfhost/Caddyfile
+++ b/installer/selfhost/Caddyfile
@@ -1,3 +1,7 @@
+{
+    admin 0.0.0.0:2019
+}
+
 {$SITE_ADDRESS} {
     handle /api/v1/* {
         reverse_proxy nixopus-api:8443

--- a/installer/selfhost/docker-compose.db.yml
+++ b/installer/selfhost/docker-compose.db.yml
@@ -3,6 +3,11 @@ services:
     image: postgres:14-alpine
     container_name: nixopus-db
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       POSTGRES_USER: nixopus
       POSTGRES_PASSWORD: ${DB_PASSWORD}

--- a/installer/selfhost/docker-compose.redis.yml
+++ b/installer/selfhost/docker-compose.redis.yml
@@ -3,6 +3,11 @@ services:
     image: redis:7-alpine
     container_name: nixopus-redis
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
     volumes:
       - nixopus-redis-data:/data

--- a/installer/selfhost/docker-compose.yml
+++ b/installer/selfhost/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     image: ${NIXOPUS_AUTH_IMAGE:-ghcr.io/nixopus/auth:latest}
     container_name: nixopus-auth
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       PORT: "9090"
       HOST: "0.0.0.0"
@@ -38,6 +43,11 @@ services:
     image: ${NIXOPUS_API_IMAGE:-ghcr.io/raghavyuva/nixopus-api:latest}
     container_name: nixopus-api
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -80,6 +90,11 @@ services:
     image: ${NIXOPUS_VIEW_IMAGE:-ghcr.io/raghavyuva/nixopus-view:latest}
     container_name: nixopus-view
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       HOSTNAME: "0.0.0.0"
       PORT: "7443"
@@ -100,9 +115,14 @@ services:
       start_period: 30s
 
   nixopus-caddy:
-    image: caddy:latest
+    image: caddy:2-alpine
     container_name: nixopus-caddy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "0.0.0.0:${CADDY_HTTP_PORT:-80}:80"
       - "0.0.0.0:${CADDY_HTTPS_PORT:-443}:443"


### PR DESCRIPTION
## Summary

- **Credential preservation on reinstall**: Sources existing `.env` before generating new secrets, so `DB_PASSWORD`, `JWT_SECRET`, etc. are preserved when containers are removed but volumes remain. Detects orphaned Docker volumes and warns when credentials will mismatch.
- **Caddyfile fixes**: Added `admin 0.0.0.0:2019` global block (deploy feature was broken without it — API couldn't reach Caddy admin API) and `flush_interval -1` for SSE/streaming support.
- **8 installer bug fixes**: SSH_PORT auto-detection was dead code, SSH private key had world-readable permissions (644→600), `domain remove` ignored custom HTTP port, Caddy image was unpinned (`latest`→`2-alpine`), double `dc down` on purge, management CLI had no root check, `authorized_keys` accumulated duplicate entries on reinstall.
- **Docker log rotation**: Added `json-file` driver with 10MB max-size / 3 files to all 6 services — prevents container logs from filling disk on long-running servers.
- **Comprehensive README**: Requirements (with fresh VPS recommendation), all configuration params, ports/firewall reference, HTTPS setup, CLI reference, update/backup/restore docs, and troubleshooting for common issues (credential mismatch, health check timeout, SSH deploy failures, SELinux, disk space, server reboot). Includes managed vs self-host guidance.

## Test plan

- [ ] Fresh install on a clean VPS (Ubuntu 22.04 or Debian 12)
- [ ] Reinstall after `docker compose down` (no purge) — verify secrets are preserved from `.env`
- [ ] Reinstall after `docker compose down` with `.env` deleted — verify orphaned volume warning appears
- [ ] Verify deploy feature works (Caddy admin API reachable from API container)
- [ ] Verify `nixopus domain remove` generates correct URLs with custom HTTP port
- [ ] Verify `nixopus uninstall --purge` runs single `dc down -v`
- [ ] Verify `nixopus` without sudo shows root required message
- [ ] Run existing test suite: `bash installer/test/run-tests.sh`