### PR TITLE
fix: resolve SSH key permission issue breaking self-hosted registration

### DIFF
--- a/api/internal/features/ssh/init.go
+++ b/api/internal/features/ssh/init.go
@@ -139,6 +139,9 @@ func GetSSHManagerForOrganization(ctx context.Context, orgID uuid.UUID) (*SSHMan
 	if len(sshClient.PrivateKey) == 0 && len(sshClient.Password) == 0 {
 		return nil, fmt.Errorf("SSH config for organization %s has no credentials: private key and password are both empty - please configure an SSH key or password in server settings", orgIDStr)
 	}
+	if len(sshClient.PrivateKey) > 0 && !strings.HasPrefix(sshClient.PrivateKey, "-----BEGIN") {
+		return nil, fmt.Errorf("SSH private key for organization %s is not a valid PEM key (got %q...) - the key may have been stored as a file path instead of its contents; re-register or update the SSH key in server settings", orgIDStr, sshClient.PrivateKey[:min(len(sshClient.PrivateKey), 40)])
+	}
 
 	manager := NewSSHManager()
 	manager.clients["default"] = sshClient

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -377,12 +377,12 @@ setup_ssh() {
     local key_path="$NIXOPUS_HOME/ssh/id_rsa"
     if [ -f "$key_path" ]; then
         chmod 755 "$NIXOPUS_HOME/ssh"
-        chmod 600 "$key_path"
+        chmod 644 "$key_path"
         log_ok "SSH key exists"
     else
         ssh-keygen -t rsa -b 4096 -f "$key_path" -N "" -q
         chmod 755 "$NIXOPUS_HOME/ssh"
-        chmod 600 "$key_path"
+        chmod 644 "$key_path"
         chmod 644 "$key_path.pub"
         log_ok "SSH key generated"
     fi

--- a/installer/selfhost/docker-compose.yml
+++ b/installer/selfhost/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       PORT: "9090"
       HOST: "0.0.0.0"
@@ -20,7 +22,7 @@ services:
       AUTH_SECURE_COOKIES: "${AUTH_SECURE_COOKIES:-false}"
       SELF_HOSTED: "true"
       ADMIN_EMAIL: "${ADMIN_EMAIL:-}"
-      NIXOPUS_API_URL: "http://nixopus-api:8443"
+      API_URL: "http://nixopus-api:8443"
       SECRET_MANAGER_ENABLED: "false"
       PASSWORD_LOGIN_ENABLED: "true"
       SSH_HOST: "${SSH_HOST}"


### PR DESCRIPTION
## Summary

- The installer set `id_rsa` to `chmod 600` (root-only read), but the `nixopus-auth` container runs as non-root user `nixopus` and couldn't read it. This caused the literal file path `/etc/nixopus/ssh/id_rsa` to be stored in `ssh_keys.private_key_encrypted` instead of the actual PEM key content, making all SSH connections fail after self-hosted registration.
- Adds PEM format validation in the Go SSH manager so invalid keys produce a clear error message instead of a cryptic "no key found"
- Adds `extra_hosts: host.docker.internal:host-gateway` to `nixopus-auth` for Docker-to-host networking parity with `nixopus-api`
- Fixes `NIXOPUS_API_URL` -> `API_URL` env var name to match what the auth service config actually reads

## Root Cause

1. `installer/get.sh` creates SSH key with `chmod 600` (owner-only)
2. `nixopus-auth` container runs as user `nixopus` (non-root)
3. `resolveSSHPrivateKey()` in auth service catches the permission error silently and returns the file path string
4. File path string gets inserted into `ssh_keys.private_key_encrypted` in the DB
5. Go API reads this from DB, tries to use it as a PEM key -> `goph.RawKey` fails with "no key found"

## Changes

- `installer/get.sh`: `chmod 600` -> `chmod 644` for `id_rsa` so non-root containers can read it
- `installer/selfhost/docker-compose.yml`: Add `extra_hosts` to auth service, fix `NIXOPUS_API_URL` -> `API_URL`
- `api/internal/features/ssh/init.go`: Add PEM format validation with descriptive error message

## Test plan

- [x] Reproduced on fresh install at 139.84.217.80 - confirmed file path stored in DB
- [x] Applied permission fix, re-registered user - confirmed PEM key stored correctly
- [x] SSH status endpoint returns `{"connected": true}` after fix
- [ ] Full fresh install with updated installer script
- [ ] Verify auth container logs show clear error when key file is unreadable

## Related

Companion PR in nixopus/auth: nixopus/auth#fix/selfhost-ssh-key-validation