### PR TITLE
test(mcp): unit tests — validation, service, MCP client, catalog

### DIFF
--- a/api/internal/features/mcp/tests/catalog_test.go
+++ b/api/internal/features/mcp/tests/catalog_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	mcp "github.com/nixopus/nixopus/api/internal/features/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const tenSeconds = 10 * time.Second
+
+// ─── GetProvider ─────────────────────────────────────────────────────────────
+
+func TestGetProvider(t *testing.T) {
+	t.Run("returns supabase provider", func(t *testing.T) {
+		p := mcp.GetProvider("supabase")
+		require.NotNil(t, p)
+		assert.Equal(t, "supabase", p.ID)
+		assert.Equal(t, "Supabase", p.Name)
+	})
+
+	t.Run("returns github provider", func(t *testing.T) {
+		p := mcp.GetProvider("github")
+		require.NotNil(t, p)
+		assert.Equal(t, "github", p.ID)
+	})
+
+	t.Run("returns custom provider", func(t *testing.T) {
+		p := mcp.GetProvider("custom")
+		require.NotNil(t, p)
+		assert.Equal(t, "custom", p.ID)
+	})
+
+	t.Run("returns nil for unknown id", func(t *testing.T) {
+		p := mcp.GetProvider("does_not_exist")
+		assert.Nil(t, p)
+	})
+}
+
+// ─── Transport correctness ────────────────────────────────────────────────────
+
+func TestCatalogTransportFields(t *testing.T) {
+	t.Run("supabase uses SSE transport", func(t *testing.T) {
+		p := mcp.GetProvider("supabase")
+		require.NotNil(t, p)
+		assert.Equal(t, "sse", p.Transport,
+			"supabase must use SSE so discoverSSE is called for it")
+	})
+
+	t.Run("github uses HTTP transport", func(t *testing.T) {
+		p := mcp.GetProvider("github")
+		require.NotNil(t, p)
+		assert.Equal(t, "http", p.Transport)
+	})
+
+	t.Run("custom uses HTTP transport", func(t *testing.T) {
+		p := mcp.GetProvider("custom")
+		require.NotNil(t, p)
+		assert.Equal(t, "http", p.Transport)
+	})
+}
+
+// ─── Provider field definitions ───────────────────────────────────────────────
+
+func TestCatalogProviderFields(t *testing.T) {
+	t.Run("supabase access_token is required and mapped to Authorization header", func(t *testing.T) {
+		p := mcp.GetProvider("supabase")
+		require.NotNil(t, p)
+
+		var tokenField *mcp.ProviderField
+		for i := range p.Fields {
+			if p.Fields[i].Key == "access_token" {
+				tokenField = &p.Fields[i]
+				break
+			}
+		}
+		require.NotNil(t, tokenField, "access_token field must exist")
+		assert.True(t, tokenField.Required)
+		assert.Equal(t, "Authorization", tokenField.HeaderName)
+		assert.Equal(t, "Bearer", tokenField.HeaderPrefix)
+		assert.True(t, tokenField.Sensitive)
+	})
+
+	t.Run("supabase project_ref is an optional query param", func(t *testing.T) {
+		p := mcp.GetProvider("supabase")
+		require.NotNil(t, p)
+
+		var refField *mcp.ProviderField
+		for i := range p.Fields {
+			if p.Fields[i].Key == "project_ref" {
+				refField = &p.Fields[i]
+				break
+			}
+		}
+		require.NotNil(t, refField, "project_ref field must exist")
+		assert.False(t, refField.Required)
+		assert.True(t, refField.IsQueryParam)
+	})
+
+	t.Run("github token is required and mapped to Authorization header", func(t *testing.T) {
+		p := mcp.GetProvider("github")
+		require.NotNil(t, p)
+		require.Len(t, p.Fields, 1)
+		assert.Equal(t, "token", p.Fields[0].Key)
+		assert.True(t, p.Fields[0].Required)
+		assert.Equal(t, "Authorization", p.Fields[0].HeaderName)
+		assert.Equal(t, "Bearer", p.Fields[0].HeaderPrefix)
+	})
+
+	t.Run("custom provider has no predefined fields", func(t *testing.T) {
+		p := mcp.GetProvider("custom")
+		require.NotNil(t, p)
+		assert.Empty(t, p.Fields,
+			"custom provider requires no pre-defined fields; URL is set by the user")
+	})
+}
+
+// ─── Catalog completeness ─────────────────────────────────────────────────────
+
+func TestCatalogCompleteness(t *testing.T) {
+	knownProviders := []string{"supabase", "github", "custom"}
+
+	for _, id := range knownProviders {
+		t.Run(id+" is in catalog", func(t *testing.T) {
+			p := mcp.GetProvider(id)
+			require.NotNil(t, p)
+			assert.NotEmpty(t, p.Name)
+			assert.NotEmpty(t, p.Description)
+		})
+	}
+
+	t.Run("all catalog entries have a non-empty transport", func(t *testing.T) {
+		for _, p := range mcp.Catalog {
+			assert.NotEmpty(t, p.Transport, "provider %q has no transport set", p.ID)
+		}
+	})
+}

--- a/api/internal/features/mcp/tests/mcp_client_test.go
+++ b/api/internal/features/mcp/tests/mcp_client_test.go
@@ -1,0 +1,233 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/nixopus/nixopus/api/internal/features/mcp"
+	"github.com/nixopus/nixopus/api/internal/features/mcp/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── JSON-RPC helpers (local mirror of unexported types) ─────────────────────
+
+type jrpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+}
+
+type jrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+var toolsPayload = json.RawMessage(`{"tools":[{"name":"search_repos","description":"Search GitHub repos"},{"name":"create_issue","description":"Open an issue"}]}`)
+var initPayload = json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{}}`)
+
+// ─── HTTP transport mock server ───────────────────────────────────────────────
+
+// newHTTPMockServer creates a Streamable-HTTP MCP server that responds to
+// initialize and tools/list over plain JSON-RPC POST.
+func newHTTPMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jrpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		var result json.RawMessage
+		switch req.Method {
+		case "initialize":
+			result = initPayload
+		case "tools/list":
+			result = toolsPayload
+		default:
+			http.Error(w, "unknown method", http.StatusNotFound)
+			return
+		}
+
+		resp := jrpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+}
+
+// ─── SSE transport mock server ────────────────────────────────────────────────
+
+// newSSEMockServer creates a legacy-SSE MCP server.
+// GET /sse streams events; POST /messages relays JSON-RPC responses back over
+// that same stream.
+func newSSEMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	outgoing := make(chan string, 4)
+	done := make(chan struct{})
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok, "ResponseWriter must implement http.Flusher")
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		fmt.Fprintf(w, "event: endpoint\ndata: /messages\n\n") //nolint:errcheck
+		flusher.Flush()
+
+		for {
+			select {
+			case msg, ok := <-outgoing:
+				if !ok {
+					return
+				}
+				fmt.Fprintf(w, "event: message\ndata: %s\n\n", msg) //nolint:errcheck
+				flusher.Flush()
+			case <-done:
+				return
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+
+	mux.HandleFunc("/messages", func(w http.ResponseWriter, r *http.Request) {
+		var req jrpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		var result json.RawMessage
+		switch req.Method {
+		case "initialize":
+			result = initPayload
+		case "tools/list":
+			result = toolsPayload
+		default:
+			http.Error(w, "unknown method", http.StatusNotFound)
+			return
+		}
+
+		resp := jrpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+		data, _ := json.Marshal(resp)
+		outgoing <- string(data)
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		close(done)
+		srv.Close()
+	})
+	return srv
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+func TestDiscoverServerTools_HTTP(t *testing.T) {
+	srv := newHTTPMockServer(t)
+	defer srv.Close()
+
+	provider := &mcp.MCPProvider{
+		ID:        "github",
+		Name:      "GitHub",
+		URL:       srv.URL + "/",
+		Transport: "http",
+		Fields: []mcp.ProviderField{
+			{Key: "token", HeaderName: "Authorization", HeaderPrefix: "Bearer", Required: true},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tenSeconds)
+	defer cancel()
+
+	tools, err := service.DiscoverServerTools(ctx, provider, "", map[string]string{
+		"token": "ghp_test_token",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	assert.Equal(t, "search_repos", tools[0].Name)
+	assert.Equal(t, "create_issue", tools[1].Name)
+}
+
+func TestDiscoverServerTools_HTTP_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	provider := &mcp.MCPProvider{
+		ID:        "github",
+		Name:      "GitHub",
+		URL:       srv.URL + "/",
+		Transport: "http",
+		Fields:    []mcp.ProviderField{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tenSeconds)
+	defer cancel()
+
+	_, err := service.DiscoverServerTools(ctx, provider, "", map[string]string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initialize")
+}
+
+func TestDiscoverServerTools_SSE(t *testing.T) {
+	srv := newSSEMockServer(t)
+
+	provider := &mcp.MCPProvider{
+		ID:        "supabase",
+		Name:      "Supabase",
+		URL:       srv.URL + "/sse",
+		Transport: "sse",
+		Fields: []mcp.ProviderField{
+			{Key: "access_token", HeaderName: "Authorization", HeaderPrefix: "Bearer", Required: true},
+			{Key: "project_ref", IsQueryParam: true},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tenSeconds)
+	defer cancel()
+
+	tools, err := service.DiscoverServerTools(ctx, provider, "", map[string]string{
+		"access_token": "sbp_test_token",
+		"project_ref":  "abcdef",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	assert.Equal(t, "search_repos", tools[0].Name)
+}
+
+func TestDiscoverServerTools_CustomHTTP(t *testing.T) {
+	srv := newHTTPMockServer(t)
+	defer srv.Close()
+
+	provider := &mcp.MCPProvider{
+		ID:        "custom",
+		Name:      "Custom",
+		URL:       "",
+		Transport: "http",
+		Fields:    []mcp.ProviderField{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tenSeconds)
+	defer cancel()
+
+	tools, err := service.DiscoverServerTools(ctx, provider, srv.URL+"/", map[string]string{})
+
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+}

--- a/api/internal/features/mcp/tests/service_test.go
+++ b/api/internal/features/mcp/tests/service_test.go
@@ -1,0 +1,219 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/mcp/service"
+	"github.com/nixopus/nixopus/api/internal/features/mcp/storage"
+	"github.com/nixopus/nixopus/api/internal/features/mcp/validation"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Mock repository ──────────────────────────────────────────────────────────
+
+type mockMCPRepo struct {
+	mock.Mock
+}
+
+func (m *mockMCPRepo) CreateServer(s *shared_types.MCPServer) error {
+	return m.Called(s).Error(0)
+}
+
+func (m *mockMCPRepo) ListServers(orgID uuid.UUID, p storage.ListServersParams) ([]shared_types.MCPServer, int, error) {
+	args := m.Called(orgID, p)
+	list, _ := args.Get(0).([]shared_types.MCPServer)
+	return list, args.Int(1), args.Error(2)
+}
+
+func (m *mockMCPRepo) GetServerByID(id uuid.UUID) (*shared_types.MCPServer, error) {
+	args := m.Called(id)
+	s, _ := args.Get(0).(*shared_types.MCPServer)
+	return s, args.Error(1)
+}
+
+func (m *mockMCPRepo) GetServerByName(orgID uuid.UUID, name string) (*shared_types.MCPServer, error) {
+	args := m.Called(orgID, name)
+	s, _ := args.Get(0).(*shared_types.MCPServer)
+	return s, args.Error(1)
+}
+
+func (m *mockMCPRepo) UpdateServer(s *shared_types.MCPServer) error {
+	return m.Called(s).Error(0)
+}
+
+func (m *mockMCPRepo) DeleteServer(id uuid.UUID) error {
+	return m.Called(id).Error(0)
+}
+
+func newTestService(repo storage.MCPRepository) *service.MCPService {
+	return service.NewMCPService(nil, context.Background(), logger.NewLogger(), repo)
+}
+
+// ─── AddServer ───────────────────────────────────────────────────────────────
+
+func TestAddServer(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	req := &validation.CreateServerRequest{
+		ProviderID:  "supabase",
+		Name:        "My Supabase",
+		Credentials: map[string]string{"access_token": "tok"},
+		Enabled:     true,
+	}
+
+	t.Run("creates server when name is unique", func(t *testing.T) {
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByName", orgID, req.Name).Return((*shared_types.MCPServer)(nil), nil)
+		repo.On("CreateServer", mock.AnythingOfType("*types.MCPServer")).Return(nil)
+
+		svc := newTestService(repo)
+		server, err := svc.AddServer(req, orgID, userID)
+
+		require.NoError(t, err)
+		require.NotNil(t, server)
+		assert.Equal(t, req.Name, server.Name)
+		assert.Equal(t, req.ProviderID, server.ProviderID)
+		assert.Equal(t, orgID, server.OrgID)
+		assert.Equal(t, userID, server.CreatedBy)
+		assert.WithinDuration(t, time.Now(), server.CreatedAt, 5*time.Second)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("returns ErrDuplicateName when name already exists", func(t *testing.T) {
+		existing := &shared_types.MCPServer{ID: uuid.New(), Name: req.Name}
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByName", orgID, req.Name).Return(existing, nil)
+
+		svc := newTestService(repo)
+		_, err := svc.AddServer(req, orgID, userID)
+
+		require.ErrorIs(t, err, service.ErrDuplicateName)
+		repo.AssertNotCalled(t, "CreateServer")
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("propagates storage error from GetServerByName", func(t *testing.T) {
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByName", orgID, req.Name).Return((*shared_types.MCPServer)(nil), assert.AnError)
+
+		svc := newTestService(repo)
+		_, err := svc.AddServer(req, orgID, userID)
+
+		require.Error(t, err)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("sets custom_url only when provided", func(t *testing.T) {
+		customReq := &validation.CreateServerRequest{
+			ProviderID:  "custom",
+			Name:        "My Custom",
+			Credentials: map[string]string{},
+			CustomURL:   "https://mcp.example.com/sse",
+			Enabled:     true,
+		}
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByName", orgID, customReq.Name).Return((*shared_types.MCPServer)(nil), nil)
+		repo.On("CreateServer", mock.AnythingOfType("*types.MCPServer")).Return(nil)
+
+		svc := newTestService(repo)
+		server, err := svc.AddServer(customReq, orgID, userID)
+
+		require.NoError(t, err)
+		require.NotNil(t, server.CustomURL)
+		assert.Equal(t, "https://mcp.example.com/sse", *server.CustomURL)
+		repo.AssertExpectations(t)
+	})
+}
+
+// ─── DeleteServer ─────────────────────────────────────────────────────────────
+
+func TestDeleteServer(t *testing.T) {
+	orgID := uuid.New()
+	serverID := uuid.New()
+
+	t.Run("deletes server that belongs to org", func(t *testing.T) {
+		server := &shared_types.MCPServer{ID: serverID, OrgID: orgID}
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByID", serverID).Return(server, nil)
+		repo.On("DeleteServer", serverID).Return(nil)
+
+		svc := newTestService(repo)
+		err := svc.DeleteServer(serverID.String(), orgID)
+
+		require.NoError(t, err)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("returns ErrServerNotFound when server doesn't exist", func(t *testing.T) {
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByID", serverID).Return((*shared_types.MCPServer)(nil), nil)
+
+		svc := newTestService(repo)
+		err := svc.DeleteServer(serverID.String(), orgID)
+
+		require.ErrorIs(t, err, service.ErrServerNotFound)
+		repo.AssertNotCalled(t, "DeleteServer")
+	})
+
+	t.Run("returns ErrServerNotFound when server belongs to different org", func(t *testing.T) {
+		otherOrgServer := &shared_types.MCPServer{ID: serverID, OrgID: uuid.New()}
+		repo := &mockMCPRepo{}
+		repo.On("GetServerByID", serverID).Return(otherOrgServer, nil)
+
+		svc := newTestService(repo)
+		err := svc.DeleteServer(serverID.String(), orgID)
+
+		require.ErrorIs(t, err, service.ErrServerNotFound)
+		repo.AssertNotCalled(t, "DeleteServer")
+	})
+
+	t.Run("returns error on invalid UUID", func(t *testing.T) {
+		repo := &mockMCPRepo{}
+		svc := newTestService(repo)
+		err := svc.DeleteServer("not-a-valid-uuid", orgID)
+		require.Error(t, err)
+	})
+}
+
+// ─── ListServers ─────────────────────────────────────────────────────────────
+
+func TestListServers(t *testing.T) {
+	orgID := uuid.New()
+
+	t.Run("returns servers from storage", func(t *testing.T) {
+		servers := []shared_types.MCPServer{
+			{ID: uuid.New(), Name: "Alpha", OrgID: orgID},
+			{ID: uuid.New(), Name: "Beta", OrgID: orgID},
+		}
+		params := storage.ListServersParams{Page: 1, Limit: 10}
+		repo := &mockMCPRepo{}
+		repo.On("ListServers", orgID, params).Return(servers, 2, nil)
+
+		svc := newTestService(repo)
+		got, total, err := svc.ListServers(orgID, params)
+
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.Equal(t, 2, total)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("forwards search and sort params to storage unchanged", func(t *testing.T) {
+		params := storage.ListServersParams{Q: "sup", SortBy: "name", SortDir: "desc", Page: 2, Limit: 5}
+		repo := &mockMCPRepo{}
+		repo.On("ListServers", orgID, params).Return([]shared_types.MCPServer{}, 0, nil)
+
+		svc := newTestService(repo)
+		_, _, err := svc.ListServers(orgID, params)
+
+		require.NoError(t, err)
+		repo.AssertExpectations(t)
+	})
+}

--- a/api/internal/features/mcp/tests/validation_test.go
+++ b/api/internal/features/mcp/tests/validation_test.go
@@ -1,0 +1,166 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/nixopus/nixopus/api/internal/features/mcp/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── ValidateURL ─────────────────────────────────────────────────────────────
+
+func TestValidateURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr error
+	}{
+		// Happy path
+		{"valid https public host", "https://mcp.supabase.com/sse", nil},
+		{"valid https with path and query", "https://api.example.com/mcp?ref=abc", nil},
+
+		// Scheme enforcement
+		{"http is rejected", "http://example.com/mcp", validation.ErrInvalidURL},
+		{"no scheme", "example.com/mcp", validation.ErrInvalidURL},
+		{"empty string", "", validation.ErrInvalidURL},
+
+		// Private / loopback address SSRF mitigations
+		{"loopback 127.0.0.1", "https://127.0.0.1/mcp", validation.ErrPrivateURL},
+		{"private 10.x", "https://10.0.0.1/mcp", validation.ErrPrivateURL},
+		{"private 192.168.x", "https://192.168.1.100/mcp", validation.ErrPrivateURL},
+		{"private 172.16.x", "https://172.16.0.1/mcp", validation.ErrPrivateURL},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validation.ValidateURL(tc.url)
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ─── ValidateCreateRequest ───────────────────────────────────────────────────
+
+func TestValidateCreateRequest(t *testing.T) {
+	validSupabaseCreds := map[string]string{"access_token": "tok_abc123"}
+
+	cases := []struct {
+		name    string
+		req     *validation.CreateServerRequest
+		wantErr error
+	}{
+		{
+			name: "valid supabase server",
+			req: &validation.CreateServerRequest{
+				ProviderID:  "supabase",
+				Name:        "My Supabase",
+				Credentials: validSupabaseCreds,
+				Enabled:     true,
+			},
+		},
+		{
+			name: "valid custom server",
+			req: &validation.CreateServerRequest{
+				ProviderID:  "custom",
+				Name:        "My Custom MCP",
+				Credentials: map[string]string{},
+				CustomURL:   "https://mcp.mycompany.com/sse",
+				Enabled:     true,
+			},
+		},
+		{
+			name:    "missing name",
+			req:     &validation.CreateServerRequest{ProviderID: "supabase", Credentials: validSupabaseCreds},
+			wantErr: validation.ErrNameRequired,
+		},
+		{
+			name:    "whitespace-only name",
+			req:     &validation.CreateServerRequest{Name: "   ", ProviderID: "supabase", Credentials: validSupabaseCreds},
+			wantErr: validation.ErrNameRequired,
+		},
+		{
+			name:    "missing provider_id",
+			req:     &validation.CreateServerRequest{Name: "test", Credentials: validSupabaseCreds},
+			wantErr: validation.ErrProviderRequired,
+		},
+		{
+			name:    "unknown provider_id",
+			req:     &validation.CreateServerRequest{Name: "test", ProviderID: "unknown_xyz", Credentials: map[string]string{}},
+			wantErr: validation.ErrUnknownProvider,
+		},
+		{
+			name: "custom without custom_url",
+			req: &validation.CreateServerRequest{
+				ProviderID:  "custom",
+				Name:        "test",
+				Credentials: map[string]string{},
+			},
+			wantErr: validation.ErrCustomURLRequired,
+		},
+		{
+			name: "custom with non-https custom_url",
+			req: &validation.CreateServerRequest{
+				ProviderID:  "custom",
+				Name:        "test",
+				Credentials: map[string]string{},
+				CustomURL:   "http://my-mcp.com/sse",
+			},
+			wantErr: validation.ErrInvalidURL,
+		},
+		{
+			name: "supabase missing required access_token",
+			req: &validation.CreateServerRequest{
+				ProviderID:  "supabase",
+				Name:        "test",
+				Credentials: map[string]string{},
+			},
+			wantErr: validation.ErrMissingRequiredField,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validation.ValidateCreateRequest(tc.req)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ─── ValidateUpdateRequest ───────────────────────────────────────────────────
+
+func TestValidateUpdateRequest(t *testing.T) {
+	t.Run("valid update", func(t *testing.T) {
+		err := validation.ValidateUpdateRequest(&validation.UpdateServerRequest{
+			ID: "uuid-abc", Name: "Renamed Server",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty name rejected", func(t *testing.T) {
+		err := validation.ValidateUpdateRequest(&validation.UpdateServerRequest{ID: "uuid-abc", Name: ""})
+		assert.ErrorIs(t, err, validation.ErrNameRequired)
+	})
+
+	t.Run("custom_url http rejected", func(t *testing.T) {
+		err := validation.ValidateUpdateRequest(&validation.UpdateServerRequest{
+			ID: "uuid-abc", Name: "test", CustomURL: "http://bad.com/mcp",
+		})
+		assert.ErrorIs(t, err, validation.ErrInvalidURL)
+	})
+
+	t.Run("valid custom_url accepted", func(t *testing.T) {
+		err := validation.ValidateUpdateRequest(&validation.UpdateServerRequest{
+			ID: "uuid-abc", Name: "test", CustomURL: "https://ok.com/mcp",
+		})
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Stacked on top of #1156. Adds 35 unit tests across 4 files covering all MCP packages.

## Test files

| File | Tests | What it covers |
|---|---|---|
| `validation_test.go` | 9 | SSRF URL blocking (HTTP, private IPs, loopback), all request validation rules |
| `service_test.go` | 9 | `AddServer` (happy path, duplicate name, storage error, custom URL), `DeleteServer` (not found, wrong org, invalid UUID), `ListServers` (data + param forwarding) |
| `mcp_client_test.go` | 4 | HTTP transport round-trip, HTTP 500 error, SSE full protocol flow, Custom provider URL override — all via `httptest` mock servers, no external network |
| `catalog_test.go` | 13 | `GetProvider` for all providers, transport field correctness, field definitions (header names, prefixes, required flags), catalog completeness |

## How to run

```bash
cd api
go test ./internal/features/mcp/tests/... -v
```

All 35 tests pass with no external dependencies.