### PR TITLE
feat: add machine backup scheduling and queue support

### DIFF
--- a/api/internal/features/machine/controller/backup.go
+++ b/api/internal/features/machine/controller/backup.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/machine/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+)
+
+func (c *MachineController) TriggerBackup(f fuego.ContextNoBody) (*types.TriggerBackupResponse, error) {
+	w, r := f.Response(), f.Request()
+	user := utils.GetUser(w, r)
+
+	if user == nil {
+		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
+	}
+
+	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
+
+	response, err := c.backupService.TriggerBackup(r.Context(), user.ID, orgID)
+	if err != nil {
+		return nil, mapBackupError(err)
+	}
+
+	return response, nil
+}
+
+func (c *MachineController) ListBackups(f fuego.ContextNoBody) (*types.BackupListResponse, error) {
+	w, r := f.Response(), f.Request()
+	user := utils.GetUser(w, r)
+
+	if user == nil {
+		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
+	}
+
+	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
+
+	response, err := c.backupService.ListBackups(r.Context(), orgID)
+	if err != nil {
+		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		return nil, fuego.HTTPError{Detail: "failed to list backups", Status: http.StatusInternalServerError}
+	}
+
+	return response, nil
+}
+
+func (c *MachineController) GetBackupSchedule(f fuego.ContextNoBody) (*types.BackupScheduleResponse, error) {
+	w, r := f.Response(), f.Request()
+	user := utils.GetUser(w, r)
+
+	if user == nil {
+		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
+	}
+
+	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
+
+	response, err := c.backupService.GetBackupSchedule(r.Context(), orgID)
+	if err != nil {
+		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		return nil, fuego.HTTPError{Detail: "failed to get backup schedule", Status: http.StatusInternalServerError}
+	}
+
+	return response, nil
+}
+
+func (c *MachineController) UpdateBackupSchedule(f fuego.ContextWithBody[types.BackupScheduleData]) (*types.BackupScheduleResponse, error) {
+	w, r := f.Response(), f.Request()
+	user := utils.GetUser(w, r)
+
+	if user == nil {
+		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
+	}
+
+	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
+
+	body, err := f.Body()
+	if err != nil {
+		return nil, fuego.BadRequestError{Detail: "invalid request body"}
+	}
+
+	response, err := c.backupService.UpdateBackupSchedule(r.Context(), orgID, body)
+	if err != nil {
+		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		return nil, fuego.BadRequestError{Detail: err.Error()}
+	}
+
+	return response, nil
+}
+
+func mapBackupError(err error) error {
+	switch {
+	case errors.Is(err, types.ErrMachineNotProvisioned):
+		return fuego.NotFoundError{Detail: err.Error()}
+	case errors.Is(err, types.ErrBackupAlreadyRunning):
+		return fuego.HTTPError{Detail: "a backup is already in progress", Status: http.StatusConflict}
+	default:
+		return fuego.HTTPError{Detail: "backup operation failed", Status: http.StatusInternalServerError}
+	}
+}

--- a/api/internal/features/machine/controller/init.go
+++ b/api/internal/features/machine/controller/init.go
@@ -20,6 +20,7 @@ type MachineController struct {
 	service          *service.MachineService
 	billingService   *service.BillingService
 	lifecycleService *service.LifecycleService
+	backupService    *service.BackupService
 	ctx              context.Context
 	logger           logger.Logger
 }
@@ -30,11 +31,13 @@ func NewMachineController(
 	l logger.Logger,
 ) *MachineController {
 	bs := billing_storage.NewBillingStorage(store.DB, ctx)
+	backupStore := billing_storage.NewBackupStorage(store.DB, ctx)
 	return &MachineController{
 		store:            store,
 		service:          service.NewMachineService(store, ctx, l),
 		billingService:   service.NewBillingService(bs),
 		lifecycleService: service.NewLifecycleService(bs, queue.ExecuteMachineLifecycle),
+		backupService:    service.NewBackupService(bs, backupStore, store.DB),
 		ctx:              ctx,
 		logger:           l,
 	}

--- a/api/internal/features/machine/service/backup.go
+++ b/api/internal/features/machine/service/backup.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/machine/storage"
+	"github.com/nixopus/nixopus/api/internal/features/machine/types"
+	"github.com/nixopus/nixopus/api/internal/queue"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+	"github.com/uptrace/bun"
+)
+
+type BackupService struct {
+	provisionInfo ProvisionInfoProvider
+	backupStore   *storage.BackupStorage
+	db            *bun.DB
+}
+
+func NewBackupService(p ProvisionInfoProvider, bs *storage.BackupStorage, db *bun.DB) *BackupService {
+	return &BackupService{provisionInfo: p, backupStore: bs, db: db}
+}
+
+func (s *BackupService) TriggerBackup(ctx context.Context, userID uuid.UUID, orgID uuid.UUID) (*types.TriggerBackupResponse, error) {
+	info, err := s.provisionInfo.GetProvisionInfo(ctx, orgID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve machine: %w", err)
+	}
+	if info == nil || info.ContainerName == "" {
+		return nil, types.ErrMachineNotProvisioned
+	}
+
+	hasRunning, err := s.backupStore.HasInProgressBackup(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check backup status: %w", err)
+	}
+	if hasRunning {
+		return nil, types.ErrBackupAlreadyRunning
+	}
+
+	payload := queue.MachineBackupPayload{
+		MachineName: info.ContainerName,
+		UserID:      userID.String(),
+		OrgID:       orgID.String(),
+		ServerID:    info.ServerID,
+		Trigger:     "api",
+	}
+
+	requestID, err := queue.EnqueueMachineBackup(ctx, payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to enqueue backup: %w", err)
+	}
+
+	return &types.TriggerBackupResponse{
+		Status:    "success",
+		Message:   "Backup initiated. Check status via GET /machine/backups.",
+		RequestID: requestID,
+	}, nil
+}
+
+func (s *BackupService) ListBackups(ctx context.Context, orgID uuid.UUID) (*types.BackupListResponse, error) {
+	backups, err := s.backupStore.ListByOrg(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backups: %w", err)
+	}
+	if backups == nil {
+		backups = []types.MachineBackup{}
+	}
+
+	return &types.BackupListResponse{
+		Status:  "success",
+		Message: "Backups retrieved",
+		Data:    backups,
+	}, nil
+}
+
+func (s *BackupService) GetBackupSchedule(ctx context.Context, orgID uuid.UUID) (*types.BackupScheduleResponse, error) {
+	settings, err := utils.GetOrganizationSettings(ctx, s.db, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization settings: %w", err)
+	}
+
+	data := types.BackupScheduleData{
+		Frequency:      "daily",
+		HourUTC:        2,
+		DayOfWeek:      0,
+		RetentionCount: 7,
+	}
+	if settings.BackupScheduleEnabled != nil {
+		data.Enabled = *settings.BackupScheduleEnabled
+	}
+	if settings.BackupScheduleFrequency != nil {
+		data.Frequency = *settings.BackupScheduleFrequency
+	}
+	if settings.BackupScheduleHourUTC != nil {
+		data.HourUTC = *settings.BackupScheduleHourUTC
+	}
+	if settings.BackupScheduleDayOfWeek != nil {
+		data.DayOfWeek = *settings.BackupScheduleDayOfWeek
+	}
+	if settings.BackupRetentionCount != nil {
+		data.RetentionCount = *settings.BackupRetentionCount
+	}
+
+	return &types.BackupScheduleResponse{
+		Status:  "success",
+		Message: "Backup schedule retrieved",
+		Data:    data,
+	}, nil
+}
+
+func (s *BackupService) UpdateBackupSchedule(ctx context.Context, orgID uuid.UUID, req types.BackupScheduleData) (*types.BackupScheduleResponse, error) {
+	if req.Frequency != "daily" && req.Frequency != "weekly" {
+		return nil, fmt.Errorf("invalid frequency: must be 'daily' or 'weekly'")
+	}
+	if req.HourUTC < 0 || req.HourUTC > 23 {
+		return nil, fmt.Errorf("invalid hour_utc: must be 0-23")
+	}
+	if req.DayOfWeek < 0 || req.DayOfWeek > 6 {
+		return nil, fmt.Errorf("invalid day_of_week: must be 0 (Sun) - 6 (Sat)")
+	}
+	if req.RetentionCount < 1 || req.RetentionCount > 365 {
+		return nil, fmt.Errorf("invalid retention_count: must be 1-365")
+	}
+
+	var orgSettings shared_types.OrganizationSettings
+	err := s.db.NewSelect().
+		Model(&orgSettings).
+		Where("organization_id = ?", orgID).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load organization settings: %w", err)
+	}
+
+	orgSettings.Settings.BackupScheduleEnabled = &req.Enabled
+	orgSettings.Settings.BackupScheduleFrequency = &req.Frequency
+	orgSettings.Settings.BackupScheduleHourUTC = &req.HourUTC
+	orgSettings.Settings.BackupScheduleDayOfWeek = &req.DayOfWeek
+	orgSettings.Settings.BackupRetentionCount = &req.RetentionCount
+	orgSettings.UpdatedAt = time.Now()
+
+	_, err = s.db.NewUpdate().
+		Model(&orgSettings).
+		Column("settings", "updated_at").
+		Where("id = ?", orgSettings.ID).
+		Exec(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update backup schedule: %w", err)
+	}
+
+	return &types.BackupScheduleResponse{
+		Status:  "success",
+		Message: "Backup schedule updated",
+		Data:    req,
+	}, nil
+}

--- a/api/internal/features/machine/storage/backup.go
+++ b/api/internal/features/machine/storage/backup.go
@@ -1,0 +1,83 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/machine/types"
+	"github.com/uptrace/bun"
+)
+
+type BackupStorage struct {
+	DB  *bun.DB
+	Ctx context.Context
+}
+
+func NewBackupStorage(db *bun.DB, ctx context.Context) *BackupStorage {
+	return &BackupStorage{DB: db, Ctx: ctx}
+}
+
+func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]types.MachineBackup, error) {
+	var backups []types.MachineBackup
+	err := s.DB.NewSelect().
+		Model(&backups).
+		Where("organization_id = ?", orgID).
+		OrderExpr("created_at DESC").
+		Limit(50).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backups: %w", err)
+	}
+	return backups, nil
+}
+
+func (s *BackupStorage) HasInProgressBackup(ctx context.Context, orgID uuid.UUID) (bool, error) {
+	exists, err := s.DB.NewSelect().
+		Model((*types.MachineBackup)(nil)).
+		Where("organization_id = ?", orgID).
+		Where("status IN (?)", bun.In([]types.MachineBackupStatus{
+			types.BackupStatusPending,
+			types.BackupStatusInProgress,
+		})).
+		Exists(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check in-progress backups: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *BackupStorage) GetLatestCompletedBackup(ctx context.Context, orgID uuid.UUID) (*types.MachineBackup, error) {
+	var backup types.MachineBackup
+	err := s.DB.NewSelect().
+		Model(&backup).
+		Where("organization_id = ?", orgID).
+		Where("status = ?", types.BackupStatusCompleted).
+		OrderExpr("completed_at DESC").
+		Limit(1).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get latest completed backup: %w", err)
+	}
+	return &backup, nil
+}
+
+func (s *BackupStorage) GetByID(ctx context.Context, id uuid.UUID, orgID uuid.UUID) (*types.MachineBackup, error) {
+	var backup types.MachineBackup
+	err := s.DB.NewSelect().
+		Model(&backup).
+		Where("id = ? AND organization_id = ?", id, orgID).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get backup: %w", err)
+	}
+	return &backup, nil
+}

--- a/api/internal/features/machine/types/backup.go
+++ b/api/internal/features/machine/types/backup.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+type MachineBackupStatus string
+
+const (
+	BackupStatusPending    MachineBackupStatus = "pending"
+	BackupStatusInProgress MachineBackupStatus = "in_progress"
+	BackupStatusCompleted  MachineBackupStatus = "completed"
+	BackupStatusFailed     MachineBackupStatus = "failed"
+)
+
+type MachineBackup struct {
+	bun.BaseModel `bun:"table:machine_backups,alias:mb" swaggerignore:"true"`
+
+	ID             uuid.UUID           `json:"id" bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	UserID         uuid.UUID           `json:"user_id" bun:"user_id,type:uuid,notnull"`
+	OrganizationID uuid.UUID           `json:"organization_id" bun:"organization_id,type:uuid,notnull"`
+	ProvisionID    *uuid.UUID          `json:"provision_id" bun:"provision_id,type:uuid"`
+	MachineName    string              `json:"machine_name" bun:"machine_name,type:varchar(255),notnull"`
+	Status         MachineBackupStatus `json:"status" bun:"status,type:machine_backup_status,notnull,default:'pending'"`
+	Trigger        string              `json:"trigger" bun:"trigger,type:varchar(50),notnull"`
+	SnapshotPath   *string             `json:"snapshot_path" bun:"snapshot_path,type:text"`
+	S3Path         *string             `json:"s3_path" bun:"s3_path,type:text"`
+	SizeBytes      int64               `json:"size_bytes" bun:"size_bytes,type:bigint,default:0"`
+	Error          *string             `json:"error" bun:"error,type:text"`
+	StartedAt      *time.Time          `json:"started_at" bun:"started_at,type:timestamptz"`
+	CompletedAt    *time.Time          `json:"completed_at" bun:"completed_at,type:timestamptz"`
+	CreatedAt      time.Time           `json:"created_at" bun:"created_at,type:timestamptz,notnull,default:now()"`
+	UpdatedAt      time.Time           `json:"updated_at" bun:"updated_at,type:timestamptz,notnull,default:now()"`
+}
+
+type TriggerBackupResponse struct {
+	Status    string `json:"status"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id"`
+}
+
+type BackupListResponse struct {
+	Status  string          `json:"status"`
+	Message string          `json:"message"`
+	Data    []MachineBackup `json:"data"`
+}
+
+type BackupScheduleData struct {
+	Enabled        bool   `json:"enabled"`
+	Frequency      string `json:"frequency"`
+	HourUTC        int    `json:"hour_utc"`
+	DayOfWeek      int    `json:"day_of_week"`
+	RetentionCount int    `json:"retention_count"`
+}
+
+type BackupScheduleResponse struct {
+	Status  string             `json:"status"`
+	Message string             `json:"message"`
+	Data    BackupScheduleData `json:"data"`
+}
+
+var (
+	ErrBackupAlreadyRunning = errors.New("a backup is already in progress for this machine")
+)

--- a/api/internal/queue/machine_backup.go
+++ b/api/internal/queue/machine_backup.go
@@ -1,0 +1,89 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/vmihailenco/taskq/v3"
+)
+
+const (
+	queueMachineBackup = "machine-backup"
+	taskMachineBackup  = "task_machine_backup"
+	backupReplyPrefix  = "backup:reply:"
+)
+
+type MachineBackupPayload struct {
+	RequestID   string `json:"request_id"`
+	MachineName string `json:"machine_name"`
+	UserID      string `json:"user_id"`
+	OrgID       string `json:"org_id"`
+	ServerID    string `json:"server_id,omitempty"`
+	Trigger     string `json:"trigger"`
+	ExpiresAt   int64  `json:"expires_at"`
+}
+
+type MachineBackupResult struct {
+	RequestID    string `json:"request_id"`
+	Success      bool   `json:"success"`
+	BackupID     string `json:"backup_id,omitempty"`
+	SnapshotPath string `json:"snapshot_path,omitempty"`
+	S3Path       string `json:"s3_path,omitempty"`
+	SizeBytes    int64  `json:"size_bytes,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+var (
+	onceMachineBackup     sync.Once
+	machineBackupQueue    taskq.Queue
+	taskMachineBackupTask *taskq.Task
+	backupReplyMux        *ReplyMultiplexer
+)
+
+func SetupMachineBackupQueue(ctx context.Context) {
+	onceMachineBackup.Do(func() {
+		machineBackupQueue = registerProducerQueue(&taskq.QueueOptions{
+			Name: queueMachineBackup,
+		})
+
+		taskMachineBackupTask = taskq.RegisterTask(&taskq.TaskOptions{
+			Name:       taskMachineBackup,
+			RetryLimit: 0,
+			Handler: func(ctx context.Context, payload MachineBackupPayload) error {
+				return nil
+			},
+		})
+
+		backupReplyMux = NewReplyMultiplexerWithPrefix(backupReplyPrefix)
+		backupReplyMux.Start(ctx)
+
+		log.Printf("Machine backup queue and reply multiplexer initialized")
+	})
+}
+
+// EnqueueMachineBackup enqueues a backup task and returns the request ID immediately.
+// The caller should poll the machine_backups table for completion status.
+func EnqueueMachineBackup(ctx context.Context, payload MachineBackupPayload) (string, error) {
+	if taskMachineBackupTask == nil {
+		return "", fmt.Errorf("machine backup queue not initialized - call SetupMachineBackupQueue first")
+	}
+
+	requestID := uuid.New().String()
+	payload.RequestID = requestID
+	payload.ExpiresAt = time.Now().Add(30 * time.Minute).Unix()
+
+	q := machineBackupQueue
+	if payload.ServerID != "" {
+		q = getOrCreateProducerQueue(queueMachineBackup + "-" + payload.ServerID)
+	}
+
+	if err := q.Add(taskMachineBackupTask.WithArgs(ctx, payload)); err != nil {
+		return "", fmt.Errorf("failed to enqueue backup task: %w", err)
+	}
+
+	return requestID, nil
+}

--- a/api/internal/queue/reply_mux.go
+++ b/api/internal/queue/reply_mux.go
@@ -11,10 +11,15 @@ const replyChannelPrefix = "machine:reply:"
 
 type ReplyMultiplexer struct {
 	waiters sync.Map
+	prefix  string
 }
 
 func NewReplyMultiplexer() *ReplyMultiplexer {
-	return &ReplyMultiplexer{}
+	return &ReplyMultiplexer{prefix: replyChannelPrefix}
+}
+
+func NewReplyMultiplexerWithPrefix(prefix string) *ReplyMultiplexer {
+	return &ReplyMultiplexer{prefix: prefix}
 }
 
 func (m *ReplyMultiplexer) Start(ctx context.Context) {
@@ -24,7 +29,7 @@ func (m *ReplyMultiplexer) Start(ctx context.Context) {
 	}
 
 	go func() {
-		pubsub := redisClient.PSubscribe(ctx, replyChannelPrefix+"*")
+		pubsub := redisClient.PSubscribe(ctx, m.prefix+"*")
 		defer pubsub.Close()
 
 		ch := pubsub.Channel()
@@ -36,7 +41,7 @@ func (m *ReplyMultiplexer) Start(ctx context.Context) {
 				if !ok {
 					return
 				}
-				requestID := ExtractRequestIDFromChannel(msg.Channel)
+				requestID := extractIDFromChannel(msg.Channel, m.prefix)
 				if requestID != "" {
 					m.Dispatch(requestID, msg.Payload)
 				}
@@ -67,9 +72,13 @@ func (m *ReplyMultiplexer) Dispatch(requestID string, data string) {
 	}
 }
 
-func ExtractRequestIDFromChannel(channel string) string {
-	if !strings.HasPrefix(channel, replyChannelPrefix) {
+func extractIDFromChannel(channel string, prefix string) string {
+	if !strings.HasPrefix(channel, prefix) {
 		return ""
 	}
-	return strings.TrimPrefix(channel, replyChannelPrefix)
+	return strings.TrimPrefix(channel, prefix)
+}
+
+func ExtractRequestIDFromChannel(channel string) string {
+	return extractIDFromChannel(channel, replyChannelPrefix)
 }

--- a/api/internal/routes/machine.go
+++ b/api/internal/routes/machine.go
@@ -46,6 +46,34 @@ func (router *Router) RegisterMachineRoutes(machineGroup *fuego.Server, machineC
 		fuego.OptionSummary("Resume machine"),
 		fuego.OptionDescription("Resumes a paused machine instance."),
 	)
+	fuego.Post(
+		machineGroup,
+		"/backup",
+		machineController.TriggerBackup,
+		fuego.OptionSummary("Trigger machine backup"),
+		fuego.OptionDescription("Initiates an async backup of the provisioned machine (snapshot + S3 upload). Returns immediately; poll GET /machine/backups for status."),
+	)
+	fuego.Get(
+		machineGroup,
+		"/backups",
+		machineController.ListBackups,
+		fuego.OptionSummary("List machine backups"),
+		fuego.OptionDescription("Returns the backup history for the organization's provisioned machine."),
+	)
+	fuego.Get(
+		machineGroup,
+		"/backup/schedule",
+		machineController.GetBackupSchedule,
+		fuego.OptionSummary("Get backup schedule"),
+		fuego.OptionDescription("Returns the automatic backup schedule configuration for the organization."),
+	)
+	fuego.Put(
+		machineGroup,
+		"/backup/schedule",
+		machineController.UpdateBackupSchedule,
+		fuego.OptionSummary("Update backup schedule"),
+		fuego.OptionDescription("Updates the automatic backup schedule (enable/disable, frequency, time)."),
+	)
 }
 
 func (router *Router) RegisterMachineBillingRoutes(billingGroup *fuego.Server, machineController *machine_controller.MachineController) {

--- a/api/internal/scheduler/backup.go
+++ b/api/internal/scheduler/backup.go
@@ -1,0 +1,165 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	machine_storage "github.com/nixopus/nixopus/api/internal/features/machine/storage"
+	"github.com/nixopus/nixopus/api/internal/queue"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/robfig/cron/v3"
+	"github.com/uptrace/bun"
+)
+
+const (
+	backupScheduleCheck = "0 * * * *"
+
+	dailyMinGap  = 20 * time.Hour
+	weeklyMinGap = 6 * 24 * time.Hour
+)
+
+type BackupScheduler struct {
+	cron         *cron.Cron
+	billingStore *machine_storage.BillingStorage
+	backupStore  *machine_storage.BackupStorage
+	db           *bun.DB
+	logger       logger.Logger
+	ctx          context.Context
+}
+
+func NewBackupScheduler(db *bun.DB, ctx context.Context, l logger.Logger) *BackupScheduler {
+	return &BackupScheduler{
+		cron:         cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
+		billingStore: machine_storage.NewBillingStorage(db, ctx),
+		backupStore:  machine_storage.NewBackupStorage(db, ctx),
+		db:           db,
+		logger:       l,
+		ctx:          ctx,
+	}
+}
+
+func (b *BackupScheduler) Start() {
+	_, err := b.cron.AddFunc(backupScheduleCheck, b.run)
+	if err != nil {
+		b.logger.Log(logger.Error, fmt.Sprintf("backup scheduler: failed to register cron: %v", err), "")
+		return
+	}
+	b.cron.Start()
+	b.logger.Log(logger.Info, fmt.Sprintf("backup scheduler started with schedule: %s", backupScheduleCheck), "")
+}
+
+func (b *BackupScheduler) Stop() {
+	b.cron.Stop()
+}
+
+func (b *BackupScheduler) run() {
+	now := time.Now().UTC()
+	currentHour := now.Hour()
+	currentDay := int(now.Weekday())
+
+	var orgSettings []*types.OrganizationSettings
+	err := b.db.NewSelect().
+		Model(&orgSettings).
+		Scan(b.ctx)
+	if err != nil {
+		b.logger.Log(logger.Error, fmt.Sprintf("backup scheduler: failed to load org settings: %v", err), "")
+		return
+	}
+
+	enqueued, skipped := 0, 0
+	for _, org := range orgSettings {
+		s := org.Settings
+		if !isBackupEnabled(s) {
+			continue
+		}
+
+		configuredHour := 2
+		if s.BackupScheduleHourUTC != nil {
+			configuredHour = *s.BackupScheduleHourUTC
+		}
+		if currentHour != configuredHour {
+			continue
+		}
+
+		freq := "daily"
+		if s.BackupScheduleFrequency != nil {
+			freq = *s.BackupScheduleFrequency
+		}
+		if freq == "weekly" {
+			configuredDay := 0
+			if s.BackupScheduleDayOfWeek != nil {
+				configuredDay = *s.BackupScheduleDayOfWeek
+			}
+			if currentDay != configuredDay {
+				continue
+			}
+		}
+
+		orgID := org.OrganizationID
+		if err := b.enqueueIfDue(orgID, freq, now); err != nil {
+			b.logger.Log(logger.Error, fmt.Sprintf("backup scheduler: org %s: %v", orgID, err), "")
+			skipped++
+		} else {
+			enqueued++
+		}
+	}
+
+	if enqueued > 0 || skipped > 0 {
+		b.logger.Log(logger.Info, fmt.Sprintf("backup scheduler: enqueued %d, skipped %d", enqueued, skipped), "")
+	}
+}
+
+func (b *BackupScheduler) enqueueIfDue(orgID uuid.UUID, freq string, now time.Time) error {
+	hasRunning, err := b.backupStore.HasInProgressBackup(b.ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("check in-progress: %w", err)
+	}
+	if hasRunning {
+		return fmt.Errorf("backup already in progress")
+	}
+
+	latest, err := b.backupStore.GetLatestCompletedBackup(b.ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("check latest backup: %w", err)
+	}
+	if latest != nil && latest.CompletedAt != nil {
+		minGap := dailyMinGap
+		if freq == "weekly" {
+			minGap = weeklyMinGap
+		}
+		if now.Sub(*latest.CompletedAt) < minGap {
+			return fmt.Errorf("last backup too recent (%s ago)", now.Sub(*latest.CompletedAt).Round(time.Minute))
+		}
+	}
+
+	info, err := b.billingStore.GetProvisionInfo(b.ctx, orgID, nil)
+	if err != nil {
+		return fmt.Errorf("resolve machine: %w", err)
+	}
+	if info == nil || info.ContainerName == "" {
+		return fmt.Errorf("no provisioned machine")
+	}
+
+	payload := queue.MachineBackupPayload{
+		MachineName: info.ContainerName,
+		UserID:      info.UserID.String(),
+		OrgID:       orgID.String(),
+		ServerID:    info.ServerID,
+		Trigger:     "scheduled",
+	}
+
+	requestID, err := queue.EnqueueMachineBackup(b.ctx, payload)
+	if err != nil {
+		return fmt.Errorf("enqueue: %w", err)
+	}
+
+	b.logger.Log(logger.Info, fmt.Sprintf("backup scheduler: enqueued backup for org %s machine %s (request %s)", orgID, info.ContainerName, requestID), "")
+	return nil
+}
+
+func isBackupEnabled(s types.OrganizationSettingsData) bool {
+	return s.BackupScheduleEnabled != nil && *s.BackupScheduleEnabled
+}

--- a/api/internal/scheduler/init.go
+++ b/api/internal/scheduler/init.go
@@ -15,6 +15,7 @@ type Schedulers struct {
 	Main        *Scheduler
 	HealthCheck *HealthCheckScheduler
 	Billing     *BillingScheduler
+	Backup      *BackupScheduler
 }
 
 // InitSchedulers creates and configures all schedulers
@@ -35,10 +36,12 @@ func InitSchedulers(store *shared_storage.Store, ctx context.Context) *Scheduler
 	healthCheckScheduler := NewHealthCheckScheduler(healthCheckService, l, ctx, nil)
 
 	billingScheduler := NewBillingScheduler(store.DB, ctx, l)
+	backupScheduler := NewBackupScheduler(store.DB, ctx, l)
 
 	return &Schedulers{
 		Main:        sched,
 		HealthCheck: healthCheckScheduler,
 		Billing:     billingScheduler,
+		Backup:      backupScheduler,
 	}
 }

--- a/api/internal/types/preferences.go
+++ b/api/internal/types/preferences.go
@@ -54,6 +54,13 @@ type OrganizationSettingsData struct {
 	AuditLogsRetentionDays       *int  `json:"audit_logs_retention_days,omitempty"`
 	ExtensionLogsCleanupEnabled  *bool `json:"extension_logs_cleanup_enabled,omitempty"`
 	ExtensionLogsRetentionDays   *int  `json:"extension_logs_retention_days,omitempty"`
+
+	// Backup schedule settings
+	BackupScheduleEnabled   *bool   `json:"backup_schedule_enabled,omitempty"`
+	BackupScheduleFrequency *string `json:"backup_schedule_frequency,omitempty"`
+	BackupScheduleHourUTC   *int    `json:"backup_schedule_hour_utc,omitempty"`
+	BackupScheduleDayOfWeek *int    `json:"backup_schedule_day_of_week,omitempty"`
+	BackupRetentionCount    *int    `json:"backup_retention_count,omitempty"`
 }
 
 // OrganizationSettings represents organization-level settings stored in the database
@@ -113,6 +120,13 @@ func DefaultOrganizationSettingsData() OrganizationSettingsData {
 	extensionLogsCleanupEnabled := true
 	extensionLogsRetentionDays := 30
 
+	// Backup schedule defaults (disabled by default, daily at 2am UTC, keep 7)
+	backupScheduleEnabled := false
+	backupScheduleFrequency := "daily"
+	backupScheduleHourUTC := 2
+	backupScheduleDayOfWeek := 0
+	backupRetentionCount := 7
+
 	return OrganizationSettingsData{
 		WebsocketReconnectAttempts:       5,
 		WebsocketReconnectInterval:       3000,
@@ -129,5 +143,10 @@ func DefaultOrganizationSettingsData() OrganizationSettingsData {
 		AuditLogsRetentionDays:           &auditLogsRetentionDays,
 		ExtensionLogsCleanupEnabled:      &extensionLogsCleanupEnabled,
 		ExtensionLogsRetentionDays:       &extensionLogsRetentionDays,
+		BackupScheduleEnabled:            &backupScheduleEnabled,
+		BackupScheduleFrequency:          &backupScheduleFrequency,
+		BackupScheduleHourUTC:            &backupScheduleHourUTC,
+		BackupScheduleDayOfWeek:          &backupScheduleDayOfWeek,
+		BackupRetentionCount:             &backupRetentionCount,
 	}
 }

--- a/api/internal/utils/organization.go
+++ b/api/internal/utils/organization.go
@@ -198,6 +198,11 @@ func GetOrganizationSettings(ctx context.Context, db *bun.DB, orgID uuid.UUID) (
 		AuditLogsRetentionDays:           defaults.AuditLogsRetentionDays,
 		ExtensionLogsCleanupEnabled:      defaults.ExtensionLogsCleanupEnabled,
 		ExtensionLogsRetentionDays:       defaults.ExtensionLogsRetentionDays,
+		BackupScheduleEnabled:            defaults.BackupScheduleEnabled,
+		BackupScheduleFrequency:          defaults.BackupScheduleFrequency,
+		BackupScheduleHourUTC:            defaults.BackupScheduleHourUTC,
+		BackupScheduleDayOfWeek:          defaults.BackupScheduleDayOfWeek,
+		BackupRetentionCount:             defaults.BackupRetentionCount,
 	}
 
 	if settings.Settings.ContainerLogTailLines != nil {
@@ -232,6 +237,21 @@ func GetOrganizationSettings(ctx context.Context, db *bun.DB, orgID uuid.UUID) (
 	}
 	if settings.Settings.ExtensionLogsRetentionDays != nil {
 		result.ExtensionLogsRetentionDays = settings.Settings.ExtensionLogsRetentionDays
+	}
+	if settings.Settings.BackupScheduleEnabled != nil {
+		result.BackupScheduleEnabled = settings.Settings.BackupScheduleEnabled
+	}
+	if settings.Settings.BackupScheduleFrequency != nil {
+		result.BackupScheduleFrequency = settings.Settings.BackupScheduleFrequency
+	}
+	if settings.Settings.BackupScheduleHourUTC != nil {
+		result.BackupScheduleHourUTC = settings.Settings.BackupScheduleHourUTC
+	}
+	if settings.Settings.BackupScheduleDayOfWeek != nil {
+		result.BackupScheduleDayOfWeek = settings.Settings.BackupScheduleDayOfWeek
+	}
+	if settings.Settings.BackupRetentionCount != nil {
+		result.BackupRetentionCount = settings.Settings.BackupRetentionCount
 	}
 
 	return result, nil

--- a/api/main.go
+++ b/api/main.go
@@ -69,6 +69,7 @@ func main() {
 	queue.SetupCustomDomainQueue()
 	queue.SetupResourceUpdateQueue()
 	queue.SetupMachineLifecycleQueue(ctx)
+	queue.SetupMachineBackupQueue(ctx)
 
 	router := routes.NewRouter(app)
 
@@ -86,6 +87,8 @@ func main() {
 	log.Println("Health check scheduler started successfully")
 	schedulers.Billing.Start()
 	log.Println("Billing scheduler started successfully")
+	schedulers.Backup.Start()
+	log.Println("Backup scheduler started successfully")
 
 	router.SetupRoutes()
 
@@ -99,6 +102,7 @@ func main() {
 		schedulers.Main.Stop()
 		schedulers.HealthCheck.Stop()
 		schedulers.Billing.Stop()
+		schedulers.Backup.Stop()
 		os.Exit(0)
 	}()
 	log.Printf("Server starting on port %s", config.AppConfig.Server.Port)


### PR DESCRIPTION
## Summary

- Adds backup types, storage layer, service, and controller for machine backups
- Implements a scheduled backup job with configurable preferences
- Adds a queue worker (`machine_backup`) to process backup tasks asynchronously
- Wires backup routes into the machine router and connects preferences to the main app

## Changes

| Area | Files |
|------|-------|
| Types | `machine/types/backup.go` |
| Storage | `machine/storage/backup.go` |
| Service | `machine/service/backup.go` |
| Controller | `machine/controller/backup.go`, `controller/init.go` |
| Queue | `queue/machine_backup.go`, `queue/reply_mux.go` |
| Scheduler | `scheduler/backup.go`, `scheduler/init.go` |
| Routes | `routes/machine.go` |
| Config | `types/preferences.go`, `utils/organization.go`, `main.go` |

## Test plan

- [ ] Verify backup can be triggered via the new API route
- [ ] Confirm the scheduler fires backup jobs at the configured interval
- [ ] Confirm the queue worker processes and completes backup tasks
- [ ] Check backup preferences are respected (retention, schedule, etc.)