### PR TITLE
fix: use consistent container layout on integrations page

### DIFF
--- a/view/packages/components/integrations/index.tsx
+++ b/view/packages/components/integrations/index.tsx
@@ -125,7 +125,7 @@ export function IntegrationsPage() {
   const catalogTotalPages = Math.ceil(catalogTotalCount / catalogPageSize);
 
   return (
-    <PageLayout maxWidth="full" padding="md" spacing="lg">
+    <PageLayout maxWidth="7xl" padding="md" spacing="lg">
       <MainPageHeader label={t('integrations.title' as any)} highlightLabel={false} />
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## Summary

- The integrations page was using `maxWidth="full"` in `PageLayout`, causing it to stretch to full width instead of being centered
- Changed to `maxWidth="7xl"` to match the consistent layout used by all other main pages (dashboard, apps, activities)

## Test plan

- [ ] Visit the integrations page and verify it has the same centered, max-width container as the dashboard and apps pages