### PR TITLE
fix: api-domain and view-domain options behave inconsistently

### DIFF
--- a/docs/.vitepress/components/install-generator/composables/useInstallGenerator.ts
+++ b/docs/.vitepress/components/install-generator/composables/useInstallGenerator.ts
@@ -78,6 +78,16 @@ export function useInstallGenerator() {
     if (isFeatureDisabled(feature)) return
 
     if (!feature.enabled) {
+      if (feature.id === 'apiDomain') {
+        const viewDomain = findFeature('viewDomain')
+        if (viewDomain && !viewDomain.enabled) viewDomain.enabled = true
+      }
+
+      if (feature.id === 'viewDomain') {
+        const apiDomain = findFeature('apiDomain')
+        if (apiDomain && !apiDomain.enabled) apiDomain.enabled = true
+      }
+
       if (feature.id === 'hostIp') {
         const apiDomain = findFeature('apiDomain')
         const viewDomain = findFeature('viewDomain')


### PR DESCRIPTION
Fixes #924. Enabling either api-domain or view-domain option now automatically enables the other.