### PR TITLE
fix(deploy): rename ApplicationServer bun alias from reserved SQL keyword

### DIFF
--- a/api/internal/features/deploy/storage/init.go
+++ b/api/internal/features/deploy/storage/init.go
@@ -969,8 +969,8 @@ func (s *DeployStorage) GetApplicationServers(appID uuid.UUID) ([]shared_types.A
 	err := s.DB.NewSelect().
 		Model(&servers).
 		Relation("Server").
-		Where("as.application_id = ?", appID).
-		Order("as.is_primary DESC", "as.created_at ASC").
+		Where("aps.application_id = ?", appID).
+		Order("aps.is_primary DESC", "aps.created_at ASC").
 		Scan(s.Ctx)
 	return servers, err
 }

--- a/api/internal/features/deploy/tasks/init.go
+++ b/api/internal/features/deploy/tasks/init.go
@@ -100,7 +100,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 				defer t.DeregisterCancellation(deploymentID)
 
 				t.Logger.Log(logger.Info, "starting update deployment", data.CorrelationID)
-				return t.HandleUpdateDeployment(ctx, data)
+				if err := t.HandleUpdateDeployment(ctx, data); err != nil {
+					t.Logger.Log(logger.Error, "update deployment failed: "+err.Error(), data.CorrelationID)
+					return err
+				}
+				t.Logger.Log(logger.Info, "update deployment completed", data.CorrelationID)
+				return nil
 			},
 		})
 
@@ -126,7 +131,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 				defer t.DeregisterCancellation(deploymentID)
 
 				t.Logger.Log(logger.Info, "starting redeploy", data.CorrelationID)
-				return t.HandleReDeploy(ctx, data)
+				if err := t.HandleReDeploy(ctx, data); err != nil {
+					t.Logger.Log(logger.Error, "redeploy failed: "+err.Error(), data.CorrelationID)
+					return err
+				}
+				t.Logger.Log(logger.Info, "redeploy completed", data.CorrelationID)
+				return nil
 			},
 		})
 
@@ -146,7 +156,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 			RetryLimit: 1,
 			Handler: func(ctx context.Context, data shared_types.TaskPayload) error {
 				t.Logger.Log(logger.Info, "starting rollback", data.CorrelationID)
-				return t.HandleRollback(ctx, data)
+				if err := t.HandleRollback(ctx, data); err != nil {
+					t.Logger.Log(logger.Error, "rollback failed: "+err.Error(), data.CorrelationID)
+					return err
+				}
+				t.Logger.Log(logger.Info, "rollback completed", data.CorrelationID)
+				return nil
 			},
 		})
 
@@ -166,7 +181,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 			RetryLimit: 1,
 			Handler: func(ctx context.Context, data shared_types.TaskPayload) error {
 				t.Logger.Log(logger.Info, "starting restart", data.CorrelationID)
-				return t.HandleRestart(ctx, data)
+				if err := t.HandleRestart(ctx, data); err != nil {
+					t.Logger.Log(logger.Error, "restart failed: "+err.Error(), data.CorrelationID)
+					return err
+				}
+				t.Logger.Log(logger.Info, "restart completed", data.CorrelationID)
+				return nil
 			},
 		})
 	})

--- a/api/internal/features/deploy/tasks/redeploy.go
+++ b/api/internal/features/deploy/tasks/redeploy.go
@@ -8,16 +8,20 @@ import (
 
 	"github.com/nixopus/nixopus/api/internal/features/deploy/caddy"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
 // HandleReDeploy fans out redeployment across all configured servers (or org default for single-server apps).
 func (s *TaskService) HandleReDeploy(ctx context.Context, TaskPayload shared_types.TaskPayload) error {
+	s.Logger.Log(logger.Info, fmt.Sprintf("redeploy: fetching servers for app %s (buildpack=%s)", TaskPayload.Application.ID, TaskPayload.Application.BuildPack), "")
 	allServers, err := s.Storage.GetApplicationServers(TaskPayload.Application.ID)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve application servers: %w", err)
 	}
+	s.Logger.Log(logger.Info, fmt.Sprintf("redeploy: got %d servers for app %s", len(allServers), TaskPayload.Application.ID), "")
 	if len(allServers) == 0 {
+		s.Logger.Log(logger.Info, "redeploy: no application_servers rows, falling back to org default", "")
 		return s.handleReDeploySingle(ctx, TaskPayload)
 	}
 	servers := filterServers(allServers, TaskPayload.TargetServerIDs)

--- a/api/internal/types/application.go
+++ b/api/internal/types/application.go
@@ -44,24 +44,24 @@ type Application struct {
 }
 
 type ApplicationDeployment struct {
-	bun.BaseModel   `bun:"table:application_deployment,alias:ad" swaggerignore:"true"`
-	ID              uuid.UUID                    `json:"id" bun:"id,pk,type:uuid"`
-	ApplicationID   uuid.UUID                    `json:"application_id" bun:"application_id,notnull,type:uuid"`
-	CreatedAt       time.Time                    `json:"created_at" bun:"created_at,notnull,default:current_timestamp"`
-	UpdatedAt       time.Time                    `json:"updated_at" bun:"updated_at,notnull,default:current_timestamp"`
-	CommitHash      string                       `json:"commit_hash" bun:"commit_hash"`
-	Application     *Application                 `json:"application,omitempty" bun:"rel:belongs-to,join:application_id=id"`
-	Status          *ApplicationDeploymentStatus `json:"status,omitempty" bun:"rel:has-one,join:id=application_deployment_id"`
-	Logs            []*ApplicationLogs           `json:"logs,omitempty" bun:"rel:has-many,join:id=application_deployment_id"`
-	ContainerID     string                       `json:"container_id" bun:"container_id"`
-	ContainerName   string                       `json:"container_name" bun:"container_name"`
-	ContainerImage  string                       `json:"container_image" bun:"container_image"`
-	ContainerStatus string                       `json:"container_status" bun:"container_status"`
-	ImageS3Key      string                       `json:"image_s3_key" bun:"image_s3_key,default:''"`
-	ImageSize       int64                        `json:"image_size" bun:"image_size,default:0"`
-	ServerID           *uuid.UUID              `json:"server_id,omitempty"            bun:"server_id,type:uuid"`
-	ParentDeploymentID *uuid.UUID              `json:"parent_deployment_id,omitempty" bun:"parent_deployment_id,type:uuid"`
-	Children           []*ApplicationDeployment `json:"children,omitempty"            bun:"rel:has-many,join:id=parent_deployment_id"`
+	bun.BaseModel      `bun:"table:application_deployment,alias:ad" swaggerignore:"true"`
+	ID                 uuid.UUID                    `json:"id" bun:"id,pk,type:uuid"`
+	ApplicationID      uuid.UUID                    `json:"application_id" bun:"application_id,notnull,type:uuid"`
+	CreatedAt          time.Time                    `json:"created_at" bun:"created_at,notnull,default:current_timestamp"`
+	UpdatedAt          time.Time                    `json:"updated_at" bun:"updated_at,notnull,default:current_timestamp"`
+	CommitHash         string                       `json:"commit_hash" bun:"commit_hash"`
+	Application        *Application                 `json:"application,omitempty" bun:"rel:belongs-to,join:application_id=id"`
+	Status             *ApplicationDeploymentStatus `json:"status,omitempty" bun:"rel:has-one,join:id=application_deployment_id"`
+	Logs               []*ApplicationLogs           `json:"logs,omitempty" bun:"rel:has-many,join:id=application_deployment_id"`
+	ContainerID        string                       `json:"container_id" bun:"container_id"`
+	ContainerName      string                       `json:"container_name" bun:"container_name"`
+	ContainerImage     string                       `json:"container_image" bun:"container_image"`
+	ContainerStatus    string                       `json:"container_status" bun:"container_status"`
+	ImageS3Key         string                       `json:"image_s3_key" bun:"image_s3_key,default:''"`
+	ImageSize          int64                        `json:"image_size" bun:"image_size,default:0"`
+	ServerID           *uuid.UUID                   `json:"server_id,omitempty"            bun:"server_id,type:uuid"`
+	ParentDeploymentID *uuid.UUID                   `json:"parent_deployment_id,omitempty" bun:"parent_deployment_id,type:uuid"`
+	Children           []*ApplicationDeployment     `json:"children,omitempty"            bun:"rel:has-many,join:id=parent_deployment_id"`
 }
 
 type ApplicationStatus struct {
@@ -100,7 +100,7 @@ type ApplicationLogs struct {
 }
 
 type ApplicationServer struct {
-	bun.BaseModel `bun:"table:application_servers,alias:as" swaggerignore:"true"`
+	bun.BaseModel `bun:"table:application_servers,alias:aps" swaggerignore:"true"`
 	ID            uuid.UUID `json:"id"             bun:"id,pk,type:uuid"`
 	ApplicationID uuid.UUID `json:"application_id" bun:"application_id,notnull,type:uuid"`
 	ServerID      uuid.UUID `json:"server_id"      bun:"server_id,notnull,type:uuid"`


### PR DESCRIPTION
## Summary

- The `ApplicationServer` bun model used `alias:as`, but `AS` is a reserved SQL keyword in PostgreSQL. This caused every query against `application_servers` to fail with `SQLSTATE 42601: syntax error at or near "as"`, silently breaking all redeploy, rollback, and restart operations since the multi-server merge.
- Renamed the alias from `as` to `aps` and updated the two query references in `GetApplicationServers`.
- Added error logging to the redeploy, update, rollback, and restart task handlers (matching the existing create handler pattern) so task errors are no longer silently swallowed by taskq.

## Test plan

- [x] Reproduced locally: triggered redeploy, confirmed `SQLSTATE 42601` error in logs
- [x] Applied fix, triggered redeploy again, confirmed `redeploy: got 1 servers` and full build/deploy proceeded
- [ ] CI passes
- [ ] Merge, rebuild image, pull on production, verify redeploy works end-to-end