### PR TITLE
fix: remove agent configured gate from chat and workflows

### DIFF
--- a/view/app/api/config/route.ts
+++ b/view/app/api/config/route.ts
@@ -19,7 +19,6 @@ export async function GET() {
     webhookUrl: process.env.WEBHOOK_URL || derived.webhookUrl,
     port: process.env.NEXT_PUBLIC_PORT || '7443',
     passwordLoginEnabled: process.env.PASSWORD_LOGIN_ENABLED !== 'false',
-    agentConfigured: Boolean(process.env.AGENT_URL),
     agentUrl: process.env.AGENT_URL || '',
     githubAppSlug: process.env.GITHUB_APP_SLUG || '',
     selfHosted: process.env.SELF_HOSTED === 'true' || false,

--- a/view/app/apps/application/[id]/workflows/[workflowId]/page.tsx
+++ b/view/app/apps/application/[id]/workflows/[workflowId]/page.tsx
@@ -7,15 +7,13 @@ import { useWorkflowDetail } from '@/packages/hooks/workflows';
 import { ResourceGuard } from '@/packages/components/rbac';
 import PageLayout from '@/packages/layouts/page-layout';
 import { Skeleton } from '@nixopus/ui';
-import { AlertCircle, Sparkles } from 'lucide-react';
-import { useAgentConfigured } from '@/packages/hooks/shared/use-config';
+import { AlertCircle } from 'lucide-react';
 
 export default function WorkflowEditorPage() {
   const params = useParams();
   const applicationId = params.id as string;
   const workflowId = params.workflowId as string;
   const isNew = workflowId === 'new';
-  const agentConfigured = useAgentConfigured() === true;
   const { dynamicWorkflow, isLoading, error } = useWorkflowDetail({ workflowId, applicationId });
 
   const { nodes, edges, name, planningMessages, executionMessages, chatThreadId } = useMemo(() => {
@@ -44,37 +42,6 @@ export default function WorkflowEditorPage() {
       chatThreadId: undefined
     };
   }, [dynamicWorkflow]);
-
-  if (!agentConfigured) {
-    return (
-      <ResourceGuard
-        resource="deploy"
-        action="read"
-        loadingFallback={<Skeleton className="h-96" />}
-      >
-        <PageLayout maxWidth="7xl" padding="md" spacing="lg">
-          <div className="flex h-full w-full items-center justify-center py-24">
-            <div className="text-center max-w-md space-y-4 px-4">
-              <div className="flex items-center justify-center size-16 rounded-2xl bg-muted mx-auto">
-                <Sparkles className="size-8 text-muted-foreground" />
-              </div>
-              <h3 className="text-lg font-semibold">AI Agent Not Configured</h3>
-              <p className="text-sm text-muted-foreground">
-                The AI-powered deployment assistant is not enabled on this instance. To get access,
-                reach out to us and we&apos;ll help you get set up.
-              </p>
-              <a
-                href="mailto:support@nixopus.com"
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
-              >
-                Contact support@nixopus.com
-              </a>
-            </div>
-          </div>
-        </PageLayout>
-      </ResourceGuard>
-    );
-  }
 
   if (error && !isNew) {
     return (

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -88,10 +88,6 @@ export function ChatPage() {
   const { t } = useTranslation();
   const page = useChatPage();
 
-  if (!page.isAgentConfigured) {
-    return <AgentDisabledState />;
-  }
-
   return (
     <div className="flex h-full w-full overflow-hidden">
       <ThreadSidebar
@@ -1389,29 +1385,6 @@ function MessagesSkeleton() {
             <Skeleton className="h-4 w-2/3" />
           </div>
         </div>
-      </div>
-    </div>
-  );
-}
-
-function AgentDisabledState() {
-  return (
-    <div className="flex h-full w-full items-center justify-center">
-      <div className="text-center max-w-md space-y-4 px-4">
-        <div className="flex items-center justify-center size-16 rounded-2xl bg-muted mx-auto">
-          <Sparkles className="size-8 text-muted-foreground" />
-        </div>
-        <h3 className="text-lg font-semibold">AI Agent Not Configured</h3>
-        <p className="text-sm text-muted-foreground">
-          The AI-powered deployment assistant is not enabled on this instance. To get access, reach
-          out to us and we&apos;ll help you get set up.
-        </p>
-        <a
-          href="mailto:support@nixopus.com"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
-        >
-          Contact support@nixopus.com
-        </a>
       </div>
     </div>
   );

--- a/view/packages/components/workflows.tsx
+++ b/view/packages/components/workflows.tsx
@@ -1125,33 +1125,11 @@ export function WorkflowEditor({
 export function WorkflowsList({ applicationId }: { applicationId: string }) {
   const { t } = useTranslation();
   const router = useRouter();
-  const { workflows, isLoading, isDeleting, error, isConfigured, deleteWorkflow } = useWorkflows({
+  const { workflows, isLoading, isDeleting, error, deleteWorkflow } = useWorkflows({
     applicationId
   });
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name?: string } | null>(null);
   const { requireSudo } = useSudoMode();
-  if (!isConfigured) {
-    return (
-      <div className="flex h-full w-full items-center justify-center py-16">
-        <div className="text-center max-w-md space-y-4 px-4">
-          <div className="flex items-center justify-center size-16 rounded-2xl bg-muted mx-auto">
-            <Sparkles className="size-8 text-muted-foreground" />
-          </div>
-          <h3 className="text-lg font-semibold">AI Agent Not Configured</h3>
-          <p className="text-sm text-muted-foreground">
-            The AI-powered deployment assistant is not enabled on this instance. To get access,
-            reach out to us and we&apos;ll help you get set up.
-          </p>
-          <a
-            href="mailto:support@nixopus.com"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
-          >
-            Contact support@nixopus.com
-          </a>
-        </div>
-      </div>
-    );
-  }
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">

--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -11,7 +11,6 @@ import {
   declineAgentToolCall,
   type StreamChunk
 } from '@/packages/lib/agent-client';
-import { useAgentConfigured } from '@/packages/hooks/shared/use-config';
 import { type ChatContext, formatContextsForAgent } from './chat-context';
 
 export type MessagePart =
@@ -229,8 +228,6 @@ export function useAgentChat({
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
   const organizationId = activeOrg?.id;
 
-  const isAgentEnabled = useAgentConfigured() === true;
-
   const scrollToBottom = useCallback(() => {
     if (scrollRef.current) {
       const el = scrollRef.current;
@@ -245,7 +242,7 @@ export function useAgentChat({
   }, [messages, scrollToBottom]);
 
   useEffect(() => {
-    if (!threadId || !isAgentEnabled) {
+    if (!threadId) {
       setMessages([]);
       return;
     }
@@ -306,7 +303,7 @@ export function useAgentChat({
     return () => {
       cancelled = true;
     };
-  }, [threadId, resourceId, token, organizationId, isAgentEnabled, waitForThread]);
+  }, [threadId, resourceId, token, organizationId, waitForThread]);
 
   const extractUsageFromPayload = useCallback((payload: unknown): TokenUsage | null => {
     if (!payload || typeof payload !== 'object') return null;
@@ -587,7 +584,7 @@ export function useAgentChat({
 
   const streamResponse = useCallback(
     async (userContent: string) => {
-      if (!isAgentEnabled || !threadId) return;
+      if (!threadId) return;
 
       const headers = await getAuthHeaders(token ?? null, organizationId ?? null);
 
@@ -660,12 +657,12 @@ export function useAgentChat({
         );
       }
     },
-    [threadId, resourceId, token, organizationId, isAgentEnabled, contexts, model, handleChunk]
+    [threadId, resourceId, token, organizationId, contexts, model, handleChunk]
   );
 
   const handleApproveToolCall = useCallback(async () => {
     const pending = pendingToolApproval;
-    if (!pending || !isAgentEnabled) return;
+    if (!pending) return;
 
     setPendingToolApproval(null);
     pendingApprovalRef.current = false;
@@ -725,11 +722,11 @@ export function useAgentChat({
         );
       }
     }
-  }, [pendingToolApproval, isAgentEnabled, token, organizationId, messages, handleChunk]);
+  }, [pendingToolApproval, token, organizationId, messages, handleChunk]);
 
   const handleDeclineToolCall = useCallback(async () => {
     const pending = pendingToolApproval;
-    if (!pending || !isAgentEnabled) return;
+    if (!pending) return;
 
     setPendingToolApproval(null);
     pendingApprovalRef.current = false;
@@ -752,7 +749,7 @@ export function useAgentChat({
     } finally {
       setIsStreaming(false);
     }
-  }, [pendingToolApproval, isAgentEnabled, token, organizationId, messages]);
+  }, [pendingToolApproval, token, organizationId, messages]);
 
   const lastAutoApprovedRef = useRef<string | null>(null);
   useEffect(() => {
@@ -872,7 +869,6 @@ export function useAgentChat({
     setInputValue,
     isStreaming,
     isLoadingHistory,
-    isAgentConfigured: isAgentEnabled,
     pendingToolApproval,
     activeQuestion,
     omStatus,

--- a/view/packages/hooks/ai/use-chat-page.ts
+++ b/view/packages/hooks/ai/use-chat-page.ts
@@ -57,7 +57,6 @@ export interface UseChatPageReturn {
   selectedModel: string;
   setSelectedModel: (model: string) => void;
   contextProviders: ContextProviderData[];
-  isAgentConfigured: boolean;
   handleNewChat: () => void;
 
   threads: ChatThread[];
@@ -226,7 +225,6 @@ export function useChatPage(): UseChatPageReturn {
     selectedModel,
     setSelectedModel,
     contextProviders,
-    isAgentConfigured: chat.isAgentConfigured,
     handleNewChat,
 
     threads: threads.threads,

--- a/view/packages/hooks/ai/use-chat-threads.ts
+++ b/view/packages/hooks/ai/use-chat-threads.ts
@@ -4,7 +4,6 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAppSelector } from '@/redux/hooks';
 import { authClient } from '@/packages/lib/auth-client';
 import { createAgentClient, AGENT_ID } from '@/packages/lib/agent-client';
-import { useAgentConfigured } from '@/packages/hooks/shared/use-config';
 
 export interface ChatThread {
   id: string;
@@ -59,7 +58,6 @@ export function useChatThreads() {
   const authUser = useAppSelector((state) => state.auth.user);
   const resourceId = authUser?.id || 'default';
 
-  const agentConfigured = useAgentConfigured() === true;
   const headersRef = useRef<Record<string, string>>({});
   const threadCreationPromises = useRef<Map<string, Promise<void>>>(new Map());
 
@@ -70,11 +68,6 @@ export function useChatThreads() {
   }, [token, organizationId]);
 
   useEffect(() => {
-    if (!agentConfigured) {
-      setIsInitialized(true);
-      return;
-    }
-
     let cancelled = false;
 
     (async () => {
@@ -115,7 +108,7 @@ export function useChatThreads() {
     return () => {
       cancelled = true;
     };
-  }, [token, organizationId, resourceId, agentConfigured]);
+  }, [token, organizationId, resourceId]);
 
   const setActiveThreadId = useCallback((id: string | null) => {
     setActiveThreadIdState(id);
@@ -136,28 +129,26 @@ export function useChatThreads() {
       setThreads((prev) => [thread, ...prev]);
       setActiveThreadId(thread.id);
 
-      if (agentConfigured) {
-        const creationPromise = (async () => {
-          try {
-            const client = createAgentClient(headersRef.current);
-            await client.createMemoryThread({
-              threadId,
-              title: thread.title,
-              resourceId,
-              agentId: AGENT_ID
-            });
-          } catch {
-            // will be created automatically on first message
-          } finally {
-            threadCreationPromises.current.delete(threadId);
-          }
-        })();
-        threadCreationPromises.current.set(threadId, creationPromise);
-      }
+      const creationPromise = (async () => {
+        try {
+          const client = createAgentClient(headersRef.current);
+          await client.createMemoryThread({
+            threadId,
+            title: thread.title,
+            resourceId,
+            agentId: AGENT_ID
+          });
+        } catch {
+          // will be created automatically on first message
+        } finally {
+          threadCreationPromises.current.delete(threadId);
+        }
+      })();
+      threadCreationPromises.current.set(threadId, creationPromise);
 
       return thread;
     },
-    [resourceId, setActiveThreadId, agentConfigured]
+    [resourceId, setActiveThreadId]
   );
 
   const deleteThread = useCallback(
@@ -172,19 +163,17 @@ export function useChatThreads() {
         });
       }
 
-      if (agentConfigured) {
-        (async () => {
-          try {
-            const client = createAgentClient(headersRef.current);
-            const thread = client.getMemoryThread({ threadId: id, agentId: AGENT_ID });
-            await thread.delete();
-          } catch {
-            // ignore
-          }
-        })();
-      }
+      (async () => {
+        try {
+          const client = createAgentClient(headersRef.current);
+          const thread = client.getMemoryThread({ threadId: id, agentId: AGENT_ID });
+          await thread.delete();
+        } catch {
+          // ignore
+        }
+      })();
     },
-    [activeThreadId, setActiveThreadId, agentConfigured]
+    [activeThreadId, setActiveThreadId]
   );
 
   const updateThreadTitle = useCallback(
@@ -193,21 +182,19 @@ export function useChatThreads() {
         prev.map((t) => (t.id === id ? { ...t, title, updatedAt: new Date() } : t))
       );
 
-      if (agentConfigured) {
-        (async () => {
-          try {
-            const pending = threadCreationPromises.current.get(id);
-            if (pending) await pending;
-            const client = createAgentClient(headersRef.current);
-            const thread = client.getMemoryThread({ threadId: id, agentId: AGENT_ID });
-            await thread.update({ title, metadata: {}, resourceId });
-          } catch {
-            // ignore
-          }
-        })();
-      }
+      (async () => {
+        try {
+          const pending = threadCreationPromises.current.get(id);
+          if (pending) await pending;
+          const client = createAgentClient(headersRef.current);
+          const thread = client.getMemoryThread({ threadId: id, agentId: AGENT_ID });
+          await thread.update({ title, metadata: {}, resourceId });
+        } catch {
+          // ignore
+        }
+      })();
     },
-    [agentConfigured, resourceId]
+    [resourceId]
   );
 
   const touchThread = useCallback((id: string) => {

--- a/view/packages/hooks/ai/use-memory-search.ts
+++ b/view/packages/hooks/ai/use-memory-search.ts
@@ -4,7 +4,6 @@ import { useState, useCallback } from 'react';
 import { useAppSelector } from '@/redux/hooks';
 import { authClient } from '@/packages/lib/auth-client';
 import { createAgentClient, AGENT_ID } from '@/packages/lib/agent-client';
-import { useAgentConfigured } from '@/packages/hooks/shared/use-config';
 
 export interface MemorySearchResult {
   id: string;
@@ -38,7 +37,6 @@ export function useMemorySearch(resourceId: string | undefined) {
   const [results, setResults] = useState<MemorySearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [query, setQuery] = useState('');
-  const agentConfigured = useAgentConfigured() === true;
 
   const token = useAppSelector((state) => state.auth.token);
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
@@ -47,7 +45,7 @@ export function useMemorySearch(resourceId: string | undefined) {
   const search = useCallback(
     async (searchQuery: string) => {
       const q = searchQuery.trim();
-      if (!q || !resourceId || !agentConfigured) {
+      if (!q || !resourceId) {
         setResults([]);
         setQuery('');
         return;
@@ -73,7 +71,7 @@ export function useMemorySearch(resourceId: string | undefined) {
         setIsSearching(false);
       }
     },
-    [resourceId, token, organizationId, agentConfigured]
+    [resourceId, token, organizationId]
   );
 
   const clear = useCallback(() => {

--- a/view/packages/hooks/shared/use-config.ts
+++ b/view/packages/hooks/shared/use-config.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getPasswordLoginEnabled, getAgentConfigured } from '@/redux/conf';
+import { getPasswordLoginEnabled } from '@/redux/conf';
 
 export function usePasswordLoginEnabled() {
   const [passwordLoginEnabled, setPasswordLoginEnabled] = useState<boolean | null>(null);
@@ -9,14 +9,4 @@ export function usePasswordLoginEnabled() {
   }, []);
 
   return passwordLoginEnabled;
-}
-
-export function useAgentConfigured() {
-  const [agentConfigured, setAgentConfigured] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    getAgentConfigured().then(setAgentConfigured);
-  }, []);
-
-  return agentConfigured;
 }

--- a/view/packages/hooks/workflows/workflows.ts
+++ b/view/packages/hooks/workflows/workflows.ts
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useAppSelector } from '@/redux/hooks';
-import { useAgentConfigured } from '@/packages/hooks/shared/use-config';
 import {
   listDynamicWorkflows,
   deleteDynamicWorkflow,
@@ -28,17 +27,11 @@ export function useWorkflows({ applicationId }: UseWorkflowsOptions) {
   const [isLoading, setIsLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const agentConfigured = useAgentConfigured() === true;
 
   const token = useAppSelector((state) => state.auth.token);
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
 
   const fetchWorkflows = useCallback(async () => {
-    if (!agentConfigured) {
-      setIsLoading(false);
-      return;
-    }
-
     try {
       setIsLoading(true);
       setError(null);
@@ -62,7 +55,7 @@ export function useWorkflows({ applicationId }: UseWorkflowsOptions) {
     } finally {
       setIsLoading(false);
     }
-  }, [applicationId, token, activeOrg?.id, agentConfigured]);
+  }, [applicationId, token, activeOrg?.id]);
 
   useEffect(() => {
     fetchWorkflows();
@@ -90,8 +83,7 @@ export function useWorkflows({ applicationId }: UseWorkflowsOptions) {
     isDeleting,
     error,
     refetch: fetchWorkflows,
-    deleteWorkflow,
-    isConfigured: agentConfigured
+    deleteWorkflow
   };
 }
 
@@ -151,13 +143,12 @@ export function useWorkflowDetail({ workflowId, applicationId }: UseWorkflowDeta
   const [dynamicWorkflow, setDynamicWorkflow] = useState<DynamicWorkflowDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const agentConfigured = useAgentConfigured() === true;
 
   const token = useAppSelector((state) => state.auth.token);
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
 
   const fetchDetail = useCallback(async () => {
-    if (!agentConfigured || workflowId === 'new') {
+    if (workflowId === 'new') {
       setIsLoading(false);
       return;
     }
@@ -181,7 +172,7 @@ export function useWorkflowDetail({ workflowId, applicationId }: UseWorkflowDeta
     } finally {
       setIsLoading(false);
     }
-  }, [workflowId, applicationId, token, activeOrg?.id, agentConfigured]);
+  }, [workflowId, applicationId, token, activeOrg?.id]);
 
   useEffect(() => {
     fetchDetail();

--- a/view/redux/conf.ts
+++ b/view/redux/conf.ts
@@ -81,11 +81,6 @@ export async function getPasswordLoginEnabled() {
   return passwordLoginEnabled;
 }
 
-export async function getAgentConfigured() {
-  const { agentConfigured } = await fetchConfig();
-  return agentConfigured;
-}
-
 export async function getGithubAppSlug() {
   const { githubAppSlug } = await fetchConfig();
   return githubAppSlug as string;


### PR DESCRIPTION
## Summary
- Removes the `isAgentConfigured` / `agentConfigured` gate from the AI chat feature and workflows UI, making them always available regardless of whether `AGENT_URL` is set
- Deletes the `useAgentConfigured` hook, `getAgentConfigured` helper, and all `AgentDisabledState` screens
- Cleans up the `/api/config` route by removing the now-unused `agentConfigured` field

## Test plan
- [ ] Verify the AI chat page (`/chats`) renders without `AGENT_URL` configured
- [ ] Verify workflows page loads without the "AI Agent Not Configured" disabled state
- [ ] Verify chat threads, memory search, and agent streaming still work when `AGENT_URL` is configured
- [ ] Verify no TypeScript build errors (`bun run build` in `view/`)