### PR TITLE
fix: replace crypto.randomUUID with uuid package for HTTP compatibility

### DIFF
--- a/view/packages/components/github-connector.tsx
+++ b/view/packages/components/github-connector.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@nixopus/ui';
 import { Alert, AlertDescription } from '@nixopus/ui';
 import { DialogWrapper, type DialogAction } from '@nixopus/ui';
 import { DeleteDialog } from '@/components/ui/delete-dialog';
+import { v4 as uuid } from 'uuid';
 import { useSudoMode } from '@/packages/hooks/security/use-sudo-mode';
 import {
   Github,
@@ -98,7 +99,7 @@ const GithubInstaller: React.FC<GithubInstallProps> = ({
       ? `/organizations/${organization}/settings/apps/${appSlug}/installations/new`
       : `/apps/${appSlug}/installations/new`;
 
-    const stateParam = encodeURIComponent(crypto.randomUUID());
+    const stateParam = encodeURIComponent(uuid());
 
     const redirectUrl = `${baseUrl}${installPath}?state=${stateParam}&redirect_uri=${encodeURIComponent(callbackUrl)}`;
 

--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -12,6 +12,7 @@ import {
   type StreamChunk
 } from '@/packages/lib/agent-client';
 import { type ChatContext, formatContextsForAgent } from './chat-context';
+import { v4 as uuid } from 'uuid';
 
 export type MessagePart =
   | { type: 'text'; content: string }
@@ -593,7 +594,7 @@ export function useAgentChat({
       const runIdRef = { current: '' };
       firstTextDeltaTimeRef.current = null;
 
-      const assistantMessageId = crypto.randomUUID();
+      const assistantMessageId = uuid();
       setMessages((prev) => [
         ...prev,
         { id: assistantMessageId, role: 'assistant', content: '', timestamp: new Date(), parts: [] }
@@ -771,7 +772,7 @@ export function useAgentChat({
 
       const content = inputValue.trim();
       const userMessage: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         role: 'user',
         content,
         timestamp: new Date(),
@@ -807,7 +808,7 @@ export function useAgentChat({
       if (!isStreaming && threadId) {
         setInputValue('');
         const userMessage: ChatMessage = {
-          id: crypto.randomUUID(),
+          id: uuid(),
           role: 'user',
           content: text,
           timestamp: new Date(),
@@ -842,7 +843,7 @@ export function useAgentChat({
       const content = `[user_response]\n${formatted}`;
 
       const userMessage: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         role: 'user',
         content,
         timestamp: new Date()

--- a/view/packages/hooks/ai/use-chat-threads.ts
+++ b/view/packages/hooks/ai/use-chat-threads.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAppSelector } from '@/redux/hooks';
 import { authClient } from '@/packages/lib/auth-client';
 import { createAgentClient, AGENT_ID } from '@/packages/lib/agent-client';
+import { v4 as uuid } from 'uuid';
 
 export interface ChatThread {
   id: string;
@@ -117,7 +118,7 @@ export function useChatThreads() {
 
   const createThread = useCallback(
     (title?: string): ChatThread => {
-      const threadId = crypto.randomUUID();
+      const threadId = uuid();
       const now = new Date();
       const thread: ChatThread = {
         id: threadId,

--- a/view/packages/hooks/workflows/workflow-editor.ts
+++ b/view/packages/hooks/workflows/workflow-editor.ts
@@ -13,6 +13,7 @@ import {
 import { WORKFLOW_STREAMING_MESSAGES } from '@/packages/lib/workflow-utils';
 import { authClient } from '@/packages/lib/auth-client';
 import { createAgentClient } from '@/packages/lib/agent-client';
+import { v4 as uuid } from 'uuid';
 import type {
   WorkflowNode,
   WorkflowEdge,
@@ -214,7 +215,7 @@ export function useWorkflowPlanner({
   const token = useAppSelector((state) => state.auth.token);
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
   const orgId = organizationId ?? activeOrg?.id ?? null;
-  const [draftSessionId] = useState(() => (workflowId === 'new' ? crypto.randomUUID() : null));
+  const [draftSessionId] = useState(() => (workflowId === 'new' ? uuid() : null));
   const resourceId = orgId && applicationId ? resourceIdFor(orgId, applicationId) : undefined;
   const threadId = applicationId
     ? resolveThreadId(workflowId, applicationId, chatThreadId, draftSessionId)
@@ -321,7 +322,7 @@ export function useWorkflowPlanner({
                   ? new Date(String(createdAtRaw))
                   : new Date();
             msgs.push({
-              id: msg.id ?? crypto.randomUUID(),
+              id: msg.id ?? uuid(),
               role,
               content: text,
               timestamp: createdAt,
@@ -372,13 +373,13 @@ export function useWorkflowPlanner({
       if (!content.trim() || isStreaming) return;
 
       const userMsg: PlannerMessage = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         role: 'user',
         content: content.trim(),
         timestamp: new Date()
       };
 
-      const assistantId = crypto.randomUUID();
+      const assistantId = uuid();
       setMessages((prev) => [
         ...prev,
         userMsg,


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` is only available in secure contexts (HTTPS or localhost). Self-hosted instances accessed over plain HTTP (`http://<ip>`) crash with `TypeError: crypto.randomUUID is not a function` when creating chat threads or workflows.
- Replaces all 10 `crypto.randomUUID()` calls with `v4()` from the already-installed `uuid` package, which uses `crypto.getRandomValues()` internally and works in all contexts.

## Test plan
- [ ] Access the instance over plain HTTP and click "create chat" -- should no longer crash
- [ ] Verify chat thread creation, message sending, and workflow editing all generate valid UUIDs
- [ ] Verify GitHub App installation flow still generates a valid state parameter