### PR TITLE
fix: pass AGENT_URL to view container in agent compose overlay

### DIFF
--- a/installer/selfhost/docker-compose.agent.yml
+++ b/installer/selfhost/docker-compose.agent.yml
@@ -1,4 +1,8 @@
 services:
+  nixopus-view:
+    environment:
+      AGENT_URL: "http://nixopus-agent:4090"
+
   nixopus-agent:
     image: ${NIXOPUS_AGENT_IMAGE:-ghcr.io/nixopus/agent:latest}
     container_name: nixopus-agent


### PR DESCRIPTION
## Summary
- The Next.js agent proxy (`/api/agent/[...path]`) returns 503 with "Agent URL not configured" because `AGENT_URL` is never set in the self-hosted `nixopus-view` container
- Adds `AGENT_URL: "http://nixopus-agent:4090"` to the view service in `docker-compose.agent.yml`, so it's automatically injected when the agent overlay is included

## Test plan
- [ ] Deploy with agent enabled (`docker compose -f docker-compose.yml -f docker-compose.agent.yml up`) and verify AI chat requests no longer return 503
- [ ] Deploy without agent overlay and verify the proxy still returns 503 gracefully (expected behavior)