### PR TITLE
feat(ai-chat): hide model selection and omit model param when self-hosted [NIX-246]

### DIFF
--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -139,6 +139,7 @@ export function ChatPage() {
               onAutoRunToolsChange={page.setAutoRunTools}
               selectedModel={page.selectedModel}
               onModelChange={page.setSelectedModel}
+              isSelfHosted={page.isSelfHosted}
               onAddContext={page.addContext}
               onRemoveContext={page.removeContext}
               onSubmit={page.handleSubmit}
@@ -1005,6 +1006,7 @@ interface ChatInputProps {
   onAutoRunToolsChange: (value: boolean) => void;
   selectedModel: string;
   onModelChange: (model: string) => void;
+  isSelfHosted: boolean;
   onAddContext: (ctx: ChatContext) => void;
   onRemoveContext: (ctx: ChatContext) => void;
   onSubmit: (e?: React.FormEvent) => void;
@@ -1023,6 +1025,7 @@ function ChatInput({
   onAutoRunToolsChange,
   selectedModel,
   onModelChange,
+  isSelfHosted,
   onAddContext,
   onRemoveContext,
   onSubmit,
@@ -1062,38 +1065,40 @@ function ChatInput({
               </span>
             );
           })}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted border border-border/50 transition-colors"
-              >
-                <Zap className="size-3" />
-                <span>{currentModelLabel}</span>
-                <ChevronDown className="size-3 opacity-50" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-52">
-              {AVAILABLE_MODELS.map((model) => (
-                <DropdownMenuItem
-                  key={model.id}
-                  onClick={() => onModelChange(model.id)}
-                  className={cn(
-                    'flex items-center gap-2',
-                    selectedModel === model.id && 'bg-primary/10'
-                  )}
+          {!isSelfHosted && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted border border-border/50 transition-colors"
                 >
-                  <Check
+                  <Zap className="size-3" />
+                  <span>{currentModelLabel}</span>
+                  <ChevronDown className="size-3 opacity-50" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-52">
+                {AVAILABLE_MODELS.map((model) => (
+                  <DropdownMenuItem
+                    key={model.id}
+                    onClick={() => onModelChange(model.id)}
                     className={cn(
-                      'size-3.5 shrink-0',
-                      selectedModel === model.id ? 'opacity-100 text-primary' : 'opacity-0'
+                      'flex items-center gap-2',
+                      selectedModel === model.id && 'bg-primary/10'
                     )}
-                  />
-                  <span>{model.label}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  >
+                    <Check
+                      className={cn(
+                        'size-3.5 shrink-0',
+                        selectedModel === model.id ? 'opacity-100 text-primary' : 'opacity-0'
+                      )}
+                    />
+                    <span>{model.label}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
           <div className="flex items-center gap-1 rounded-md border border-border/50 p-0.5">
             <button
               type="button"

--- a/view/packages/hooks/ai/use-chat-page.ts
+++ b/view/packages/hooks/ai/use-chat-page.ts
@@ -18,6 +18,7 @@ import {
   useChatContextProviders
 } from './chat-context';
 import { useMemorySearch, type MemorySearchResult } from './use-memory-search';
+import { getSelfHosted } from '@/redux/conf';
 
 function useLocalStorageState(key: string, defaultValue: boolean) {
   const [value, setValue] = useState(() => {
@@ -56,6 +57,7 @@ export interface UseChatPageReturn {
   setAutoRunTools: (value: boolean) => void;
   selectedModel: string;
   setSelectedModel: (model: string) => void;
+  isSelfHosted: boolean;
   contextProviders: ContextProviderData[];
   handleNewChat: () => void;
 
@@ -107,6 +109,11 @@ export function useChatPage(): UseChatPageReturn {
   });
   const [pendingDeployPrompt, setPendingDeployPrompt] = useState<string | null>(null);
   const repoParamsHandledRef = useRef(false);
+  const [isSelfHosted, setIsSelfHosted] = useState(false);
+
+  useEffect(() => {
+    getSelfHosted().then(setIsSelfHosted);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem('chat_selected_model', selectedModel);
@@ -119,7 +126,7 @@ export function useChatPage(): UseChatPageReturn {
     resourceId: threads.resourceId,
     contexts: selectedContexts,
     autoRunTools,
-    model: selectedModel,
+    model: isSelfHosted ? undefined : selectedModel,
     waitForThread: threads.waitForThread,
     onFirstMessage: (content) => {
       if (threads.activeThreadId) {
@@ -224,6 +231,7 @@ export function useChatPage(): UseChatPageReturn {
     setAutoRunTools,
     selectedModel,
     setSelectedModel,
+    isSelfHosted,
     contextProviders,
     handleNewChat,
 


### PR DESCRIPTION
## Summary

Closes [NIX-246](https://linear.app/nixopus/issue/NIX-246/hide-model-selection-and-omit-model-param-when-self-hosted)

When `SELF_HOSTED=true`:
- The model selection dropdown is hidden in the AI chat input
- No `model` query param is sent to the stream endpoint, letting the locally hosted model (e.g. Ollama) decide

## Changes

- **`view/packages/components/ai-chat.tsx`** — Wrap model selection `DropdownMenu` in `{!isSelfHosted && (...)}`. Added `isSelfHosted` prop to `ChatInputProps`.
- **`view/packages/hooks/ai/use-chat-page.ts`** — Load `isSelfHosted` via `getSelfHosted()` on mount. Pass `model: isSelfHosted ? undefined : selectedModel` to `useAgentChat`.

## Test plan

- [ ] With `SELF_HOSTED=false` (default): model dropdown is visible and model param is sent to stream endpoint
- [ ] With `SELF_HOSTED=true`: model dropdown is hidden and no model param is sent to the stream endpoint