### PR TITLE
feat(server): enrich server list API with allocated resource totals

### DIFF
--- a/api/internal/features/server/storage/init.go
+++ b/api/internal/features/server/storage/init.go
@@ -152,9 +152,6 @@ func (s *ServerStorage) ListServersByOrganizationID(orgID uuid.UUID, params type
 		Where("ssh_key_id IN (?)", bun.In(sshKeyIDs)).
 		Where("organization_id = ?", orgID)
 
-	// Note: Status filter is now applied via user.provision_status join above
-	// No need to filter provision details by status here
-
 	err = provisionQuery.Scan(s.Ctx)
 	if err != nil {
 		return nil, 0, err
@@ -168,7 +165,34 @@ func (s *ServerStorage) ListServersByOrganizationID(orgID uuid.UUID, params type
 		}
 	}
 
-	// Combine SSH keys with provision details
+	// Aggregate resource totals (vcpu, ram, disk) per SSH key
+	type resourceAggregate struct {
+		SSHKeyID    uuid.UUID `bun:"ssh_key_id"`
+		TotalVcpu   int       `bun:"total_vcpu"`
+		TotalRamMB  int       `bun:"total_ram_mb"`
+		TotalDiskGB int       `bun:"total_disk_gb"`
+	}
+	var aggregates []resourceAggregate
+	err = s.getDB().NewSelect().
+		TableExpr("user_provision_details").
+		ColumnExpr("ssh_key_id").
+		ColumnExpr("COALESCE(SUM(vcpu_count), 0) AS total_vcpu").
+		ColumnExpr("COALESCE(SUM(memory_mb), 0) AS total_ram_mb").
+		ColumnExpr("COALESCE(SUM(disk_size_gb), 0) AS total_disk_gb").
+		Where("ssh_key_id IN (?)", bun.In(sshKeyIDs)).
+		Where("organization_id = ?", orgID).
+		GroupExpr("ssh_key_id").
+		Scan(s.Ctx, &aggregates)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	aggregateMap := make(map[uuid.UUID]resourceAggregate, len(aggregates))
+	for _, agg := range aggregates {
+		aggregateMap[agg.SSHKeyID] = agg
+	}
+
+	// Combine SSH keys with provision details and resource totals
 	servers := make([]types.ServerResponse, 0, len(sshKeys))
 	for _, key := range sshKeys {
 		server := types.ServerResponse{
@@ -176,6 +200,11 @@ func (s *ServerStorage) ListServersByOrganizationID(orgID uuid.UUID, params type
 		}
 		if provision, ok := provisionMap[key.ID]; ok {
 			server.Provision = provision
+		}
+		if agg, ok := aggregateMap[key.ID]; ok {
+			server.TotalVcpu = agg.TotalVcpu
+			server.TotalRamMB = agg.TotalRamMB
+			server.TotalDiskGB = agg.TotalDiskGB
 		}
 		servers = append(servers, server)
 	}

--- a/api/internal/features/server/types/init.go
+++ b/api/internal/features/server/types/init.go
@@ -23,9 +23,13 @@ type ServerListParams struct {
 }
 
 // ServerResponse represents a server (SSH key) with optional provision details
+// and aggregated resource allocation from all provisions on this server.
 type ServerResponse struct {
 	shared_types.SSHKey
-	Provision *shared_types.UserProvisionDetails `json:"provision,omitempty"`
+	Provision   *shared_types.UserProvisionDetails `json:"provision,omitempty"`
+	TotalVcpu   int                                `json:"total_vcpu"`
+	TotalRamMB  int                                `json:"total_ram_mb"`
+	TotalDiskGB int                                `json:"total_disk_gb"`
 }
 
 // ListServersResponseData contains the data for list servers response

--- a/api/internal/types/user_provision_details.go
+++ b/api/internal/types/user_provision_details.go
@@ -35,6 +35,9 @@ type UserProvisionDetails struct {
 	SSHKeyID         *uuid.UUID     `json:"ssh_key_id,omitempty" bun:"ssh_key_id,type:uuid"`
 	Subdomain        *string        `json:"subdomain,omitempty" bun:"subdomain"`
 	Domain           *string        `json:"domain,omitempty" bun:"domain"`
+	VcpuCount        int            `json:"vcpu_count" bun:"vcpu_count"`
+	MemoryMB         int            `json:"memory_mb" bun:"memory_mb"`
+	DiskSizeGB       int            `json:"disk_size_gb" bun:"disk_size_gb"`
 	Step             *ProvisionStep `json:"step,omitempty" bun:"step,type:provision_step"`
 	Error            *string        `json:"error,omitempty" bun:"error,type:text"`
 	CreatedAt        time.Time      `json:"created_at" bun:"created_at,notnull,default:now()"`


### PR DESCRIPTION
## Summary
- Adds `vcpu_count`, `memory_mb`, and `disk_size_gb` fields to the shared `UserProvisionDetails` Go model to expose existing DB columns
- Enriches the server list API response with `total_vcpu`, `total_ram_mb`, and `total_disk_gb` per server, aggregated from all `user_provision_details` rows linked by `ssh_key_id`
- No migration needed — the columns already exist in the database

## Test plan
- [ ] Call `GET /api/v1/servers` and verify each server object includes `total_vcpu`, `total_ram_mb`, `total_disk_gb`
- [ ] Verify servers with no provisions return `0` for all three resource fields
- [ ] Verify servers with multiple provisions return correctly summed totals