### PR TITLE
fix(domain): hard delete custom domains to prevent duplicate key errors

### DIFF
--- a/api/internal/features/domain/storage/custom_domains.go
+++ b/api/internal/features/domain/storage/custom_domains.go
@@ -86,13 +86,9 @@ func (s *DomainStorage) UpdateCustomDomainVerification(id uuid.UUID, status stri
 }
 
 func (s *DomainStorage) DeleteCustomDomain(id uuid.UUID) error {
-	now := time.Now()
-	result, err := s.getDB().NewUpdate().
+	result, err := s.getDB().NewDelete().
 		Model((*shared_types.Domain)(nil)).
-		Set("deleted_at = ?", now).
-		Set("updated_at = ?", now).
 		Where("id = ?", id).
-		Where("deleted_at IS NULL").
 		Exec(s.Ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Changed `DeleteCustomDomain` from soft delete (`UPDATE ... SET deleted_at`) to hard delete (`DELETE`) so the row is fully removed from the `domains` table.
- Prevents duplicate key constraint violations when re-adding a previously deleted domain name.

## Test plan
- [ ] Delete a custom domain and verify the row is removed from the `domains` table
- [ ] Re-add the same domain name and confirm no duplicate key error occurs