### PR TITLE
feat(view): add guards, globalComponents, and noLayoutPaths plugin hooks

### DIFF
--- a/view/app/client-layout.tsx
+++ b/view/app/client-layout.tsx
@@ -5,7 +5,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from '@/redux/store';
 import { Toaster } from '@nixopus/ui';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, Suspense } from 'react';
 import { initializeAuth } from '@/redux/features/users/authSlice';
 import { preloadBaseUrl } from '@/redux/base-query';
 import { usePathname, useRouter } from 'next/navigation';
@@ -20,12 +20,36 @@ import { CSPostHogProvider } from '@/packages/components/analytics/posthog-provi
 import Image from 'next/image';
 import { useTheme } from 'next-themes';
 import { Skeleton } from '@nixopus/ui';
-import { getPluginProviders } from '@/plugins/registry';
+import {
+  getPluginProviders,
+  getPluginGuards,
+  getPluginGlobalComponents,
+  getPluginNoLayoutPaths
+} from '@/plugins/registry';
+import type { ReactElement } from 'react';
 
 function PluginProviderWrapper({ children }: { children: React.ReactNode }) {
   const Providers = getPluginProviders();
   if (!Providers) return <>{children}</>;
   return <Providers>{children}</Providers>;
+}
+
+function PluginGuardWrapper({ children }: { children: React.ReactNode }) {
+  const guards = getPluginGuards();
+  if (guards.length === 0) return <>{children}</>;
+  return guards.reduceRight((acc, Guard) => <Guard>{acc}</Guard>, children) as ReactElement;
+}
+
+function PluginGlobalComponents() {
+  const components = getPluginGlobalComponents();
+  if (components.length === 0) return null;
+  return (
+    <>
+      {components.map((Component, i) => (
+        <Component key={i} />
+      ))}
+    </>
+  );
 }
 
 const AppLoadingScreen = () => {
@@ -198,6 +222,12 @@ const ChildrenWrapper = ({ children }: { children: React.ReactNode }) => {
     }
   }, [pathname, isLoading, isInitialized, router, isPublicRoute, isAuthenticated]);
 
+  const noLayoutPaths = useMemo(() => getPluginNoLayoutPaths(), []);
+  const isNoLayoutRoute = useMemo(
+    () => noLayoutPaths.some((route) => pathname === route || pathname.startsWith(route + '/')),
+    [pathname, noLayoutPaths]
+  );
+
   return (
     <>
       <ThemeProvider
@@ -219,13 +249,24 @@ const ChildrenWrapper = ({ children }: { children: React.ReactNode }) => {
               {isPublicRoute ? (
                 <>{children}</>
               ) : (
-                <SystemStatsProvider>
-                  <SudoModeProvider>
-                    <AppLayout>
-                      <PluginProviderWrapper>{children}</PluginProviderWrapper>
-                    </AppLayout>
-                  </SudoModeProvider>
-                </SystemStatsProvider>
+                <>
+                  <PluginGlobalComponents />
+                  <Suspense fallback={<AppShellSkeleton />}>
+                    <PluginGuardWrapper>
+                      <SystemStatsProvider>
+                        <SudoModeProvider>
+                          {isNoLayoutRoute ? (
+                            <PluginProviderWrapper>{children}</PluginProviderWrapper>
+                          ) : (
+                            <AppLayout>
+                              <PluginProviderWrapper>{children}</PluginProviderWrapper>
+                            </AppLayout>
+                          )}
+                        </SudoModeProvider>
+                      </SystemStatsProvider>
+                    </PluginGuardWrapper>
+                  </Suspense>
+                </>
               )}
             </FeatureFlagsProvider>
           </WebSocketProvider>

--- a/view/plugins/registry.tsx
+++ b/view/plugins/registry.tsx
@@ -26,6 +26,9 @@ export interface PluginManifest {
   providers?: ComponentType<{ children: ReactNode }>;
   banners?: ComponentType[];
   captcha?: ComponentType<CaptchaComponentProps>;
+  guards?: ComponentType<{ children: ReactNode }>[];
+  globalComponents?: ComponentType[];
+  noLayoutPaths?: string[];
 }
 
 // Plugin manifests are loaded from a generated file that the route
@@ -72,4 +75,16 @@ export function getPluginCaptcha(): ComponentType<CaptchaComponentProps> | null 
     if (p.captcha) return p.captcha;
   }
   return null;
+}
+
+export function getPluginGuards(): ComponentType<{ children: ReactNode }>[] {
+  return plugins.flatMap((p) => p.guards ?? []);
+}
+
+export function getPluginGlobalComponents(): ComponentType[] {
+  return plugins.flatMap((p) => p.globalComponents ?? []);
+}
+
+export function getPluginNoLayoutPaths(): string[] {
+  return plugins.flatMap((p) => p.noLayoutPaths ?? []);
 }


### PR DESCRIPTION
## Summary

- Extends `PluginManifest` with three new extension points: `guards` (components wrapping authenticated content), `globalComponents` (renderless components mounted globally in the authenticated section), and `noLayoutPaths` (routes rendered without sidebar/AppLayout)
- Adds `PluginGuardWrapper`, `PluginGlobalComponents`, and conditional layout rendering to `client-layout.tsx`
- Enables plugins to register onboarding guards, auto-provisioning checkers, and fullscreen routes without modifying core code

## Test plan

- [ ] Verify app loads correctly without any plugins installed (empty guards/globalComponents arrays)
- [ ] Verify plugin-provided guards wrap authenticated content correctly
- [ ] Verify plugin-provided global components mount in the authenticated section
- [ ] Verify paths listed in `noLayoutPaths` render without sidebar/AppLayout
- [ ] Verify existing routes continue to render with sidebar as before