### PR TITLE
fix(view): clear localStorage and sessionStorage on logout

### DIFF
--- a/view/redux/features/users/authSlice.ts
+++ b/view/redux/features/users/authSlice.ts
@@ -81,10 +81,15 @@ export const initializeAuth = createAsyncThunk<
 export const logoutUser = createAsyncThunk('auth/logoutUser', async (_, { dispatch }) => {
   try {
     await authClient.signOut();
-    dispatch(logout());
   } catch (error) {
     console.error('Better Auth logout failed:', error);
+  } finally {
+    if (typeof window !== 'undefined') {
+      localStorage.clear();
+      sessionStorage.clear();
+    }
     dispatch(logout());
+    dispatch({ type: 'RESET_STATE' });
   }
 });
 


### PR DESCRIPTION
## Summary

- Clears `localStorage` and `sessionStorage` on logout to prevent stale state from persisting across user sessions
- Dispatches `RESET_STATE` to fully reset Redux store on logout
- Moves cleanup into a `finally` block so it runs even if sign-out fails

## Test plan

- [ ] Log in, then log out — verify localStorage and sessionStorage are cleared
- [ ] Log out and log in as a different user — verify no stale data from the previous session