### PR TITLE
fix(api): add missing user cache invalidation after onboarding and provisioning

### DIFF
--- a/api/internal/cache/cache.go
+++ b/api/internal/cache/cache.go
@@ -162,6 +162,15 @@ func (c *Cache) InvalidateUser(ctx context.Context, email string) error {
 	return c.client.Del(ctx, key).Err()
 }
 
+// InvalidateUserByID removes a cached user record keyed by UUID.
+// This must be called whenever user fields (name, avatar, is_onboarded,
+// provision_status, etc.) are modified so the auth middleware re-reads
+// the row from the database on the next request.
+func (c *Cache) InvalidateUserByID(ctx context.Context, userID string) error {
+	key := UserByIDCacheKeyPrefix + userID
+	return c.client.Del(ctx, key).Err()
+}
+
 func (c *Cache) InvalidateOrgMembership(ctx context.Context, userID, orgID string) error {
 	key := OrgMembershipCacheKeyPrefix + userID + ":" + orgID
 	return c.client.Del(ctx, key).Err()

--- a/api/internal/features/trail/controller/provision.go
+++ b/api/internal/features/trail/controller/provision.go
@@ -61,6 +61,10 @@ func (c *TrailController) ProvisionTrail(f fuego.ContextWithBody[types.Provision
 		}
 	}
 
+	if c.cache != nil {
+		_ = c.cache.InvalidateUserByID(c.ctx, user.ID.String())
+	}
+
 	return &types.ProvisionTrailResponse{
 		Status:  "success",
 		Message: "Trail provisioning started",

--- a/api/internal/features/user/controller/avatar.go
+++ b/api/internal/features/user/controller/avatar.go
@@ -45,7 +45,7 @@ func (u *UserController) UpdateAvatar(s fuego.ContextWithBody[types.UpdateAvatar
 		}
 	}
 
-	u.cache.InvalidateUser(u.ctx, user.ID.String())
+	u.cache.InvalidateUserByID(u.ctx, user.ID.String())
 
 	return &types.MessageResponse{
 		Status:  "success",

--- a/api/internal/features/user/controller/mark_onboarding_complete.go
+++ b/api/internal/features/user/controller/mark_onboarding_complete.go
@@ -32,6 +32,10 @@ func (u *UserController) MarkOnboardingComplete(s fuego.ContextNoBody) (*types.M
 		}
 	}
 
+	if u.cache != nil {
+		_ = u.cache.InvalidateUserByID(u.ctx, user.ID.String())
+	}
+
 	return &types.MarkOnboardingCompleteResponse{
 		Data: types.IsOnboardedResponseData{
 			IsOnboarded: true,

--- a/api/internal/features/user/controller/update_username.go
+++ b/api/internal/features/user/controller/update_username.go
@@ -46,7 +46,7 @@ func (u *UserController) UpdateUserName(s fuego.ContextWithBody[types.UpdateUser
 		}
 	}
 
-	u.cache.InvalidateUser(u.ctx, user.ID.String())
+	u.cache.InvalidateUserByID(u.ctx, user.ID.String())
 
 	return &types.UpdateUsernameResponse{
 		Status:  "success",


### PR DESCRIPTION
## Summary

- **Added `InvalidateUserByID`** to the `Cache` struct — the auth middleware caches users under `user_id:<uuid>` but no function existed to invalidate that key, so user mutations were silently leaving stale data in Redis for up to 10 minutes.
- **Fixed stale `is_onboarded` after onboarding** — `MarkOnboardingComplete` now invalidates the user cache so subsequent requests see the updated flag immediately.
- **Fixed stale `provision_status` after trail provisioning** — `ProvisionTrail` now invalidates the user cache after updating the user's provision status.
- **Fixed broken invalidation in `UpdateUserName` and `UpdateAvatar`** — both were calling `InvalidateUser(email)` with a UUID argument, which deleted key `user:<uuid>` (never set) instead of `user_id:<uuid>` (the actual cached key). Switched to `InvalidateUserByID`.

## Root Cause

The `AuthMiddleware` caches the full `User` struct (including `is_onboarded`, `provision_status`, `name`, `avatar`) via `SetUserByID` under Redis key `user_id:<uuid>` with a 10-minute TTL. Two issues:

1. No `InvalidateUserByID` function existed — the only invalidation function `InvalidateUser(email)` operates on key `user:<email>`, a different key namespace entirely.
2. `MarkOnboardingComplete` and `ProvisionTrail` had zero cache invalidation after mutating user fields.

## Test plan

- [ ] Mark onboarding complete and verify subsequent requests immediately reflect `is_onboarded: true` (no stale cache)
- [ ] Provision a trail and verify `provision_status` updates immediately in the user object
- [ ] Update username and verify the change is reflected on the next request without waiting for cache expiry
- [ ] Update avatar and verify same immediate reflection
- [ ] Verify Redis keys: after invalidation, `GET user_id:<uuid>` should return nil