### PR TITLE
fix(view): persist chat streaming across navigation and fix tool approval

### DIFF
--- a/view/packages/hooks/ai/chat-stream-store.ts
+++ b/view/packages/hooks/ai/chat-stream-store.ts
@@ -1,0 +1,541 @@
+import type { StreamChunk } from '@/packages/lib/agent-client';
+import type { ChatMessage, PendingToolApproval, OmStatus, TokenUsage } from './use-agent-chat';
+
+export interface SessionSnapshot {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  pendingToolApproval: PendingToolApproval | null;
+  omStatus: OmStatus | null;
+}
+
+interface SessionInternal {
+  snapshot: SessionSnapshot;
+  abortController: AbortController | null;
+  needsStepSeparator: boolean;
+  needsNewTextPart: boolean;
+  firstTextDeltaTime: number | null;
+  pendingApproval: boolean;
+  omStatusCache: OmStatus | null;
+  assistantMessageId: string | null;
+  runId: string;
+}
+
+type Listener = () => void;
+
+const EMPTY_SNAPSHOT: SessionSnapshot = Object.freeze({
+  messages: [],
+  isStreaming: false,
+  pendingToolApproval: null,
+  omStatus: null
+});
+
+function extractUsageFromPayload(payload: unknown): TokenUsage | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+
+  const output = p.output as Record<string, unknown> | undefined;
+  const outputUsage = output?.usage as Record<string, unknown> | undefined;
+
+  const metadata = p.metadata as Record<string, unknown> | undefined;
+  const providerMeta = metadata?.providerMetadata as Record<string, unknown> | undefined;
+  const orMeta = providerMeta?.openrouter as Record<string, unknown> | undefined;
+  const orUsage = orMeta?.usage as Record<string, unknown> | undefined;
+
+  const usage = outputUsage ?? orUsage;
+  if (!usage) return null;
+
+  const prompt = (usage.promptTokens as number) ?? (usage.inputTokens as number) ?? undefined;
+  const completion =
+    (usage.completionTokens as number) ?? (usage.outputTokens as number) ?? undefined;
+
+  if (typeof prompt !== 'number' && typeof completion !== 'number') return null;
+
+  const promptTokens = prompt ?? 0;
+  const completionTokens = completion ?? 0;
+  const costUsd = typeof orUsage?.cost === 'number' ? (orUsage.cost as number) : undefined;
+
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens:
+      typeof (usage.totalTokens as number) === 'number'
+        ? (usage.totalTokens as number)
+        : promptTokens + completionTokens,
+    costUsd
+  };
+}
+
+class ChatStreamStore {
+  private sessions = new Map<string, SessionInternal>();
+  private listeners = new Map<string, Set<Listener>>();
+
+  private notify(threadId: string) {
+    this.listeners.get(threadId)?.forEach((fn) => fn());
+  }
+
+  private getOrCreate(threadId: string): SessionInternal {
+    let s = this.sessions.get(threadId);
+    if (!s) {
+      s = {
+        snapshot: { messages: [], isStreaming: false, pendingToolApproval: null, omStatus: null },
+        abortController: null,
+        needsStepSeparator: false,
+        needsNewTextPart: false,
+        firstTextDeltaTime: null,
+        pendingApproval: false,
+        omStatusCache: null,
+        assistantMessageId: null,
+        runId: ''
+      };
+      this.sessions.set(threadId, s);
+    }
+    return s;
+  }
+
+  private accumulateUsage(s: SessionInternal, messageId: string, usage: TokenUsage) {
+    s.snapshot = {
+      ...s.snapshot,
+      messages: s.snapshot.messages.map((m) => {
+        if (m.id !== messageId) return m;
+        const existing = m.usage;
+        if (existing) {
+          const costUsd =
+            existing.costUsd != null || usage.costUsd != null
+              ? (existing.costUsd ?? 0) + (usage.costUsd ?? 0)
+              : undefined;
+          return {
+            ...m,
+            usage: {
+              promptTokens: existing.promptTokens + usage.promptTokens,
+              completionTokens: existing.completionTokens + usage.completionTokens,
+              totalTokens: existing.totalTokens + usage.totalTokens,
+              costUsd
+            }
+          };
+        }
+        return { ...m, usage };
+      })
+    };
+  }
+
+  subscribe = (threadId: string | null, listener: Listener): (() => void) => {
+    if (!threadId) return () => {};
+    let set = this.listeners.get(threadId);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(threadId, set);
+    }
+    set.add(listener);
+    return () => {
+      set!.delete(listener);
+      if (set!.size === 0) this.listeners.delete(threadId);
+    };
+  };
+
+  getSnapshot = (threadId: string | null): SessionSnapshot => {
+    if (!threadId) return EMPTY_SNAPSHOT;
+    return this.sessions.get(threadId)?.snapshot ?? EMPTY_SNAPSHOT;
+  };
+
+  getEmptySnapshot = (): SessionSnapshot => EMPTY_SNAPSHOT;
+
+  hasActiveStream(threadId: string | null): boolean {
+    if (!threadId) return false;
+    return this.sessions.get(threadId)?.snapshot.isStreaming ?? false;
+  }
+
+  setMessages(threadId: string, messages: ChatMessage[]) {
+    const s = this.getOrCreate(threadId);
+    s.snapshot = { ...s.snapshot, messages };
+    this.notify(threadId);
+  }
+
+  addUserMessage(threadId: string, message: ChatMessage) {
+    const s = this.getOrCreate(threadId);
+    s.snapshot = { ...s.snapshot, messages: [...s.snapshot.messages, message] };
+    this.notify(threadId);
+  }
+
+  beginStream(threadId: string, assistantMessageId: string, abortController: AbortController) {
+    const s = this.getOrCreate(threadId);
+    s.abortController = abortController;
+    s.assistantMessageId = assistantMessageId;
+    s.runId = '';
+    s.needsStepSeparator = false;
+    s.needsNewTextPart = false;
+    s.firstTextDeltaTime = null;
+    s.pendingApproval = false;
+    s.snapshot = {
+      ...s.snapshot,
+      messages: [
+        ...s.snapshot.messages,
+        {
+          id: assistantMessageId,
+          role: 'assistant',
+          content: '',
+          timestamp: new Date(),
+          parts: []
+        }
+      ],
+      isStreaming: true,
+      pendingToolApproval: null
+    };
+    this.notify(threadId);
+  }
+
+  handleChunk(threadId: string, chunk: StreamChunk) {
+    const s = this.sessions.get(threadId);
+    if (!s || !s.assistantMessageId) return;
+    const amId = s.assistantMessageId;
+
+    if (s.abortController?.signal.aborted) return;
+
+    if (chunk.type === 'start' && chunk.runId) {
+      s.runId = chunk.runId;
+      return;
+    }
+
+    if (chunk.type === 'text-delta') {
+      if (s.firstTextDeltaTime === null) {
+        s.firstTextDeltaTime = Date.now();
+      }
+      const text = (chunk.payload as Record<string, unknown> | undefined)?.text as
+        | string
+        | undefined;
+      if (!text) return;
+
+      const insertSep = s.needsStepSeparator;
+      const startNewPart = s.needsNewTextPart;
+      s.needsStepSeparator = false;
+      s.needsNewTextPart = false;
+
+      s.snapshot = {
+        ...s.snapshot,
+        messages: s.snapshot.messages.map((m) => {
+          if (m.id !== amId) return m;
+          const sep = insertSep && m.content.length > 0 ? '\n\n' : '';
+          const newContent = m.content + sep + text;
+
+          let parts = [...(m.parts || [])];
+          parts = parts.map((p) =>
+            p.type === 'tool-call' && p.status === 'running' ? { ...p, status: 'done' as const } : p
+          );
+          const lastPart = parts[parts.length - 1];
+          if (!startNewPart && lastPart?.type === 'text') {
+            parts[parts.length - 1] = { ...lastPart, content: lastPart.content + text };
+          } else {
+            parts.push({ type: 'text' as const, content: text });
+          }
+
+          return { ...m, content: newContent, parts };
+        })
+      };
+      this.notify(threadId);
+      return;
+    }
+
+    if (chunk.type === 'step-finish') {
+      s.needsStepSeparator = true;
+      s.needsNewTextPart = true;
+      const stepUsage = extractUsageFromPayload(chunk.payload);
+      if (stepUsage) {
+        this.accumulateUsage(s, amId, stepUsage);
+        this.notify(threadId);
+      }
+      return;
+    }
+
+    if (chunk.type === 'text-end') {
+      s.needsStepSeparator = true;
+      s.needsNewTextPart = true;
+      return;
+    }
+
+    if (
+      chunk.type === 'tool-call' ||
+      chunk.type === 'tool-call-start' ||
+      chunk.type === 'tool-call-approval'
+    ) {
+      const p = chunk.payload as Record<string, unknown> | undefined;
+      const toolCallId = (p?.toolCallId ?? p?.id) as string | undefined;
+      const toolName = (p?.toolName as string) ?? 'tool';
+
+      if (toolName === 'ask_user' || toolName === 'askUser') return;
+
+      if (toolCallId) {
+        s.needsNewTextPart = true;
+        const tcId = String(toolCallId);
+        s.snapshot = {
+          ...s.snapshot,
+          messages: s.snapshot.messages.map((m) => {
+            if (m.id !== amId) return m;
+            const parts = [...(m.parts || [])];
+            if (!parts.some((pt) => pt.type === 'tool-call' && pt.toolCallId === tcId)) {
+              parts.push({
+                type: 'tool-call' as const,
+                toolName,
+                toolCallId: tcId,
+                args: p?.args,
+                status: 'running' as const
+              });
+            }
+            return { ...m, parts };
+          })
+        };
+
+        if (chunk.type === 'tool-call-approval') {
+          s.pendingApproval = true;
+          s.snapshot = {
+            ...s.snapshot,
+            pendingToolApproval: {
+              runId: s.runId,
+              toolCallId: tcId,
+              toolName,
+              args: p?.args ?? {}
+            }
+          };
+        }
+
+        this.notify(threadId);
+      }
+      return;
+    }
+
+    if (chunk.type === 'tool-result') {
+      const p = chunk.payload as Record<string, unknown> | undefined;
+      const tcId = p?.toolCallId as string | undefined;
+      if (tcId) {
+        s.needsNewTextPart = true;
+        s.snapshot = {
+          ...s.snapshot,
+          messages: s.snapshot.messages.map((m) => {
+            if (m.id !== amId) return m;
+            const parts = (m.parts || []).map((pt) =>
+              pt.type === 'tool-call' && pt.toolCallId === tcId
+                ? { ...pt, status: 'done' as const }
+                : pt
+            );
+            return { ...m, parts };
+          })
+        };
+        this.notify(threadId);
+      }
+      return;
+    }
+
+    if (chunk.type === 'finish' && chunk.payload) {
+      const finishPayload = chunk.payload as Record<string, unknown>;
+
+      const msg = s.snapshot.messages.find((m) => m.id === amId);
+      if (!msg?.usage) {
+        const finishUsage = extractUsageFromPayload(finishPayload);
+        if (finishUsage) {
+          s.snapshot = {
+            ...s.snapshot,
+            messages: s.snapshot.messages.map((m) =>
+              m.id === amId ? { ...m, usage: finishUsage } : m
+            )
+          };
+        }
+      }
+
+      const finishReason = finishPayload.finishReason as string | undefined;
+      const sp = finishPayload.suspendPayload as Record<string, unknown> | undefined;
+      if (finishReason === 'suspended' && sp) {
+        s.pendingApproval = true;
+        s.snapshot = {
+          ...s.snapshot,
+          pendingToolApproval: {
+            runId: (sp.runId as string) ?? '',
+            toolCallId: (sp.toolCallId as string) ?? '',
+            toolName: (sp.toolName as string) ?? 'tool',
+            args: sp.args ?? {}
+          }
+        };
+      }
+      this.notify(threadId);
+      return;
+    }
+
+    if (chunk.type === 'data-om-status') {
+      const d = chunk.payload as Record<string, unknown> | undefined;
+      const windows = d?.windows as Record<string, unknown> | undefined;
+      const active = windows?.active as Record<string, unknown> | undefined;
+      if (active) {
+        const msgs = active.messages as Record<string, unknown> | undefined;
+        const obs = active.observations as Record<string, unknown> | undefined;
+        const next: OmStatus = {
+          messages: {
+            tokens: (msgs?.tokens as number) ?? 0,
+            threshold: (msgs?.threshold as number) ?? 30000
+          },
+          observations: {
+            tokens: (obs?.tokens as number) ?? 0,
+            threshold: (obs?.threshold as number) ?? 40000
+          },
+          isObserving: s.omStatusCache?.isObserving ?? false,
+          observationsText: s.omStatusCache?.observationsText ?? null
+        };
+        s.omStatusCache = next;
+        s.snapshot = { ...s.snapshot, omStatus: next };
+        this.notify(threadId);
+      }
+      return;
+    }
+
+    if (chunk.type === 'data-om-observation-start') {
+      if (s.omStatusCache) {
+        const next = { ...s.omStatusCache, isObserving: true };
+        s.omStatusCache = next;
+        s.snapshot = { ...s.snapshot, omStatus: next };
+        this.notify(threadId);
+      }
+      return;
+    }
+
+    if (chunk.type === 'data-om-observation-end' || chunk.type === 'data-om-activation') {
+      const d = chunk.payload as Record<string, unknown> | undefined;
+      if (s.omStatusCache) {
+        const next: OmStatus = {
+          ...s.omStatusCache,
+          isObserving: false,
+          observationsText: (d?.observations as string) ?? s.omStatusCache.observationsText
+        };
+        s.omStatusCache = next;
+        s.snapshot = { ...s.snapshot, omStatus: next };
+        this.notify(threadId);
+      }
+      return;
+    }
+  }
+
+  finishStream(threadId: string, errorMessage?: string) {
+    const s = this.sessions.get(threadId);
+    if (!s) return;
+    const amId = s.assistantMessageId;
+
+    if (!s.pendingApproval) {
+      s.snapshot = { ...s.snapshot, isStreaming: false };
+    }
+    s.abortController = null;
+
+    if (amId) {
+      const durationMs = s.firstTextDeltaTime ? Date.now() - s.firstTextDeltaTime : undefined;
+      s.firstTextDeltaTime = null;
+
+      s.snapshot = {
+        ...s.snapshot,
+        messages: s.snapshot.messages.map((m) => {
+          if (m.id !== amId) return m;
+          let { content } = m;
+          if (errorMessage && !content) {
+            content = `Error: ${errorMessage}`;
+          }
+          const parts = m.parts?.some((p) => p.type === 'tool-call' && p.status === 'running')
+            ? m.parts.map((p) =>
+                p.type === 'tool-call' && p.status === 'running'
+                  ? { ...p, status: 'done' as const }
+                  : p
+              )
+            : m.parts;
+          const usage = m.usage
+            ? { ...m.usage, durationMs }
+            : durationMs != null
+              ? { promptTokens: 0, completionTokens: 0, totalTokens: 0, durationMs }
+              : m.usage;
+          return { ...m, content, parts, usage };
+        })
+      };
+    }
+
+    s.needsStepSeparator = false;
+    s.needsNewTextPart = false;
+    this.notify(threadId);
+  }
+
+  stopStream(threadId: string) {
+    const s = this.sessions.get(threadId);
+    if (!s) return;
+    s.abortController?.abort();
+    s.snapshot = { ...s.snapshot, isStreaming: false };
+    this.notify(threadId);
+  }
+
+  prepareApprovalStream(threadId: string): string | null {
+    const s = this.sessions.get(threadId);
+    if (!s) return null;
+    s.pendingApproval = false;
+    s.snapshot = { ...s.snapshot, pendingToolApproval: null };
+    const amId = s.snapshot.messages.filter((m) => m.role === 'assistant').pop()?.id ?? null;
+    s.assistantMessageId = amId;
+    this.notify(threadId);
+    return amId;
+  }
+
+  startApprovalStream(threadId: string, abortController: AbortController) {
+    const s = this.sessions.get(threadId);
+    if (!s) return;
+    s.abortController = abortController;
+    s.needsNewTextPart = true;
+  }
+
+  finishApprovalStream(threadId: string) {
+    const s = this.sessions.get(threadId);
+    if (!s) return;
+
+    if (!s.pendingApproval) {
+      s.snapshot = { ...s.snapshot, isStreaming: false };
+    }
+    s.abortController = null;
+    s.needsStepSeparator = false;
+    s.needsNewTextPart = false;
+
+    const amId = s.snapshot.messages.filter((m) => m.role === 'assistant').pop()?.id;
+    if (amId) {
+      s.snapshot = {
+        ...s.snapshot,
+        messages: s.snapshot.messages.map((m) => {
+          if (m.id !== amId || !m.parts) return m;
+          if (!m.parts.some((p) => p.type === 'tool-call' && p.status === 'running')) return m;
+          return {
+            ...m,
+            parts: m.parts.map((p) =>
+              p.type === 'tool-call' && p.status === 'running'
+                ? { ...p, status: 'done' as const }
+                : p
+            )
+          };
+        })
+      };
+    }
+    this.notify(threadId);
+  }
+
+  appendErrorToLastAssistant(threadId: string, text: string) {
+    const s = this.sessions.get(threadId);
+    if (!s) return;
+    const amId = s.snapshot.messages.filter((m) => m.role === 'assistant').pop()?.id;
+    if (!amId) return;
+    s.snapshot = {
+      ...s.snapshot,
+      messages: s.snapshot.messages.map((m) =>
+        m.id === amId ? { ...m, content: m.content + text } : m
+      )
+    };
+    this.notify(threadId);
+  }
+
+  declineApproval(threadId: string) {
+    const s = this.sessions.get(threadId);
+    if (!s) return;
+    s.pendingApproval = false;
+    s.snapshot = { ...s.snapshot, pendingToolApproval: null, isStreaming: false };
+    this.notify(threadId);
+  }
+
+  clearSession(threadId: string) {
+    this.sessions.delete(threadId);
+  }
+}
+
+export const chatStreamStore = new ChatStreamStore();

--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useSyncExternalStore } from 'react';
 import { useAppSelector } from '@/redux/hooks';
 import { authClient } from '@/packages/lib/auth-client';
 import {
@@ -13,6 +13,7 @@ import {
 } from '@/packages/lib/agent-client';
 import { type ChatContext, formatContextsForAgent } from './chat-context';
 import { v4 as uuid } from 'uuid';
+import { chatStreamStore } from './chat-stream-store';
 
 export type MessagePart =
   | { type: 'text'; content: string }
@@ -209,21 +210,24 @@ export function useAgentChat({
   onFirstMessage,
   waitForThread
 }: UseAgentChatOptions) {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const subscribe = useCallback(
+    (cb: () => void) => chatStreamStore.subscribe(threadId, cb),
+    [threadId]
+  );
+  const snapshot = useSyncExternalStore(
+    subscribe,
+    () => chatStreamStore.getSnapshot(threadId),
+    chatStreamStore.getEmptySnapshot
+  );
+
+  const { messages, isStreaming, pendingToolApproval, omStatus } = snapshot;
+
   const [inputValue, setInputValue] = useState('');
-  const [isStreaming, setIsStreaming] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
-  const [pendingToolApproval, setPendingToolApproval] = useState<PendingToolApproval | null>(null);
   const [activeQuestion, setActiveQuestion] = useState<AgentQuestion | null>(null);
-  const [omStatus, setOmStatus] = useState<OmStatus | null>(null);
-  const omStatusRef = useRef<OmStatus | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const abortRef = useRef<AbortController | null>(null);
-  const pendingApprovalRef = useRef(false);
-  const needsStepSeparatorRef = useRef(false);
-  const needsNewTextPartRef = useRef(false);
-  const firstTextDeltaTimeRef = useRef<number | null>(null);
+  const lastAutoApprovedRef = useRef<string | null>(null);
 
   const token = useAppSelector((state) => state.auth.token);
   const activeOrg = useAppSelector((state) => state.user.activeOrganization);
@@ -243,14 +247,12 @@ export function useAgentChat({
   }, [messages, scrollToBottom]);
 
   useEffect(() => {
-    if (!threadId) {
-      setMessages([]);
-      return;
-    }
+    if (!threadId) return;
+
+    if (chatStreamStore.hasActiveStream(threadId)) return;
 
     let cancelled = false;
     setIsLoadingHistory(true);
-    setMessages([]);
 
     (async () => {
       try {
@@ -265,6 +267,7 @@ export function useAgentChat({
         });
 
         if (cancelled) return;
+        if (chatStreamStore.hasActiveStream(threadId)) return;
 
         const msgs: ChatMessage[] = [];
         const rawMessages = result?.messages ?? [];
@@ -293,7 +296,7 @@ export function useAgentChat({
             });
           }
         }
-        setMessages(msgs);
+        chatStreamStore.setMessages(threadId, msgs);
       } catch {
         // thread may not exist on server yet
       } finally {
@@ -306,301 +309,16 @@ export function useAgentChat({
     };
   }, [threadId, resourceId, token, organizationId, waitForThread]);
 
-  const extractUsageFromPayload = useCallback((payload: unknown): TokenUsage | null => {
-    if (!payload || typeof payload !== 'object') return null;
-    const p = payload as Record<string, unknown>;
-
-    const output = p.output as Record<string, unknown> | undefined;
-    const outputUsage = output?.usage as Record<string, unknown> | undefined;
-
-    const metadata = p.metadata as Record<string, unknown> | undefined;
-    const providerMeta = metadata?.providerMetadata as Record<string, unknown> | undefined;
-    const orMeta = providerMeta?.openrouter as Record<string, unknown> | undefined;
-    const orUsage = orMeta?.usage as Record<string, unknown> | undefined;
-
-    const usage = outputUsage ?? orUsage;
-    if (!usage) return null;
-
-    const prompt = (usage.promptTokens as number) ?? (usage.inputTokens as number) ?? undefined;
-    const completion =
-      (usage.completionTokens as number) ?? (usage.outputTokens as number) ?? undefined;
-
-    if (typeof prompt !== 'number' && typeof completion !== 'number') return null;
-
-    const promptTokens = prompt ?? 0;
-    const completionTokens = completion ?? 0;
-    const costUsd = typeof orUsage?.cost === 'number' ? (orUsage.cost as number) : undefined;
-
-    return {
-      promptTokens,
-      completionTokens,
-      totalTokens:
-        typeof (usage.totalTokens as number) === 'number'
-          ? (usage.totalTokens as number)
-          : promptTokens + completionTokens,
-      costUsd
-    };
-  }, []);
-
-  const accumulateUsage = useCallback((messageId: string, usage: TokenUsage) => {
-    setMessages((prev) =>
-      prev.map((m) => {
-        if (m.id !== messageId) return m;
-        const existing = m.usage;
-        if (existing) {
-          const costUsd =
-            existing.costUsd != null || usage.costUsd != null
-              ? (existing.costUsd ?? 0) + (usage.costUsd ?? 0)
-              : undefined;
-          return {
-            ...m,
-            usage: {
-              promptTokens: existing.promptTokens + usage.promptTokens,
-              completionTokens: existing.completionTokens + usage.completionTokens,
-              totalTokens: existing.totalTokens + usage.totalTokens,
-              costUsd
-            }
-          };
-        }
-        return { ...m, usage };
-      })
-    );
-  }, []);
-
-  const handleChunk = useCallback(
-    (
-      chunk: StreamChunk,
-      assistantMessageId: string,
-      runIdRef: { current: string },
-      abortSignal: AbortSignal
-    ) => {
-      if (abortSignal.aborted) return;
-
-      if (chunk.type === 'start' && chunk.runId) {
-        runIdRef.current = chunk.runId;
-      }
-
-      if (chunk.type === 'text-delta') {
-        if (firstTextDeltaTimeRef.current === null) {
-          firstTextDeltaTimeRef.current = Date.now();
-        }
-        const text = chunk.payload?.text as string | undefined;
-        if (text) {
-          const insertSep = needsStepSeparatorRef.current;
-          const startNewPart = needsNewTextPartRef.current;
-          needsStepSeparatorRef.current = false;
-          needsNewTextPartRef.current = false;
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== assistantMessageId) return m;
-              const sep = insertSep && m.content.length > 0 ? '\n\n' : '';
-              const newContent = m.content + sep + text;
-
-              let parts = [...(m.parts || [])];
-              parts = parts.map((p) =>
-                p.type === 'tool-call' && p.status === 'running'
-                  ? { ...p, status: 'done' as const }
-                  : p
-              );
-              const lastPart = parts[parts.length - 1];
-              if (!startNewPart && lastPart?.type === 'text') {
-                parts[parts.length - 1] = { ...lastPart, content: lastPart.content + text };
-              } else {
-                parts.push({ type: 'text' as const, content: text });
-              }
-
-              return { ...m, content: newContent, parts };
-            })
-          );
-        }
-      }
-
-      if (chunk.type === 'step-finish') {
-        needsStepSeparatorRef.current = true;
-        needsNewTextPartRef.current = true;
-        const stepUsage = extractUsageFromPayload(chunk.payload);
-        if (stepUsage) {
-          accumulateUsage(assistantMessageId, stepUsage);
-        }
-      }
-
-      if (chunk.type === 'text-end') {
-        needsStepSeparatorRef.current = true;
-        needsNewTextPartRef.current = true;
-      }
-
-      if (
-        chunk.type === 'tool-call' ||
-        chunk.type === 'tool-call-start' ||
-        chunk.type === 'tool-call-approval'
-      ) {
-        const p = chunk.payload as
-          | {
-              toolCallId?: string;
-              toolName?: string;
-              args?: unknown;
-              runId?: string;
-              id?: string;
-            }
-          | undefined;
-        const toolCallId = p?.toolCallId ?? p?.id;
-        const toolName = (p?.toolName as string) ?? 'tool';
-
-        if (toolName === 'ask_user' || toolName === 'askUser') return;
-
-        if (toolCallId) {
-          needsNewTextPartRef.current = true;
-          const tcId = String(toolCallId);
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== assistantMessageId) return m;
-              const parts = [...(m.parts || [])];
-              if (!parts.some((pt) => pt.type === 'tool-call' && pt.toolCallId === tcId)) {
-                parts.push({
-                  type: 'tool-call' as const,
-                  toolName,
-                  toolCallId: tcId,
-                  args: p?.args,
-                  status: 'running' as const
-                });
-              }
-              return { ...m, parts };
-            })
-          );
-        }
-      }
-
-      if (chunk.type === 'tool-result') {
-        const p = chunk.payload as
-          | {
-              toolCallId?: string;
-              toolName?: string;
-              result?: { title?: string; description?: string; fields?: AgentQuestionField[] };
-            }
-          | undefined;
-        const tcId = p?.toolCallId;
-
-        if (tcId) {
-          needsNewTextPartRef.current = true;
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== assistantMessageId) return m;
-              const parts = (m.parts || []).map((pt) =>
-                pt.type === 'tool-call' && pt.toolCallId === tcId
-                  ? { ...pt, status: 'done' as const }
-                  : pt
-              );
-              return { ...m, parts };
-            })
-          );
-        }
-      }
-
-      if (chunk.type === 'finish' && chunk.payload) {
-        const finishPayload = chunk.payload as Record<string, unknown>;
-
-        setMessages((prev) => {
-          const msg = prev.find((m) => m.id === assistantMessageId);
-          if (!msg?.usage) {
-            const finishUsage = extractUsageFromPayload(finishPayload);
-            if (finishUsage) {
-              return prev.map((m) =>
-                m.id === assistantMessageId ? { ...m, usage: finishUsage } : m
-              );
-            }
-          }
-          return prev;
-        });
-
-        const finishReason = finishPayload.finishReason as string | undefined;
-        const sp = finishPayload.suspendPayload as
-          | { toolCallId?: string; runId?: string; toolName?: string; args?: unknown }
-          | undefined;
-        if (finishReason === 'suspended' && sp) {
-          pendingApprovalRef.current = true;
-          setPendingToolApproval({
-            runId: sp.runId ?? '',
-            toolCallId: sp.toolCallId ?? '',
-            toolName: (sp.toolName as string) ?? 'tool',
-            args: sp.args ?? {}
-          });
-        }
-      }
-
-      if (chunk.type === 'data-om-status') {
-        const d = chunk.payload as
-          | {
-              windows?: {
-                active?: {
-                  messages?: { tokens?: number; threshold?: number };
-                  observations?: { tokens?: number; threshold?: number };
-                };
-              };
-            }
-          | undefined;
-        const active = d?.windows?.active;
-        if (active) {
-          const next: OmStatus = {
-            messages: {
-              tokens: active.messages?.tokens ?? 0,
-              threshold: active.messages?.threshold ?? 30000
-            },
-            observations: {
-              tokens: active.observations?.tokens ?? 0,
-              threshold: active.observations?.threshold ?? 40000
-            },
-            isObserving: omStatusRef.current?.isObserving ?? false,
-            observationsText: omStatusRef.current?.observationsText ?? null
-          };
-          omStatusRef.current = next;
-          setOmStatus(next);
-        }
-      }
-
-      if (chunk.type === 'data-om-observation-start') {
-        const prev = omStatusRef.current;
-        if (prev) {
-          const next = { ...prev, isObserving: true };
-          omStatusRef.current = next;
-          setOmStatus(next);
-        }
-      }
-
-      if (chunk.type === 'data-om-observation-end' || chunk.type === 'data-om-activation') {
-        const d = chunk.payload as { observations?: string } | undefined;
-        const prev = omStatusRef.current;
-        if (prev) {
-          const next: OmStatus = {
-            ...prev,
-            isObserving: false,
-            observationsText: d?.observations ?? prev.observationsText
-          };
-          omStatusRef.current = next;
-          setOmStatus(next);
-        }
-      }
-    },
-    [extractUsageFromPayload, accumulateUsage]
-  );
-
   const streamResponse = useCallback(
     async (userContent: string) => {
       if (!threadId) return;
 
-      const headers = await getAuthHeaders(token ?? null, organizationId ?? null);
-
       const abortController = new AbortController();
-      abortRef.current = abortController;
-      const runIdRef = { current: '' };
-      firstTextDeltaTimeRef.current = null;
-
       const assistantMessageId = uuid();
-      setMessages((prev) => [
-        ...prev,
-        { id: assistantMessageId, role: 'assistant', content: '', timestamp: new Date(), parts: [] }
-      ]);
+      chatStreamStore.beginStream(threadId, assistantMessageId, abortController);
 
       try {
+        const headers = await getAuthHeaders(token ?? null, organizationId ?? null);
         const contextPrefix = formatContextsForAgent(contexts);
         const stream = streamAgent(
           contextPrefix + userContent,
@@ -608,76 +326,39 @@ export function useAgentChat({
           resourceId || threadId,
           headers,
           abortController.signal,
-          model
+          model,
+          !autoRunTools
         );
 
         for await (const chunk of stream) {
-          handleChunk(chunk, assistantMessageId, runIdRef, abortController.signal);
+          chatStreamStore.handleChunk(threadId, chunk);
         }
       } catch (err: unknown) {
         if (err instanceof Error && err.name === 'AbortError') return;
-
         const errorMessage =
           err instanceof Error ? err.message : 'Failed to get response from AI agent';
-
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantMessageId
-              ? { ...m, content: m.content || `Error: ${errorMessage}` }
-              : m
-          )
-        );
-      } finally {
-        if (!pendingApprovalRef.current) {
-          setIsStreaming(false);
-        }
-        abortRef.current = null;
-        needsStepSeparatorRef.current = false;
-        needsNewTextPartRef.current = false;
-        const durationMs = firstTextDeltaTimeRef.current
-          ? Date.now() - firstTextDeltaTimeRef.current
-          : undefined;
-        firstTextDeltaTimeRef.current = null;
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== assistantMessageId) return m;
-            const parts = m.parts?.some((p) => p.type === 'tool-call' && p.status === 'running')
-              ? m.parts.map((p) =>
-                  p.type === 'tool-call' && p.status === 'running'
-                    ? { ...p, status: 'done' as const }
-                    : p
-                )
-              : m.parts;
-            const usage = m.usage
-              ? { ...m.usage, durationMs }
-              : durationMs != null
-                ? { promptTokens: 0, completionTokens: 0, totalTokens: 0, durationMs }
-                : m.usage;
-            return { ...m, parts, usage };
-          })
-        );
+        chatStreamStore.finishStream(threadId, errorMessage);
+        return;
       }
+      chatStreamStore.finishStream(threadId);
     },
-    [threadId, resourceId, token, organizationId, contexts, model, handleChunk]
+    [threadId, resourceId, token, organizationId, contexts, model, autoRunTools]
   );
 
   const handleApproveToolCall = useCallback(async () => {
-    const pending = pendingToolApproval;
+    if (!threadId) return;
+    const snap = chatStreamStore.getSnapshot(threadId);
+    const pending = snap.pendingToolApproval;
     if (!pending) return;
 
-    setPendingToolApproval(null);
-    pendingApprovalRef.current = false;
-
-    const assistantMessageId = messages.filter((m) => m.role === 'assistant').pop()?.id;
+    const assistantMessageId = chatStreamStore.prepareApprovalStream(threadId);
     if (!assistantMessageId) {
-      setIsStreaming(false);
+      chatStreamStore.stopStream(threadId);
       return;
     }
 
     const abortController = new AbortController();
-    abortRef.current = abortController;
-    const runIdRef = { current: '' };
-    needsNewTextPartRef.current = true;
+    chatStreamStore.startApprovalStream(threadId, abortController);
 
     try {
       const headers = await getAuthHeaders(token ?? null, organizationId ?? null);
@@ -688,71 +369,31 @@ export function useAgentChat({
       );
 
       for await (const chunk of stream) {
-        handleChunk(chunk, assistantMessageId, runIdRef, abortController.signal);
+        chatStreamStore.handleChunk(threadId, chunk);
       }
     } catch {
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantMessageId
-            ? { ...m, content: m.content + '\n\n_Tool execution failed._' }
-            : m
-        )
-      );
-    } finally {
-      if (!pendingApprovalRef.current) setIsStreaming(false);
-      abortRef.current = null;
-      needsStepSeparatorRef.current = false;
-      needsNewTextPartRef.current = false;
-      if (assistantMessageId) {
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== assistantMessageId || !m.parts) return m;
-            const hasRunning = m.parts.some(
-              (p) => p.type === 'tool-call' && p.status === 'running'
-            );
-            if (!hasRunning) return m;
-            return {
-              ...m,
-              parts: m.parts.map((p) =>
-                p.type === 'tool-call' && p.status === 'running'
-                  ? { ...p, status: 'done' as const }
-                  : p
-              )
-            };
-          })
-        );
-      }
+      chatStreamStore.appendErrorToLastAssistant(threadId, '\n\n_Tool execution failed._');
     }
-  }, [pendingToolApproval, token, organizationId, messages, handleChunk]);
+    chatStreamStore.finishApprovalStream(threadId);
+  }, [threadId, token, organizationId]);
 
   const handleDeclineToolCall = useCallback(async () => {
-    const pending = pendingToolApproval;
+    if (!threadId) return;
+    const snap = chatStreamStore.getSnapshot(threadId);
+    const pending = snap.pendingToolApproval;
     if (!pending) return;
 
-    setPendingToolApproval(null);
-    pendingApprovalRef.current = false;
+    chatStreamStore.declineApproval(threadId);
 
     try {
       const headers = await getAuthHeaders(token ?? null, organizationId ?? null);
       await declineAgentToolCall({ runId: pending.runId, toolCallId: pending.toolCallId }, headers);
-      const assistantMessageId = messages.filter((m) => m.role === 'assistant').pop()?.id;
-      if (assistantMessageId) {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantMessageId
-              ? { ...m, content: m.content + '\n\n_Tool call was declined._' }
-              : m
-          )
-        );
-      }
+      chatStreamStore.appendErrorToLastAssistant(threadId, '\n\n_Tool call was declined._');
     } catch {
       // ignore
-    } finally {
-      setIsStreaming(false);
     }
-  }, [pendingToolApproval, token, organizationId, messages]);
+  }, [threadId, token, organizationId]);
 
-  const lastAutoApprovedRef = useRef<string | null>(null);
   useEffect(() => {
     if (!pendingToolApproval) {
       lastAutoApprovedRef.current = null;
@@ -768,7 +409,8 @@ export function useAgentChat({
   const handleSubmit = useCallback(
     (e?: React.FormEvent) => {
       e?.preventDefault();
-      if (!inputValue.trim() || isStreaming || !threadId) return;
+      if (!inputValue.trim() || !threadId) return;
+      if (chatStreamStore.getSnapshot(threadId).isStreaming) return;
 
       const content = inputValue.trim();
       const userMessage: ChatMessage = {
@@ -779,18 +421,16 @@ export function useAgentChat({
         ...(contexts.length > 0 ? { contexts: [...contexts] } : {})
       };
 
-      setMessages((prev) => {
-        const isFirst = prev.length === 0;
-        if (isFirst && onFirstMessage) {
-          onFirstMessage(content);
-        }
-        return [...prev, userMessage];
-      });
+      const snap = chatStreamStore.getSnapshot(threadId);
+      if (snap.messages.length === 0 && onFirstMessage) {
+        onFirstMessage(content);
+      }
+
+      chatStreamStore.addUserMessage(threadId, userMessage);
       setInputValue('');
-      setIsStreaming(true);
       streamResponse(content);
     },
-    [inputValue, isStreaming, threadId, streamResponse, onFirstMessage, contexts]
+    [inputValue, threadId, streamResponse, onFirstMessage, contexts]
   );
 
   const handleKeyDown = useCallback(
@@ -805,27 +445,27 @@ export function useAgentChat({
 
   const handleSuggestionClick = useCallback(
     (text: string) => {
-      if (!isStreaming && threadId) {
-        setInputValue('');
-        const userMessage: ChatMessage = {
-          id: uuid(),
-          role: 'user',
-          content: text,
-          timestamp: new Date(),
-          ...(contexts.length > 0 ? { contexts: [...contexts] } : {})
-        };
-        setMessages((prev) => {
-          const isFirst = prev.length === 0;
-          if (isFirst && onFirstMessage) {
-            onFirstMessage(text);
-          }
-          return [...prev, userMessage];
-        });
-        setIsStreaming(true);
-        streamResponse(text);
+      if (!threadId) return;
+      if (chatStreamStore.getSnapshot(threadId).isStreaming) return;
+
+      const userMessage: ChatMessage = {
+        id: uuid(),
+        role: 'user',
+        content: text,
+        timestamp: new Date(),
+        ...(contexts.length > 0 ? { contexts: [...contexts] } : {})
+      };
+
+      const snap = chatStreamStore.getSnapshot(threadId);
+      if (snap.messages.length === 0 && onFirstMessage) {
+        onFirstMessage(text);
       }
+
+      chatStreamStore.addUserMessage(threadId, userMessage);
+      setInputValue('');
+      streamResponse(text);
     },
-    [isStreaming, threadId, streamResponse, onFirstMessage, contexts]
+    [threadId, streamResponse, onFirstMessage, contexts]
   );
 
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -835,7 +475,8 @@ export function useAgentChat({
   const submitQuestionResponse = useCallback(
     (answers: Record<string, string>) => {
       setActiveQuestion(null);
-      if (!threadId || isStreaming) return;
+      if (!threadId) return;
+      if (chatStreamStore.getSnapshot(threadId).isStreaming) return;
 
       const formatted = Object.entries(answers)
         .map(([key, value]) => `${key}: ${value}`)
@@ -848,11 +489,10 @@ export function useAgentChat({
         content,
         timestamp: new Date()
       };
-      setMessages((prev) => [...prev, userMessage]);
-      setIsStreaming(true);
+      chatStreamStore.addUserMessage(threadId, userMessage);
       streamResponse(content);
     },
-    [threadId, isStreaming, streamResponse]
+    [threadId, streamResponse]
   );
 
   const dismissQuestion = useCallback(() => {
@@ -860,9 +500,8 @@ export function useAgentChat({
   }, []);
 
   const stopStreaming = useCallback(() => {
-    abortRef.current?.abort();
-    setIsStreaming(false);
-  }, []);
+    if (threadId) chatStreamStore.stopStream(threadId);
+  }, [threadId]);
 
   return {
     messages,

--- a/view/packages/hooks/ai/use-chat-page.ts
+++ b/view/packages/hooks/ai/use-chat-page.ts
@@ -100,7 +100,7 @@ export function useChatPage(): UseChatPageReturn {
     false
   );
   const [selectedContexts, setSelectedContexts] = useState<ChatContext[]>([]);
-  const [autoRunTools, setAutoRunTools] = useLocalStorageState('chat_auto_run_tools', false);
+  const [autoRunTools, setAutoRunTools] = useLocalStorageState('chat_auto_run_tools', true);
   const [selectedModel, setSelectedModel] = useState<string>(() => {
     if (typeof window !== 'undefined') {
       return localStorage.getItem('chat_selected_model') || AVAILABLE_MODELS[0].id;

--- a/view/packages/lib/agent-client.ts
+++ b/view/packages/lib/agent-client.ts
@@ -158,19 +158,18 @@ export async function* streamAgent(
   resourceId: string,
   headers: Record<string, string>,
   signal?: AbortSignal,
-  model?: string
+  model?: string,
+  requireToolApproval?: boolean
 ): AsyncGenerator<StreamChunk> {
   const query = model ? { model } : undefined;
-  const response = await agentFetch(
-    `/agents/${AGENT_ID}/stream`,
-    {
-      messages: [{ role: 'user', content }],
-      memory: { thread: threadId, resource: resourceId }
-    },
-    headers,
-    signal,
-    query
-  );
+  const body: Record<string, unknown> = {
+    messages: [{ role: 'user', content }],
+    memory: { thread: threadId, resource: resourceId }
+  };
+  if (requireToolApproval) {
+    body.requireToolApproval = true;
+  }
+  const response = await agentFetch(`/agents/${AGENT_ID}/stream`, body, headers, signal, query);
 
   yield* readSseStream(response.body!, signal);
 }


### PR DESCRIPTION
## Summary
- Extract chat streaming state into a singleton `ChatStreamStore` so active streams survive React component unmounts during navigation
- Wire tool approval flow through the store so pending approvals are not lost when switching pages
- Default `autoRunTools` to `true` and pass `requireToolApproval` flag to the agent stream API

## Test plan
- [ ] Start a chat, navigate away mid-stream, return — stream should still be updating
- [ ] Trigger a tool call requiring approval, navigate away and back — approval banner should persist
- [ ] Verify auto-run tools toggle works and the `requireToolApproval` flag is sent correctly