### PR TITLE
fix: scope machine_byos feature flag to /machines routes only

### DIFF
--- a/api/internal/routes/machine.go
+++ b/api/internal/routes/machine.go
@@ -112,13 +112,13 @@ func (router *Router) RegisterMachineRoutes(machineGroup *fuego.Server, machineC
 }
 
 func (router *Router) RegisterMachineRegistrationRoutes(regGroup *fuego.Server, machineController *machine_controller.MachineController) {
-	fuego.Post(regGroup, "/machines", machineController.CreateMachine,
+	fuego.Post(regGroup, "/", machineController.CreateMachine,
 		fuego.OptionSummary("Register a BYOS machine"))
-	fuego.Post(regGroup, "/machines/{id}/verify", machineController.VerifyMachine,
+	fuego.Post(regGroup, "/{id}/verify", machineController.VerifyMachine,
 		fuego.OptionSummary("Verify SSH connection"))
-	fuego.Delete(regGroup, "/machines/{id}", machineController.DeleteMachine,
+	fuego.Delete(regGroup, "/{id}", machineController.DeleteMachine,
 		fuego.OptionSummary("Remove a machine"))
-	fuego.Get(regGroup, "/machines/{id}/ssh/status", machineController.GetSSHStatus,
+	fuego.Get(regGroup, "/{id}/ssh/status", machineController.GetSSHStatus,
 		fuego.OptionSummary("SSH connection status"))
 }
 

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -393,7 +393,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	})
 	router.RegisterMachineBillingRoutes(machineBillingGroup, machineController)
 
-	machineRegGroup := fuego.Group(server, apiV1.Path)
+	machineRegGroup := fuego.Group(server, apiV1.Path+"/machines")
 	router.applyMiddleware(machineRegGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "machine_byos",


### PR DESCRIPTION
## Summary

- The `machineRegGroup` was mounted at the bare `/api/v1` prefix, causing the `machine_byos` feature flag middleware to intercept **all** API routes under `/api/v1/*`
- Orgs without the `machine_byos` flag enabled got 404s on every endpoint (`/machine/status`, `/servers`, `/deploy/*`, etc.)
- Moved the group to `/api/v1/machines` so the flag only gates BYOS registration endpoints

## Test plan

- [ ] Verify `/api/v1/machine/status` returns 200 for orgs without `machine_byos` enabled
- [ ] Verify `/api/v1/machines` (POST) still requires `machine_byos` flag
- [ ] Confirm all other API endpoints are unaffected


Made with [Cursor](https://cursor.com)