### PR TITLE
fix: route machine-verify tasks to correct abyss queue

### DIFF
--- a/api/internal/features/machine/service/registration.go
+++ b/api/internal/features/machine/service/registration.go
@@ -139,9 +139,12 @@ func (s *RegistrationService) VerifyMachine(orgID uuid.UUID, machineID uuid.UUID
 		return fmt.Errorf("machine not found: %w", err)
 	}
 
+	serverID, _ := s.storage.GetAnyActiveInfraServerID()
+
 	return queue.EnqueueMachineVerifyTask(s.ctx, queue.MachineVerifyPayload{
 		MachineID: machineID.String(),
 		OrgID:     orgID.String(),
+		ServerID:  serverID,
 	})
 }
 

--- a/api/internal/features/machine/storage/billing.go
+++ b/api/internal/features/machine/storage/billing.go
@@ -343,7 +343,7 @@ func (s *BillingStorage) GetProvisionInfo(ctx context.Context, orgID uuid.UUID, 
 	var row UserProvisionDetail
 	q := s.DB.NewSelect().Model(&row).Column("user_id", "lxd_container_name", "server_id")
 	if serverID != nil {
-		q = q.Where("server_id = ? AND organization_id = ?", *serverID, orgID)
+		q = q.Where("(upd.ssh_key_id = ? OR upd.server_id = ?) AND upd.organization_id = ?", *serverID, *serverID, orgID)
 	} else {
 		q = q.Where("organization_id = ?", orgID).
 			Where("upd.type != 'user_owned'")

--- a/api/internal/features/machine/storage/registration.go
+++ b/api/internal/features/machine/storage/registration.go
@@ -167,3 +167,17 @@ func (s *RegistrationStorage) GetProvisionDetailsBySSHKeyID(sshKeyID uuid.UUID) 
 		Scan(s.ctx, &id)
 	return id, err
 }
+
+func (s *RegistrationStorage) GetAnyActiveInfraServerID() (string, error) {
+	var serverID string
+	err := s.db.NewSelect().
+		TableExpr("infra_servers").
+		ColumnExpr("id::text").
+		Where("status = ?", "active").
+		Limit(1).
+		Scan(s.ctx, &serverID)
+	if err != nil {
+		return "", err
+	}
+	return serverID, nil
+}

--- a/api/internal/scheduler/machine_health_check.go
+++ b/api/internal/scheduler/machine_health_check.go
@@ -57,6 +57,8 @@ func (s *MachineHealthCheckScheduler) run() {
 		return
 	}
 
+	serverID, _ := s.storage.GetAnyActiveInfraServerID()
+
 	recentCutoff := time.Now().Add(-25 * time.Minute)
 	enqueued := 0
 
@@ -75,6 +77,7 @@ func (s *MachineHealthCheckScheduler) run() {
 			payload := queue.MachineVerifyPayload{
 				MachineID: machine.ID.String(),
 				OrgID:     org.OrganizationID.String(),
+				ServerID:  serverID,
 			}
 			if err := queue.EnqueueMachineVerifyTask(s.ctx, payload); err != nil {
 				s.logger.Log(logger.Error, fmt.Sprintf("machine health check: enqueue failed for %s: %v", machine.ID, err), "")


### PR DESCRIPTION
## Summary

- Fix machine verification tasks never being consumed by abyss — tasks were enqueued to base `machine-verify` queue but abyss consumers listen on `machine-verify-{SERVER_ID}`
- Fix `GetProvisionInfo` to resolve trail machines by `ssh_key_id` (what frontend sends) in addition to `server_id` (infra server), fixing 404 on `/api/v1/machine/status`

## Changes

- **`storage/registration.go`**: Add `GetAnyActiveInfraServerID()` to query an active infra server for queue routing
- **`service/registration.go`**: `VerifyMachine` now includes `ServerID` in the queue payload
- **`scheduler/machine_health_check.go`**: Health check scheduler includes `ServerID` in verify payloads
- **`storage/billing.go`**: `GetProvisionInfo` matches on `ssh_key_id OR server_id` instead of only `server_id`

## Test plan

- [ ] Verify BYOS machine → click Verify → abyss picks up task, `is_active` flips to true
- [ ] Health check scheduler enqueues tasks that abyss consumes
- [ ] Trail machine status endpoint returns data (no more 404)
- [ ] Existing lifecycle tests pass