### PR TITLE
feat: add direct SSH status checks and lazy spec detection for BYOS machines

### DIFF
--- a/api/internal/features/dashboard/get_deployments.go
+++ b/api/internal/features/dashboard/get_deployments.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"github.com/nixopus/nixopus/api/internal/features/logger"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
 func (p *OrgPoller) getDeployments() {
@@ -11,7 +12,14 @@ func (p *OrgPoller) getDeployments() {
 		return
 	}
 
-	deployments, err := p.deployService.GetLatestDeployments(p.organizationID, 5)
+	var deployments []shared_types.ApplicationDeployment
+	var err error
+
+	if p.serverID != "" {
+		deployments, err = p.deployService.GetLatestDeploymentsByServer(p.organizationID, p.serverID, 5)
+	} else {
+		deployments, err = p.deployService.GetLatestDeployments(p.organizationID, 5)
+	}
 	if err != nil {
 		p.log.Log(logger.Error, "Failed to get deployments", err.Error())
 		p.broadcastError(err.Error(), GetDeployments)

--- a/api/internal/features/dashboard/init.go
+++ b/api/internal/features/dashboard/init.go
@@ -50,6 +50,7 @@ func getOrCreateOrgPoller(
 		dockerService:  dockerService,
 		deployService:  deployService,
 		organizationID: organizationID,
+		serverID:       serverID,
 		pollerKey:      key,
 		log:            log,
 	}
@@ -180,6 +181,7 @@ func NewDashboardMonitor(conn *websocket.Conn, wsMu *sync.Mutex, log logger.Logg
 		connMutex:  wsMu,
 		log:        log,
 		poller:     poller,
+		ServerID:   serverID,
 		Interval:   defaultPollerInterval,
 		Operations: AllOperations,
 	}

--- a/api/internal/features/dashboard/types.go
+++ b/api/internal/features/dashboard/types.go
@@ -36,6 +36,7 @@ type MonitoringConfig struct {
 // DeployServiceProvider defines the interface for fetching latest deployments.
 type DeployServiceProvider interface {
 	GetLatestDeployments(organizationID string, limit int) ([]shared_types.ApplicationDeployment, error)
+	GetLatestDeploymentsByServer(organizationID string, serverID string, limit int) ([]shared_types.ApplicationDeployment, error)
 }
 
 // OrgPoller runs a single polling loop per organization. All DashboardMonitors
@@ -48,6 +49,7 @@ type OrgPoller struct {
 	dockerService  docker.DockerRepository
 	deployService  DeployServiceProvider
 	organizationID string
+	serverID       string
 	pollerKey      string
 	log            logger.Logger
 
@@ -72,6 +74,8 @@ type DashboardMonitor struct {
 
 	subMu      sync.Mutex
 	subscribed bool
+
+	ServerID string
 
 	// Kept for API compatibility with the realtime package.
 	Interval   time.Duration

--- a/api/internal/features/deploy/controller/get_applications.go
+++ b/api/internal/features/deploy/controller/get_applications.go
@@ -41,7 +41,14 @@ func (c *DeployController) GetApplications(f fuego.ContextNoBody) (*types.ListAp
 		}
 	}
 
-	applications, totalCount, err := c.service.GetApplications(page, pageSize, sortBy, sortDirection, organizationID)
+	var serverID *uuid.UUID
+	if s := r.URL.Query().Get("server_id"); s != "" {
+		if parsed, err := uuid.Parse(s); err == nil {
+			serverID = &parsed
+		}
+	}
+
+	applications, totalCount, err := c.service.GetApplications(page, pageSize, sortBy, sortDirection, organizationID, serverID)
 	if err != nil {
 		c.logger.Log(logger.Error, err.Error(), "")
 		return nil, fuego.HTTPError{

--- a/api/internal/features/deploy/docker/init.go
+++ b/api/internal/features/deploy/docker/init.go
@@ -160,10 +160,9 @@ func newDockerClientWithSSHTunnel(lgr logger.Logger, ctx context.Context, organi
 		return nil, nil
 	}
 
-	// Get SSH manager for organization
-	sshManager, err := ssh.GetSSHManagerForOrganization(ctx, organizationID)
+	sshManager, err := ssh.GetSSHManagerFromContext(ctx)
 	if err != nil {
-		lgr.Log(logger.Error, "Failed to get SSH manager for organization", err.Error())
+		lgr.Log(logger.Error, "Failed to get SSH manager", err.Error())
 		return nil, nil
 	}
 
@@ -216,8 +215,8 @@ func NewDockerServiceWithClient(cli *client.Client, ctx context.Context, logger 
 	}
 }
 
-func getOrgMutex(orgID uuid.UUID) *sync.Mutex {
-	v, _ := orgMutexes.LoadOrStore(orgID.String(), &sync.Mutex{})
+func getCacheMutex(key string) *sync.Mutex {
+	v, _ := orgMutexes.LoadOrStore(key, &sync.Mutex{})
 	return v.(*sync.Mutex)
 }
 
@@ -227,6 +226,17 @@ func getOrgMutex(orgID uuid.UUID) *sync.Mutex {
 // A per-org mutex serializes all callers so concurrent HandleFileWritten goroutines
 // don't race on cache invalidation (avoiding multiple Close) and only one creation runs.
 func GetDockerServiceForOrganization(ctx context.Context, orgID uuid.UUID) (*DockerService, error) {
+	cacheKey := orgID.String()
+	return getOrCreateDockerService(ctx, cacheKey, orgID)
+}
+
+func GetDockerServiceForServer(ctx context.Context, orgID uuid.UUID, serverID uuid.UUID) (*DockerService, error) {
+	serverCtx := context.WithValue(ctx, shared_types.ServerIDKey, serverID.String())
+	cacheKey := orgID.String() + ":" + serverID.String()
+	return getOrCreateDockerService(serverCtx, cacheKey, orgID)
+}
+
+func getOrCreateDockerService(ctx context.Context, cacheKey string, orgID uuid.UUID) (*DockerService, error) {
 	if config.GlobalStore == nil {
 		return nil, fmt.Errorf("global store not initialized, ensure config.Init() has been called")
 	}
@@ -235,20 +245,18 @@ func GetDockerServiceForOrganization(ctx context.Context, orgID uuid.UUID) (*Doc
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	mu := getOrgMutex(orgID)
+	mu := getCacheMutex(cacheKey)
 	mu.Lock()
 	defer mu.Unlock()
 
-	// Check cache (fast path when valid)
-	if cached, ok := dockerServiceCache.Load(orgID); ok {
+	if cached, ok := dockerServiceCache.Load(cacheKey); ok {
 		entry := cached.(*cachedDockerService)
 		if time.Since(entry.createdAt) < cacheMaxAge && entry.service != nil && entry.service.Cli != nil {
 			if _, err := entry.service.Cli.Ping(ctx); err == nil {
 				return entry.service, nil
 			}
 		}
-		// Invalid or expired: atomically remove and close (only we can do this while holding lock)
-		if old, ok := dockerServiceCache.LoadAndDelete(orgID); ok {
+		if old, ok := dockerServiceCache.LoadAndDelete(cacheKey); ok {
 			oldEntry := old.(*cachedDockerService)
 			if oldEntry.service != nil {
 				_ = oldEntry.service.Close()
@@ -256,13 +264,12 @@ func GetDockerServiceForOrganization(ctx context.Context, orgID uuid.UUID) (*Doc
 		}
 	}
 
-	// Cache miss: create (we hold the lock, so only one creation per org at a time)
 	svc := NewDockerServiceWithServer(config.GlobalStore.DB, ctx, orgID)
 	if svc == nil {
 		return nil, fmt.Errorf("failed to create Docker service via SSH tunnel for organization %s", orgID.String())
 	}
 
-	dockerServiceCache.Store(orgID, &cachedDockerService{
+	dockerServiceCache.Store(cacheKey, &cachedDockerService{
 		service:   svc,
 		createdAt: time.Now(),
 	})
@@ -272,12 +279,22 @@ func GetDockerServiceForOrganization(ctx context.Context, orgID uuid.UUID) (*Doc
 // InvalidateDockerServiceCache removes a cached DockerService for the given organization,
 // closing the underlying SSH tunnel. Use this when the SSH connection is known to be broken.
 func InvalidateDockerServiceCache(orgID uuid.UUID) {
-	if cached, ok := dockerServiceCache.LoadAndDelete(orgID); ok {
-		entry := cached.(*cachedDockerService)
-		if entry.service != nil {
-			entry.service.Close()
+	prefix := orgID.String()
+	dockerServiceCache.Range(func(key, value interface{}) bool {
+		keyStr, ok := key.(string)
+		if !ok {
+			return true
 		}
-	}
+		if keyStr == prefix || strings.HasPrefix(keyStr, prefix+":") {
+			if old, ok := dockerServiceCache.LoadAndDelete(key); ok {
+				entry := old.(*cachedDockerService)
+				if entry.service != nil {
+					entry.service.Close()
+				}
+			}
+		}
+		return true
+	})
 }
 
 // CloseAllDockerServiceCaches closes and removes all cached Docker services.
@@ -313,6 +330,12 @@ func GetDockerServiceFromContext(ctx context.Context) (DockerRepository, error) 
 		orgID = v
 	default:
 		return nil, fmt.Errorf("unexpected organization ID type in context: %T", v)
+	}
+
+	if serverIDStr, _ := ctx.Value(shared_types.ServerIDKey).(string); serverIDStr != "" {
+		if serverID, err := uuid.Parse(serverIDStr); err == nil && serverID != uuid.Nil {
+			return GetDockerServiceForServer(ctx, orgID, serverID)
+		}
 	}
 
 	return GetDockerServiceForOrganization(ctx, orgID)

--- a/api/internal/features/deploy/service/deploy_service.go
+++ b/api/internal/features/deploy/service/deploy_service.go
@@ -20,3 +20,15 @@ func (s *DeployService) GetLatestDeployments(organizationID string, limit int) (
 	}
 	return s.storage.GetLatestDeployments(orgUUID, limit)
 }
+
+func (s *DeployService) GetLatestDeploymentsByServer(organizationID string, serverID string, limit int) ([]shared_types.ApplicationDeployment, error) {
+	orgUUID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, err
+	}
+	serverUUID, err := uuid.Parse(serverID)
+	if err != nil {
+		return nil, err
+	}
+	return s.storage.GetLatestDeploymentsByServer(orgUUID, serverUUID, limit)
+}

--- a/api/internal/features/deploy/service/get_applications.go
+++ b/api/internal/features/deploy/service/get_applications.go
@@ -7,7 +7,7 @@ import (
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
-func (s *DeployService) GetApplications(page string, pageSize string, sortBy string, sortDirection string, organizationID uuid.UUID) ([]shared_types.Application, int, error) {
+func (s *DeployService) GetApplications(page string, pageSize string, sortBy string, sortDirection string, organizationID uuid.UUID, serverID *uuid.UUID) ([]shared_types.Application, int, error) {
 	pageNum, err := strconv.Atoi(page)
 	if err != nil {
 		return nil, 0, err
@@ -16,7 +16,7 @@ func (s *DeployService) GetApplications(page string, pageSize string, sortBy str
 	if err != nil {
 		return nil, 0, err
 	}
-	applications, totalCount, err := s.storage.GetApplications(pageNum, pageSizeNum, sortBy, sortDirection, organizationID)
+	applications, totalCount, err := s.storage.GetApplications(pageNum, pageSizeNum, sortBy, sortDirection, organizationID, serverID)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api/internal/features/deploy/storage/init.go
+++ b/api/internal/features/deploy/storage/init.go
@@ -32,7 +32,7 @@ type DeployRepository interface {
 	AddApplicationLogs(applicationLogs *shared_types.ApplicationLogs) error
 	AddApplicationLogsBatch(logs []shared_types.ApplicationLogs) error
 	AddApplicationStatus(applicationStatus *shared_types.ApplicationStatus) error
-	GetApplications(page int, pageSize int, sortBy string, sortDirection string, organizationID uuid.UUID) ([]shared_types.Application, int, error)
+	GetApplications(page int, pageSize int, sortBy string, sortDirection string, organizationID uuid.UUID, serverID *uuid.UUID) ([]shared_types.Application, int, error)
 	UpdateApplicationStatus(applicationStatus *shared_types.ApplicationStatus) error
 	GetApplicationById(id string, organizationID uuid.UUID) (shared_types.Application, error)
 	AddApplicationDeployment(deployment *shared_types.ApplicationDeployment) error
@@ -59,6 +59,7 @@ type DeployRepository interface {
 	CountFamilyMembers(familyID uuid.UUID) (int, error)
 	ClearFamilyIDIfSingleMember(familyID uuid.UUID) error
 	GetLatestDeployments(organizationID uuid.UUID, limit int) ([]shared_types.ApplicationDeployment, error)
+	GetLatestDeploymentsByServer(organizationID uuid.UUID, serverID uuid.UUID, limit int) ([]shared_types.ApplicationDeployment, error)
 	GetDeployedApplications(organizationID uuid.UUID) ([]shared_types.Application, error)
 	GetLatestS3Deployment(applicationID uuid.UUID) (*shared_types.ApplicationDeployment, error)
 	UpsertComposeServices(applicationID uuid.UUID, services []shared_types.ComposeService) error
@@ -243,21 +244,26 @@ func (s *DeployStorage) AddApplicationLogs(applicationLogs *shared_types.Applica
 	return nil
 }
 
-func (s *DeployStorage) GetApplications(page, pageSize int, sortBy string, sortDirection string, organizationID uuid.UUID) ([]shared_types.Application, int, error) {
+func (s *DeployStorage) GetApplications(page, pageSize int, sortBy string, sortDirection string, organizationID uuid.UUID, serverID *uuid.UUID) ([]shared_types.Application, int, error) {
 	var applications []shared_types.Application
 
 	offset := (page - 1) * pageSize
 
-	totalCount, err := s.DB.NewSelect().
+	countQ := s.DB.NewSelect().
 		Model((*shared_types.Application)(nil)).
-		Where("organization_id = ?", organizationID).
-		Count(s.Ctx)
+		Where("a.organization_id = ?", organizationID)
 
+	if serverID != nil {
+		countQ = countQ.
+			Join("JOIN application_servers aps ON aps.application_id = a.id").
+			Where("aps.server_id = ?", *serverID)
+	}
+
+	totalCount, err := countQ.Count(s.Ctx)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	// Build order expression based on sort parameters
 	orderExpr := s.buildOrderExpression(sortBy, sortDirection)
 
 	query := s.DB.NewSelect().
@@ -267,14 +273,19 @@ func (s *DeployStorage) GetApplications(page, pageSize int, sortBy string, sortD
 		Relation("Domains.ComposeService").
 		Limit(pageSize).
 		Offset(offset).
-		Where("organization_id = ?", organizationID)
+		Where("a.organization_id = ?", organizationID)
+
+	if serverID != nil {
+		query = query.
+			Join("JOIN application_servers aps ON aps.application_id = a.id").
+			Where("aps.server_id = ?", *serverID)
+	}
 
 	if orderExpr != "" {
 		query = query.OrderExpr(orderExpr)
 	}
 
 	err = query.Scan(s.Ctx)
-
 	if err != nil {
 		return nil, 0, err
 	}
@@ -333,6 +344,7 @@ func (s *DeployStorage) GetApplicationById(id string, organizationID uuid.UUID) 
 		Model(&application).
 		Relation("Status").
 		Relation("Domains.ComposeService").
+		Relation("Servers.Server").
 		Where("a.id = ? AND a.organization_id = ?", id, organizationID).
 		Scan(s.Ctx)
 
@@ -680,6 +692,28 @@ func (s *DeployStorage) GetLatestDeployments(organizationID uuid.UUID, limit int
 		Relation("Status").
 		Join("JOIN applications a ON a.id = ad.application_id").
 		Where("a.organization_id = ?", organizationID).
+		Order("ad.created_at DESC").
+		Limit(limit).
+		Scan(s.Ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return deployments, nil
+}
+
+func (s *DeployStorage) GetLatestDeploymentsByServer(organizationID uuid.UUID, serverID uuid.UUID, limit int) ([]shared_types.ApplicationDeployment, error) {
+	var deployments []shared_types.ApplicationDeployment
+
+	err := s.DB.NewSelect().
+		Model(&deployments).
+		Relation("Application").
+		Relation("Status").
+		Join("JOIN applications a ON a.id = ad.application_id").
+		Join("JOIN application_servers aps ON aps.application_id = a.id").
+		Where("a.organization_id = ?", organizationID).
+		Where("aps.server_id = ?", serverID).
 		Order("ad.created_at DESC").
 		Limit(limit).
 		Scan(s.Ctx)

--- a/api/internal/features/machine/controller/backup.go
+++ b/api/internal/features/machine/controller/backup.go
@@ -27,12 +27,12 @@ func (c *MachineController) TriggerBackup(f fuego.ContextNoBody) (*types.Trigger
 	}
 
 	serverID := parseServerID(r)
-	response, err := c.backupService.TriggerBackup(r.Context(), user.ID, orgID, serverID)
+	resp, err := c.backupService.TriggerBackup(r.Context(), user.ID, orgID, serverID)
 	if err != nil {
 		return nil, mapBackupError(err)
 	}
 
-	return response, nil
+	return resp, nil
 }
 
 func (c *MachineController) ListBackups(f fuego.ContextNoBody) (*types.BackupListResponse, error) {
@@ -71,6 +71,9 @@ func (c *MachineController) ListBackups(f fuego.ContextNoBody) (*types.BackupLis
 	if v := f.QueryParam("status"); v != "" {
 		params.Status = strings.TrimSpace(v)
 	}
+	if v := f.QueryParam("server_id"); v != "" {
+		params.ServerID = strings.TrimSpace(v)
+	}
 
 	response, err := c.backupService.ListBackups(r.Context(), orgID, params)
 	if err != nil {
@@ -94,7 +97,8 @@ func (c *MachineController) GetBackupSchedule(f fuego.ContextNoBody) (*types.Bac
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
-	response, err := c.backupService.GetBackupSchedule(r.Context(), orgID)
+	serverID := parseServerID(r)
+	response, err := c.backupService.GetBackupSchedule(r.Context(), orgID, serverID)
 	if err != nil {
 		c.logger.Log(logger.Error, err.Error(), orgID.String())
 		return nil, fuego.HTTPError{Detail: "failed to get backup schedule", Status: http.StatusInternalServerError}
@@ -121,7 +125,8 @@ func (c *MachineController) UpdateBackupSchedule(f fuego.ContextWithBody[types.B
 		return nil, fuego.BadRequestError{Detail: "invalid request body"}
 	}
 
-	response, err := c.backupService.UpdateBackupSchedule(r.Context(), orgID, body)
+	serverID := parseServerID(r)
+	response, err := c.backupService.UpdateBackupSchedule(r.Context(), orgID, serverID, body)
 	if err != nil {
 		c.logger.Log(logger.Error, err.Error(), orgID.String())
 		return nil, fuego.BadRequestError{Detail: err.Error()}

--- a/api/internal/features/machine/controller/init.go
+++ b/api/internal/features/machine/controller/init.go
@@ -45,7 +45,7 @@ func NewMachineController(
 	regService := service.NewRegistrationService(regStore, ffService, nil, l, ctx)
 	return &MachineController{
 		store:               store,
-		service:             service.NewMachineService(store, ctx, l),
+		service:             service.NewMachineService(store, ctx, l, regStore),
 		billingService:      service.NewBillingService(bs),
 		lifecycleService:    service.NewLifecycleService(bs, queue.ExecuteMachineLifecycle),
 		backupService:       service.NewBackupService(bs, backupStore, store.DB),

--- a/api/internal/features/machine/controller/lifecycle.go
+++ b/api/internal/features/machine/controller/lifecycle.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/machine/types"
+	sharedtypes "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
 )
 
@@ -39,6 +41,17 @@ func (c *MachineController) GetMachineStatus(f fuego.ContextNoBody) (*types.Mach
 	serverID := parseServerID(r)
 	if serverID == nil {
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
+	}
+
+	userOwned, _ := c.billingService.IsServerUserOwned(orgID, *serverID)
+	if userOwned {
+		ctx := context.WithValue(r.Context(), sharedtypes.ServerIDKey, serverID.String())
+		response, err := c.service.GetMachineStatus(ctx, orgID)
+		if err != nil {
+			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
+		}
+		return response, nil
 	}
 
 	response, err := c.lifecycleService.GetStatus(r.Context(), orgID, serverID)

--- a/api/internal/features/machine/service/backup.go
+++ b/api/internal/features/machine/service/backup.go
@@ -33,7 +33,7 @@ func (s *BackupService) TriggerBackup(ctx context.Context, userID, orgID uuid.UU
 		return nil, types.ErrMachineNotProvisioned
 	}
 
-	hasRunning, err := s.backupStore.HasInProgressBackup(ctx, orgID)
+	hasRunning, err := s.backupStore.HasInProgressBackup(ctx, orgID, serverID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check backup status: %w", err)
 	}
@@ -75,7 +75,16 @@ func (s *BackupService) ListBackups(ctx context.Context, orgID uuid.UUID, params
 		params.SortOrder = "desc"
 	}
 
-	backups, totalCount, err := s.backupStore.ListByOrg(ctx, orgID, params)
+	var serverUUID *uuid.UUID
+	if params.ServerID != "" {
+		parsed, err := uuid.Parse(params.ServerID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid server_id: %w", err)
+		}
+		serverUUID = &parsed
+	}
+
+	backups, totalCount, err := s.backupStore.ListByOrg(ctx, orgID, serverUUID, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list backups: %w", err)
 	}
@@ -95,7 +104,7 @@ func (s *BackupService) ListBackups(ctx context.Context, orgID uuid.UUID, params
 	}, nil
 }
 
-func (s *BackupService) GetBackupSchedule(ctx context.Context, orgID uuid.UUID) (*types.BackupScheduleResponse, error) {
+func (s *BackupService) GetBackupSchedule(ctx context.Context, orgID uuid.UUID, _ *uuid.UUID) (*types.BackupScheduleResponse, error) {
 	settings, err := utils.GetOrganizationSettings(ctx, s.db, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization settings: %w", err)
@@ -130,7 +139,7 @@ func (s *BackupService) GetBackupSchedule(ctx context.Context, orgID uuid.UUID) 
 	}, nil
 }
 
-func (s *BackupService) UpdateBackupSchedule(ctx context.Context, orgID uuid.UUID, req types.BackupScheduleData) (*types.BackupScheduleResponse, error) {
+func (s *BackupService) UpdateBackupSchedule(ctx context.Context, orgID uuid.UUID, _ *uuid.UUID, req types.BackupScheduleData) (*types.BackupScheduleResponse, error) {
 	if req.Frequency != "daily" && req.Frequency != "weekly" {
 		return nil, fmt.Errorf("invalid frequency: must be 'daily' or 'weekly'")
 	}

--- a/api/internal/features/machine/service/billing.go
+++ b/api/internal/features/machine/service/billing.go
@@ -140,6 +140,10 @@ func (s *BillingService) enqueueResourceUpgrade(ctx context.Context, orgID uuid.
 	})
 }
 
+func (s *BillingService) IsServerUserOwned(orgID uuid.UUID, serverID uuid.UUID) (bool, error) {
+	return s.storage.IsServerUserOwned(orgID, serverID)
+}
+
 func (s *BillingService) GetBillingStatus(orgID uuid.UUID) (*types.MachineBillingResponse, error) {
 	billing, err := s.storage.GetBillingByOrgID(orgID)
 	if err != nil {

--- a/api/internal/features/machine/service/init.go
+++ b/api/internal/features/machine/service/init.go
@@ -4,27 +4,104 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/dashboard"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/machine/storage"
 	"github.com/nixopus/nixopus/api/internal/features/machine/types"
 	sshpkg "github.com/nixopus/nixopus/api/internal/features/ssh"
 	shared_storage "github.com/nixopus/nixopus/api/internal/storage"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	cryptossh "golang.org/x/crypto/ssh"
 )
 
 type MachineService struct {
-	store  *shared_storage.Store
-	ctx    context.Context
-	logger logger.Logger
+	store    *shared_storage.Store
+	regStore *storage.RegistrationStorage
+	ctx      context.Context
+	logger   logger.Logger
 }
 
-func NewMachineService(store *shared_storage.Store, ctx context.Context, l logger.Logger) *MachineService {
+func NewMachineService(store *shared_storage.Store, ctx context.Context, l logger.Logger, regStore *storage.RegistrationStorage) *MachineService {
 	return &MachineService{
-		store:  store,
-		ctx:    ctx,
-		logger: l,
+		store:    store,
+		regStore: regStore,
+		ctx:      ctx,
+		logger:   l,
+	}
+}
+
+func (s *MachineService) GetMachineStatus(ctx context.Context, orgID uuid.UUID) (*types.MachineStateResponse, error) {
+	sshMgr, err := sshpkg.GetSSHManagerFromContext(ctx)
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
+		return nil, fmt.Errorf("failed to connect to server: %w", err)
+	}
+
+	output, err := sshMgr.RunCommand("cat /proc/uptime")
+	if err != nil {
+		return &types.MachineStateResponse{
+			Status:  "success",
+			Message: "Machine status retrieved",
+			Data:    &types.MachineState{Active: false, State: "Stopped"},
+		}, nil
+	}
+
+	s.lazyFillSpecs(ctx, sshMgr, orgID)
+
+	return &types.MachineStateResponse{
+		Status:  "success",
+		Message: "Machine status retrieved",
+		Data:    ParseUptimeToState(output),
+	}, nil
+}
+
+func (s *MachineService) lazyFillSpecs(ctx context.Context, sshMgr *sshpkg.SSHManager, orgID uuid.UUID) {
+	if s.regStore == nil {
+		return
+	}
+
+	serverIDStr, _ := ctx.Value(shared_types.ServerIDKey).(string)
+	serverID, err := uuid.Parse(serverIDStr)
+	if err != nil {
+		return
+	}
+
+	vcpu, mem, disk, err := s.regStore.GetProvisionResources(serverID)
+	if err != nil || (vcpu > 0 && mem > 0 && disk > 0) {
+		return
+	}
+
+	stats, err := dashboard.CollectSystemStats(s.logger, dashboard.GetSystemStatsOptions{
+		CommandExecutor: sshMgr.RunCommand,
+	})
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("lazy fill: failed to collect stats: %s", err.Error()), orgID.String())
+		return
+	}
+
+	cpuCores := stats.CPUCores
+	memMB := int(stats.Memory.Total * 1024)
+	diskGB := int(stats.Disk.Total)
+
+	if cpuCores == 0 && memMB == 0 && diskGB == 0 {
+		return
+	}
+
+	if err := s.regStore.UpdateProvisionResources(serverID, cpuCores, memMB, diskGB); err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("lazy fill: failed to persist specs: %s", err.Error()), orgID.String())
+	}
+}
+
+func ParseUptimeToState(raw string) *types.MachineState {
+	var uptimeSec float64
+	fmt.Sscanf(strings.TrimSpace(raw), "%f", &uptimeSec)
+	return &types.MachineState{
+		Active:    true,
+		State:     "Running",
+		UptimeSec: int64(uptimeSec),
 	}
 }
 

--- a/api/internal/features/machine/storage/backup.go
+++ b/api/internal/features/machine/storage/backup.go
@@ -21,7 +21,7 @@ func NewBackupStorage(db *bun.DB, ctx context.Context) *BackupStorage {
 	return &BackupStorage{DB: db, Ctx: ctx}
 }
 
-func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, params types.BackupListParams) ([]types.MachineBackup, int, error) {
+func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, serverID *uuid.UUID, params types.BackupListParams) ([]types.MachineBackup, int, error) {
 	query := s.DB.NewSelect().
 		Model((*types.MachineBackup)(nil)).
 		Where("mb.organization_id = ?", orgID)
@@ -29,6 +29,15 @@ func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, params t
 	countQuery := s.DB.NewSelect().
 		Model((*types.MachineBackup)(nil)).
 		Where("mb.organization_id = ?", orgID)
+
+	if serverID != nil {
+		serverFilter := func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.Join("JOIN user_provision_details upd ON upd.id = mb.provision_id").
+				Where("(upd.ssh_key_id = ? OR upd.server_id = ?)", *serverID, *serverID)
+		}
+		query = serverFilter(query)
+		countQuery = serverFilter(countQuery)
+	}
 
 	if params.Search != "" {
 		searchPattern := "%" + strings.ToLower(params.Search) + "%"
@@ -80,15 +89,21 @@ func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, params t
 	return backups, totalCount, nil
 }
 
-func (s *BackupStorage) HasInProgressBackup(ctx context.Context, orgID uuid.UUID) (bool, error) {
-	exists, err := s.DB.NewSelect().
+func (s *BackupStorage) HasInProgressBackup(ctx context.Context, orgID uuid.UUID, serverID *uuid.UUID) (bool, error) {
+	q := s.DB.NewSelect().
 		Model((*types.MachineBackup)(nil)).
-		Where("organization_id = ?", orgID).
-		Where("status IN (?)", bun.In([]types.MachineBackupStatus{
+		Where("mb.organization_id = ?", orgID).
+		Where("mb.status IN (?)", bun.In([]types.MachineBackupStatus{
 			types.BackupStatusPending,
 			types.BackupStatusInProgress,
-		})).
-		Exists(ctx)
+		}))
+
+	if serverID != nil {
+		q = q.Join("JOIN user_provision_details upd ON upd.id = mb.provision_id").
+			Where("(upd.ssh_key_id = ? OR upd.server_id = ?)", *serverID, *serverID)
+	}
+
+	exists, err := q.Exists(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to check in-progress backups: %w", err)
 	}

--- a/api/internal/features/machine/storage/billing.go
+++ b/api/internal/features/machine/storage/billing.go
@@ -339,6 +339,19 @@ type ProvisionInfo struct {
 	ServerID      string
 }
 
+func (s *BillingStorage) IsServerUserOwned(orgID uuid.UUID, serverID uuid.UUID) (bool, error) {
+	exists, err := s.DB.NewSelect().
+		TableExpr("user_provision_details AS upd").
+		Where("upd.organization_id = ?", orgID).
+		Where("upd.ssh_key_id = ?", serverID).
+		Where("upd.type = 'user_owned'").
+		Exists(s.Ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check server ownership: %w", err)
+	}
+	return exists, nil
+}
+
 func (s *BillingStorage) GetProvisionInfo(ctx context.Context, orgID uuid.UUID, serverID *uuid.UUID) (*ProvisionInfo, error) {
 	var row UserProvisionDetail
 	q := s.DB.NewSelect().Model(&row).Column("user_id", "lxd_container_name", "server_id")

--- a/api/internal/features/machine/storage/registration.go
+++ b/api/internal/features/machine/storage/registration.go
@@ -158,6 +158,38 @@ func (s *RegistrationStorage) GetActiveUserOwnedMachines(orgID uuid.UUID) ([]api
 	return keys, err
 }
 
+func (s *RegistrationStorage) GetProvisionResources(sshKeyID uuid.UUID) (vcpu, memMB, diskGB int, err error) {
+	var row struct {
+		VcpuCount  int `bun:"vcpu_count"`
+		MemoryMB   int `bun:"memory_mb"`
+		DiskSizeGB int `bun:"disk_size_gb"`
+	}
+	err = s.db.NewSelect().
+		TableExpr("user_provision_details").
+		Column("vcpu_count", "memory_mb", "disk_size_gb").
+		Where("ssh_key_id = ?", sshKeyID).
+		Where("type = 'user_owned'").
+		Limit(1).
+		Scan(s.ctx, &row)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return row.VcpuCount, row.MemoryMB, row.DiskSizeGB, nil
+}
+
+func (s *RegistrationStorage) UpdateProvisionResources(sshKeyID uuid.UUID, vcpu, memMB, diskGB int) error {
+	_, err := s.db.NewUpdate().
+		TableExpr("user_provision_details").
+		Set("vcpu_count = ?", vcpu).
+		Set("memory_mb = ?", memMB).
+		Set("disk_size_gb = ?", diskGB).
+		Set("updated_at = ?", time.Now()).
+		Where("ssh_key_id = ?", sshKeyID).
+		Where("type = 'user_owned'").
+		Exec(s.ctx)
+	return err
+}
+
 func (s *RegistrationStorage) GetProvisionDetailsBySSHKeyID(sshKeyID uuid.UUID) (uuid.UUID, error) {
 	var id uuid.UUID
 	err := s.db.NewSelect().

--- a/api/internal/features/machine/types/backup.go
+++ b/api/internal/features/machine/types/backup.go
@@ -50,6 +50,7 @@ type BackupListParams struct {
 	SortBy    string `json:"sort_by"`
 	SortOrder string `json:"sort_order"`
 	Status    string `json:"status"`
+	ServerID  string `json:"server_id"`
 }
 
 type BackupListResponseData struct {

--- a/api/internal/features/terminal/init.go
+++ b/api/internal/features/terminal/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	sshpkg "github.com/nixopus/nixopus/api/internal/features/ssh"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -45,6 +46,7 @@ type Terminal struct {
 	startedAt time.Time
 
 	TerminalId string
+	ServerID   string
 }
 
 // signalDone closes the done channel exactly once, regardless of which
@@ -98,6 +100,8 @@ func NewTerminal(ctx context.Context, conn *websocket.Conn, wsMu *sync.Mutex, lo
 	if err != nil {
 		return nil, fmt.Errorf("failed to get SSH client: %w", err)
 	}
+	serverIDStr, _ := ctx.Value(shared_types.ServerIDKey).(string)
+
 	terminal := &Terminal{
 		sshManager: sshManager,
 		conn:       conn,
@@ -108,6 +112,7 @@ func NewTerminal(ctx context.Context, conn *websocket.Conn, wsMu *sync.Mutex, lo
 		log:        *log,
 		wsLock:     wsMu,
 		TerminalId: terminalId,
+		ServerID:   serverIDStr,
 		startedAt:  time.Now(),
 	}
 

--- a/api/internal/realtime/dashboard_monitor.go
+++ b/api/internal/realtime/dashboard_monitor.go
@@ -41,21 +41,28 @@ func (s *SocketServer) handleStopDashboardMonitor(conn *websocket.Conn) {
 // Returns:
 //   - nil
 func (s *SocketServer) handleDashboardMonitor(conn *websocket.Conn, msg types.Payload) {
-	s.dashboardMutex.Lock()
-	monitor, exists := s.dashboardMonitors[conn]
-	if !exists {
-		var organizationID, serverID string
-		if msg.Data != nil {
-			if dataMap, ok := msg.Data.(map[string]interface{}); ok {
-				if orgID, ok := dataMap["organization_id"].(string); ok {
-					organizationID = orgID
-				}
-				if sid, ok := dataMap["server_id"].(string); ok {
-					serverID = sid
-				}
+	var organizationID, serverID string
+	if msg.Data != nil {
+		if dataMap, ok := msg.Data.(map[string]interface{}); ok {
+			if orgID, ok := dataMap["organization_id"].(string); ok {
+				organizationID = orgID
+			}
+			if sid, ok := dataMap["server_id"].(string); ok {
+				serverID = sid
 			}
 		}
+	}
 
+	s.dashboardMutex.Lock()
+	monitor, exists := s.dashboardMonitors[conn]
+
+	if exists && monitor.ServerID != serverID {
+		monitor.Stop()
+		delete(s.dashboardMonitors, conn)
+		exists = false
+	}
+
+	if !exists {
 		newMonitor, err := dashboard.NewDashboardMonitor(conn, s.getConnWriteMu(conn), logger.NewLogger(), organizationID, serverID, s.deployController.Service())
 		if err != nil {
 			s.dashboardMutex.Unlock()

--- a/api/internal/realtime/init.go
+++ b/api/internal/realtime/init.go
@@ -2,7 +2,6 @@ package realtime
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -152,7 +151,6 @@ func (s *SocketServer) HandleHTTP(w http.ResponseWriter, r *http.Request) {
 // Returns:
 //   - nil
 func (s *SocketServer) handleDisconnect(conn *websocket.Conn) {
-	fmt.Println("[ws] handleDisconnect: client disconnected, cleaning up")
 	s.conns.Delete(conn)
 	s.orgIDs.Delete(conn)
 
@@ -170,9 +168,7 @@ func (s *SocketServer) handleDisconnect(conn *websocket.Conn) {
 
 	s.terminalMutex.Lock()
 	if terminalSessions, exists := s.terminals[conn]; exists {
-		fmt.Printf("[ws] handleDisconnect: closing %d terminal session(s)\n", len(terminalSessions))
-		for id, terminalSession := range terminalSessions {
-			fmt.Printf("[ws] handleDisconnect: closing terminal %s\n", id)
+		for _, terminalSession := range terminalSessions {
 			terminalSession.Close()
 		}
 		delete(s.terminals, conn)

--- a/api/internal/realtime/read_loop.go
+++ b/api/internal/realtime/read_loop.go
@@ -2,7 +2,7 @@ package realtime
 
 import (
 	"encoding/json"
-	"fmt"
+
 	"github.com/gorilla/websocket"
 	"github.com/nixopus/nixopus/api/internal/types"
 )
@@ -11,13 +11,11 @@ func (s *SocketServer) readLoop(conn *websocket.Conn) {
 	for {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
-			fmt.Printf("[ws] readLoop: read error (conn closing): %v\n", err)
 			return
 		}
 
 		var msg types.Payload
 		if err := json.Unmarshal(message, &msg); err != nil {
-			fmt.Printf("[ws] readLoop: unmarshal error: %v\n", err)
 			s.sendError(conn, "Invalid message format")
 			continue
 		}

--- a/api/internal/realtime/terminal_handler.go
+++ b/api/internal/realtime/terminal_handler.go
@@ -41,9 +41,7 @@ func (s *SocketServer) handleTerminal(conn *websocket.Conn, msg types.Payload) {
 		return
 	}
 
-	if err := term.WriteMessage(input); err != nil {
-		fmt.Printf("[ws] handleTerminal: WriteMessage failed for terminal %s: %v\n", terminalId, err)
-	}
+	term.WriteMessage(input)
 }
 
 // getOrCreateTerminal returns the existing terminal for the given ID or creates
@@ -58,20 +56,21 @@ func (s *SocketServer) getOrCreateTerminal(conn *websocket.Conn, terminalId stri
 	}
 
 	if term, exists := s.terminals[conn][terminalId]; exists {
-		if !term.IsDone() {
+		if term.IsDone() {
+			term.Close()
+			delete(s.terminals[conn], terminalId)
+		} else if term.ServerID != serverID {
+			term.Close()
+			delete(s.terminals[conn], terminalId)
+		} else {
 			return term
 		}
-		fmt.Printf("[ws] getOrCreateTerminal: terminal %s is dead, cleaning up and recreating\n", terminalId)
-		term.Close()
-		delete(s.terminals[conn], terminalId)
 	}
 
 	return s.createTerminal(conn, terminalId, serverID)
 }
 
 func (s *SocketServer) createTerminal(conn *websocket.Conn, terminalId string, serverID string) *terminal.Terminal {
-	fmt.Printf("[ws] createTerminal: creating terminal %s\n", terminalId)
-
 	orgIDVal, ok := s.orgIDs.Load(conn)
 	if !ok || orgIDVal == nil {
 		s.sendError(conn, "Organization ID not found for this connection")
@@ -97,13 +96,11 @@ func (s *SocketServer) createTerminal(conn *websocket.Conn, terminalId string, s
 	log := logger.NewLogger()
 	newTerminal, err := terminal.NewTerminal(ctx, conn, s.getConnWriteMu(conn), &log, terminalId)
 	if err != nil {
-		fmt.Printf("[ws] createTerminal: failed to create terminal %s: %v\n", terminalId, err)
 		s.sendError(conn, fmt.Sprintf("Failed to start terminal: %v", err))
 		return nil
 	}
 	s.terminals[conn][terminalId] = newTerminal
 	go newTerminal.Start()
-	fmt.Printf("[ws] createTerminal: terminal %s started\n", terminalId)
 	return newTerminal
 }
 

--- a/api/internal/scheduler/backup.go
+++ b/api/internal/scheduler/backup.go
@@ -113,7 +113,7 @@ func (b *BackupScheduler) run() {
 }
 
 func (b *BackupScheduler) enqueueIfDue(orgID uuid.UUID, freq string, now time.Time) error {
-	hasRunning, err := b.backupStore.HasInProgressBackup(b.ctx, orgID)
+	hasRunning, err := b.backupStore.HasInProgressBackup(b.ctx, orgID, nil)
 	if err != nil {
 		return fmt.Errorf("check in-progress: %w", err)
 	}

--- a/view/app/machines/[machineId]/apps/application/[id]/deployments/[deployment_id]/page.tsx
+++ b/view/app/machines/[machineId]/apps/application/[id]/deployments/[deployment_id]/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/application/[id]/deployments/[deployment_id]/page';

--- a/view/app/machines/[machineId]/apps/application/[id]/deployments/page.tsx
+++ b/view/app/machines/[machineId]/apps/application/[id]/deployments/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/application/[id]/deployments/page';

--- a/view/app/machines/[machineId]/apps/application/[id]/page.tsx
+++ b/view/app/machines/[machineId]/apps/application/[id]/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/application/[id]/page';

--- a/view/app/machines/[machineId]/apps/application/page.tsx
+++ b/view/app/machines/[machineId]/apps/application/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/application/page';

--- a/view/app/machines/[machineId]/apps/create/[id]/page.tsx
+++ b/view/app/machines/[machineId]/apps/create/[id]/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/create/[id]/page';

--- a/view/app/machines/[machineId]/apps/create/page.tsx
+++ b/view/app/machines/[machineId]/apps/create/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/create/page';

--- a/view/app/machines/[machineId]/apps/github-callback/page.tsx
+++ b/view/app/machines/[machineId]/apps/github-callback/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/apps/github-callback/page';

--- a/view/app/machines/[machineId]/charts/application/[id]/deployments/[deployment_id]/page.tsx
+++ b/view/app/machines/[machineId]/charts/application/[id]/deployments/[deployment_id]/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/application/[id]/deployments/[deployment_id]/page';

--- a/view/app/machines/[machineId]/charts/application/[id]/deployments/page.tsx
+++ b/view/app/machines/[machineId]/charts/application/[id]/deployments/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/application/[id]/deployments/page';

--- a/view/app/machines/[machineId]/charts/application/[id]/page.tsx
+++ b/view/app/machines/[machineId]/charts/application/[id]/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/application/[id]/page';

--- a/view/app/machines/[machineId]/charts/application/page.tsx
+++ b/view/app/machines/[machineId]/charts/application/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/application/page';

--- a/view/app/machines/[machineId]/charts/create/[id]/page.tsx
+++ b/view/app/machines/[machineId]/charts/create/[id]/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/create/[id]/page';

--- a/view/app/machines/[machineId]/charts/create/page.tsx
+++ b/view/app/machines/[machineId]/charts/create/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/create/page';

--- a/view/app/machines/[machineId]/charts/github-callback/page.tsx
+++ b/view/app/machines/[machineId]/charts/github-callback/page.tsx
@@ -1,1 +1,0 @@
-export { default } from '@/app/charts/github-callback/page';

--- a/view/app/machines/[machineId]/layout.tsx
+++ b/view/app/machines/[machineId]/layout.tsx
@@ -1,12 +1,3 @@
-import { MachineProvider } from '@/packages/contexts/machine-context';
-
-export default async function MachineLayout({
-  children,
-  params
-}: {
-  children: React.ReactNode;
-  params: Promise<{ machineId: string }>;
-}) {
-  const { machineId } = await params;
-  return <MachineProvider machineId={machineId}>{children}</MachineProvider>;
+export default function MachineLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
 }

--- a/view/packages/components/machine-switcher.tsx
+++ b/view/packages/components/machine-switcher.tsx
@@ -11,20 +11,12 @@ import {
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useGetServersQuery, useVerifyMachineMutation } from '@/redux/services/servers/serversApi';
-import { useAppDispatch } from '@/redux/hooks';
-import { deployApi } from '@/redux/services/deploy/applicationsApi';
-import { containerApi } from '@/redux/services/container/containerApi';
-import { imagesApi } from '@/redux/services/container/imagesApi';
-import { fileManagersApi } from '@/redux/services/file-manager/fileManagersApi';
 import { useMachineContext } from '@/packages/contexts/machine-context';
 import { toast } from 'sonner';
-
-const PLUGIN_MACHINE_APIS = ['machineLifecycleApi', 'machineBackupApi', 'machineBillingApi'];
 
 export function MachineSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
-  const dispatch = useAppDispatch();
   const { machineId: contextMachineId } = useMachineContext();
   const { data } = useGetServersQuery({ page: 1, page_size: 100 });
   const [verifyMachine] = useVerifyMachineMutation();
@@ -39,19 +31,9 @@ export function MachineSwitcher() {
 
   const currentServer = servers.find((s) => s.id === activeMachineId);
 
-  const resetMachineScopedCache = () => {
-    dispatch(deployApi.util.resetApiState());
-    dispatch(containerApi.util.resetApiState());
-    dispatch(imagesApi.util.resetApiState());
-    dispatch(fileManagersApi.util.resetApiState());
-    PLUGIN_MACHINE_APIS.forEach((path) => dispatch({ type: `${path}/resetApiState` }));
-  };
-
   const handleSelect = (server: (typeof servers)[number]) => {
     if (server.id === activeMachineId) return;
     if (!server.is_active) return;
-
-    resetMachineScopedCache();
 
     const target = urlMatch
       ? `/machines/${server.id}${pathname.replace(urlMatch[0], '')}`
@@ -97,12 +79,7 @@ export function MachineSwitcher() {
                 server.is_active ? 'bg-green-500' : 'bg-red-500'
               )}
             />
-            <div className="flex flex-col min-w-0 flex-1">
-              <span className="truncate text-sm">{server.name}</span>
-              {server.host && (
-                <span className="truncate text-xs text-muted-foreground">{server.host}</span>
-              )}
-            </div>
+            <span className="truncate text-sm flex-1 min-w-0">{server.name}</span>
             {!server.is_active ? (
               <Button
                 variant="ghost"

--- a/view/packages/contexts/machine-context.tsx
+++ b/view/packages/contexts/machine-context.tsx
@@ -1,6 +1,14 @@
 'use client';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
+import { usePathname } from 'next/navigation';
 import { useGetServersQuery } from '@/redux/services/servers/serversApi';
+import { useAppDispatch } from '@/redux/hooks';
+import { deployApi } from '@/redux/services/deploy/applicationsApi';
+import { containerApi } from '@/redux/services/container/containerApi';
+import { imagesApi } from '@/redux/services/container/imagesApi';
+import { fileManagersApi } from '@/redux/services/file-manager/fileManagersApi';
+
+const PLUGIN_MACHINE_APIS = ['machineLifecycleApi', 'machineBackupApi', 'machineBillingApi'];
 
 interface MachineContextValue {
   machineId: string | null;
@@ -18,10 +26,31 @@ interface MachineProviderProps {
 }
 
 export function MachineProvider({ machineId, children }: MachineProviderProps) {
-  const isExplicit = !!machineId;
+  const pathname = usePathname();
+  const dispatch = useAppDispatch();
+
+  const urlMachineId = useMemo(() => {
+    const match = pathname.match(/^\/machines\/([^/]+)/);
+    return match ? match[1] : null;
+  }, [pathname]);
+
+  const explicitId = machineId ?? urlMachineId;
+  const isExplicit = !!explicitId;
   const { data } = useGetServersQuery({ page: 1, page_size: 1 }, { skip: isExplicit });
 
-  const resolvedId = isExplicit ? machineId! : (data?.servers?.[0]?.id ?? null);
+  const resolvedId = isExplicit ? explicitId! : (data?.servers?.[0]?.id ?? null);
+
+  const prevMachineIdRef = useRef<string | null>(resolvedId);
+  useEffect(() => {
+    if (resolvedId && resolvedId !== prevMachineIdRef.current) {
+      prevMachineIdRef.current = resolvedId;
+      dispatch(deployApi.util.resetApiState());
+      dispatch(containerApi.util.resetApiState());
+      dispatch(imagesApi.util.resetApiState());
+      dispatch(fileManagersApi.util.resetApiState());
+      PLUGIN_MACHINE_APIS.forEach((path) => dispatch({ type: `${path}/resetApiState` }));
+    }
+  }, [resolvedId, dispatch]);
 
   const value = useMemo(() => ({ machineId: resolvedId, isExplicit }), [resolvedId, isExplicit]);
 

--- a/view/packages/hooks/ai/use-chat-page.ts
+++ b/view/packages/hooks/ai/use-chat-page.ts
@@ -159,6 +159,8 @@ export function useChatPage(): UseChatPageReturn {
     const language = searchParams.get('repo_language') || '';
     const description = searchParams.get('repo_description') || '';
     const htmlUrl = searchParams.get('repo_html_url') || '';
+    const serverId = searchParams.get('server_id') || '';
+    const serverName = searchParams.get('server_name') || '';
 
     threads.createThread(repoName);
 
@@ -172,16 +174,28 @@ export function useChatPage(): UseChatPageReturn {
     if (description) meta['Description'] = description;
     if (htmlUrl) meta['GitHub URL'] = htmlUrl;
 
-    setSelectedContexts([
+    const contexts: ChatContext[] = [
       {
         type: 'Repository',
         id: repoId,
         label: repoFullName,
         meta
       }
-    ]);
+    ];
 
-    setPendingDeployPrompt(`Deploy "${repoFullName}" as a new application.`);
+    if (serverId) {
+      contexts.push({
+        type: 'Machine',
+        id: serverId,
+        label: serverName || serverId,
+        meta: { ID: serverId }
+      });
+    }
+
+    setSelectedContexts(contexts);
+
+    const serverSuffix = serverName ? ` on server "${serverName}"` : '';
+    setPendingDeployPrompt(`Deploy "${repoFullName}" as a new application${serverSuffix}.`);
     navRouter.replace('/chats');
   }, [threads.isInitialized, searchParams]);
 

--- a/view/packages/hooks/applications/use_application_header.tsx
+++ b/view/packages/hooks/applications/use_application_header.tsx
@@ -14,7 +14,17 @@ import { cn } from '@/lib/utils';
 import { Button } from '@nixopus/ui';
 import { Badge } from '@nixopus/ui';
 import { Input } from '@nixopus/ui';
-import { ExternalLink, RotateCcw, Trash2, Rocket, RefreshCw, X, Plus, Square } from 'lucide-react';
+import {
+  ExternalLink,
+  RotateCcw,
+  Trash2,
+  Rocket,
+  RefreshCw,
+  X,
+  Plus,
+  Square,
+  Server
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -243,6 +253,9 @@ export function useApplicationHeader({ application }: UseApplicationHeaderProps)
     [application]
   );
 
+  const primaryServer =
+    application?.servers?.find((s) => s.is_primary) ?? application?.servers?.[0];
+
   const metadata = useMemo(
     () => (
       <div className="flex flex-wrap items-center gap-2">
@@ -259,6 +272,15 @@ export function useApplicationHeader({ application }: UseApplicationHeaderProps)
         >
           {application?.environment}
         </Badge>
+        {primaryServer?.server?.name && (
+          <Badge
+            variant="outline"
+            className="text-xs gap-1 border-zinc-500/30 text-zinc-500 bg-zinc-500/10"
+          >
+            <Server size={10} />
+            {primaryServer.server.name}
+          </Badge>
+        )}
         {application?.labels && application.labels.length > 0 && (
           <>
             {application.labels.map((label, index) => (
@@ -295,7 +317,15 @@ export function useApplicationHeader({ application }: UseApplicationHeaderProps)
         </AnyPermissionGuard>
       </div>
     ),
-    [application, isAddingLabel, newLabel, isUpdatingLabels, handleLabelKeyDown, handleAddLabel]
+    [
+      application,
+      primaryServer,
+      isAddingLabel,
+      newLabel,
+      isUpdatingLabels,
+      handleLabelKeyDown,
+      handleAddLabel
+    ]
   );
 
   const primaryActions = useMemo(() => {

--- a/view/packages/hooks/applications/use_get_deployed_applications.ts
+++ b/view/packages/hooks/applications/use_get_deployed_applications.ts
@@ -13,6 +13,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { setActiveConnectorId } from '@/redux/features/github-connector/githubConnectorSlice';
 import { useLabelFilter } from './use_label_filter';
 import { getSelfHosted } from '@/redux/conf';
+import { useMachineId } from '@/packages/contexts/machine-context';
 
 /**
  * Hook to get the deployed applications.
@@ -39,6 +40,7 @@ import { getSelfHosted } from '@/redux/conf';
 function useGetDeployedApplications() {
   const [limit, setLimit] = React.useState(10);
   const [currentPage, setCurrentPage] = useState(1);
+  const machineId = useMachineId();
   const {
     data: connectors,
     refetch: GetGithubConnectors,
@@ -51,7 +53,8 @@ function useGetDeployedApplications() {
     isFetching: isFetchingApplications
   } = useGetApplicationsQuery({
     page: currentPage,
-    limit
+    limit,
+    ...(machineId ? { server_id: machineId } : {})
   });
   const {
     filteredAndSortedData: filteredAndSortedApplications,

--- a/view/packages/hooks/applications/use_github_repo_pagination.ts
+++ b/view/packages/hooks/applications/use_github_repo_pagination.ts
@@ -6,6 +6,8 @@ import { GithubRepository } from '@/redux/types/github';
 import { SortOption } from '@/components/ui/sort-selector';
 import { useAppSelector } from '@/redux/hooks';
 import { useDebounce } from '@/packages/hooks/shared/use-debounce';
+import { useMachineId } from '@/packages/contexts/machine-context';
+import { useGetServersQuery } from '@/redux/services/servers/serversApi';
 
 /**
  * @function useGithubRepoPagination
@@ -33,6 +35,9 @@ function useGithubRepoPagination() {
   const [currentPage, setCurrentPage] = useState(1);
   const PAGE_SIZE = 16;
   const router = useRouter();
+  const machineId = useMachineId();
+  const { data: serversData } = useGetServersQuery({ page: 1, page_size: 100 });
+  const currentServer = serversData?.servers?.find((s) => s.id === machineId);
   const [selectedRepository, setSelectedRepository] = React.useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [sortConfig, setSortConfig] = useState<{
@@ -119,7 +124,9 @@ function useGithubRepoPagination() {
         ...(repo.clone_url && { repo_clone_url: repo.clone_url }),
         ...(repo.language && { repo_language: repo.language }),
         ...(repo.description && { repo_description: repo.description }),
-        ...(repo.html_url && { repo_html_url: repo.html_url })
+        ...(repo.html_url && { repo_html_url: repo.html_url }),
+        ...(machineId && { server_id: machineId }),
+        ...(currentServer?.name && { server_name: currentServer.name })
       });
       router.push(`/chats?${params.toString()}`);
     } else {

--- a/view/packages/hooks/dashboard/use-monitor.ts
+++ b/view/packages/hooks/dashboard/use-monitor.ts
@@ -28,22 +28,21 @@ function use_monitor() {
   const startMonitoring = useCallback(() => {
     if (!isReady || !organizationId) return;
 
-    console.log('Starting dashboard monitoring');
+    const payload = {
+      interval: 10,
+      operations: ['get_containers', 'get_system_stats', 'get_deployments'],
+      organization_id: organizationId,
+      ...(serverId ? { server_id: serverId } : {})
+    };
     sendJsonMessage({
       action: 'dashboard_monitor',
-      data: {
-        interval: 10,
-        operations: ['get_containers', 'get_system_stats', 'get_deployments'],
-        organization_id: organizationId,
-        ...(serverId ? { server_id: serverId } : {})
-      }
+      data: payload
     });
     setIsMonitoring(true);
     setLastError(null);
   }, [isReady, sendJsonMessage, organizationId, serverId]);
 
   const stopMonitoring = useCallback(() => {
-    console.log('Stopping dashboard monitoring');
     sendJsonMessage({
       action: 'stop_dashboard_monitor'
     });
@@ -86,10 +85,8 @@ function use_monitor() {
     }
   }, [message, isReady, startMonitoring]);
 
-  // Initialize monitoring when WebSocket is ready
   useEffect(() => {
     if (isReady && !isInitializedRef.current) {
-      console.log('WebSocket ready, initializing monitoring');
       startMonitoring();
       isInitializedRef.current = true;
     }
@@ -106,10 +103,21 @@ function use_monitor() {
     };
   }, [isReady, startMonitoring]);
 
+  const prevServerIdRef = useRef(serverId);
+  useEffect(() => {
+    if (prevServerIdRef.current !== serverId && isReady && isInitializedRef.current) {
+      prevServerIdRef.current = serverId;
+      setContainersData([]);
+      setSystemStats(null);
+      setDeploymentsData([]);
+      stopMonitoring();
+      setTimeout(() => startMonitoring(), 100);
+    }
+  }, [serverId, isReady, startMonitoring, stopMonitoring]);
+
   // Retry monitoring on error
   useEffect(() => {
     if (isReady && !isMonitoring && lastError) {
-      console.log('Retrying monitoring after error');
       reconnectTimeoutRef.current = setTimeout(() => {
         startMonitoring();
       }, 5000);

--- a/view/packages/hooks/shared/use-bread-crumbs.ts
+++ b/view/packages/hooks/shared/use-bread-crumbs.ts
@@ -39,11 +39,12 @@ function useBreadCrumbs() {
       result = pathname.startsWith('/chats')
         ? [dashboardCrumb, ...crumblist]
         : [dashboardCrumb, { href: '/chats', label: 'Chats' }, ...crumblist];
+    } else if (isInMachineContext) {
+      result = [...crumblist];
     } else {
-      result =
-        pathname.startsWith('/chats') || (isInMachineContext && effectivePath.startsWith('/chats'))
-          ? [...crumblist]
-          : [{ href: '/chats', label: 'Chats' }, ...crumblist];
+      result = pathname.startsWith('/chats')
+        ? [...crumblist]
+        : [{ href: '/chats', label: 'Chats' }, ...crumblist];
     }
 
     const machineScopedPaths = ['/charts', '/apps', '/backups'];

--- a/view/redux/services/deploy/applicationsApi.ts
+++ b/view/redux/services/deploy/applicationsApi.ts
@@ -24,12 +24,13 @@ export const deployApi = createApi({
   endpoints: (builder) => ({
     getApplications: builder.query<
       { applications: Application[]; total_count: number },
-      { page: number; limit: number }
+      { page: number; limit: number; server_id?: string }
     >({
-      query: ({ page, limit }) => ({
-        url: `${DEPLOY.GET_APPLICATIONS}?page=${page}&page_size=${limit}`,
-        method: 'GET'
-      }),
+      query: ({ page, limit, server_id }) => {
+        const params = new URLSearchParams({ page: String(page), page_size: String(limit) });
+        if (server_id) params.set('server_id', server_id);
+        return { url: `${DEPLOY.GET_APPLICATIONS}?${params}`, method: 'GET' };
+      },
       providesTags: [{ type: 'Deploy', id: 'LIST' }],
       transformResponse: (response: {
         data: { applications: Application[]; total_count: number };

--- a/view/redux/types/applications.ts
+++ b/view/redux/types/applications.ts
@@ -20,6 +20,19 @@ export type ApplicationDomain = {
   compose_service?: ComposeService;
 };
 
+export type ApplicationServer = {
+  id: string;
+  application_id: string;
+  server_id: string;
+  is_primary: boolean;
+  created_at: string;
+  server?: {
+    id: string;
+    name: string;
+    host?: string;
+  };
+};
+
 export type Application = {
   id: string;
   name: string;
@@ -42,6 +55,7 @@ export type Application = {
   status?: ApplicationStatus;
   logs?: ApplicationLogs[];
   deployments?: ApplicationDeployment[];
+  servers?: ApplicationServer[];
   dockerfile_path?: string;
   base_path?: string;
   labels?: string[];
@@ -183,6 +197,7 @@ export interface CreateProjectRequest {
   port?: number;
   dockerfile_path?: string;
   base_path?: string;
+  server_ids?: string[];
 }
 
 // DeployProjectRequest is used to trigger deployment of an existing project.


### PR DESCRIPTION
## Summary
- BYOS (user-owned) machines now get their status via direct SSH (`cat /proc/uptime`) instead of the hosted lifecycle RPC, with a controller-level branch based on `IsServerUserOwned`
- Machine hardware specs (CPU, RAM, disk) are lazily detected over SSH and persisted to `user_provision_details` on the first successful status call, so the frontend displays accurate resource info
- Frontend multi-machine support improvements: machine-scoped API cache invalidation moved to context provider, application queries pass `server_id`, dashboard monitor restarts on server switch, and stale re-export pages under `/machines/[machineId]/apps` and `/charts` are cleaned up

## Test plan
- [ ] Verify BYOS machine shows "Running" / "Stopped" status correctly on the machines page
- [ ] Confirm CPU, RAM, and disk size populate after the first status poll for a BYOS machine with previously zero specs
- [ ] Verify hosted machines still use the existing lifecycle RPC path (no regression)
- [ ] Switch between machines in the UI and confirm dashboard data resets and reloads for the new server
- [ ] Confirm application list filters by `server_id` when inside a machine context


Made with [Cursor](https://cursor.com)