### PR TITLE
fix: improve sidebar defaults and integrations placement

### DIFF
--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -209,7 +209,7 @@ export function useAgentChat({
   agentId: overrideAgentId,
   readOnly = false,
   contexts = [],
-  autoRunTools = false,
+  autoRunTools = true,
   model,
   onFirstMessage,
   waitForThread

--- a/view/packages/hooks/shared/use-app-sidebar.ts
+++ b/view/packages/hooks/shared/use-app-sidebar.ts
@@ -16,7 +16,7 @@ import { fileManagersApi } from '@/redux/services/file-manager/fileManagersApi';
 import { auditApi } from '@/redux/services/audit';
 import { FeatureFlagsApi } from '@/redux/services/feature-flags/featureFlagsApi';
 import { useState, useMemo, useEffect } from 'react';
-import { Layers, Settings } from 'lucide-react';
+import { Layers, Plug, Settings } from 'lucide-react';
 import { getPluginNavItems } from '@/plugins/registry';
 
 const BROWSE_HIDDEN_URLS = ['/backups', '/chats'];
@@ -32,10 +32,9 @@ const coreNavItems = [
   {
     title: 'navigation.integrations',
     url: '/integrations',
+    icon: Plug,
     resource: 'notification',
-    group: 'settings',
-    section: 'Organization',
-    order: 94
+    order: 41
   },
   {
     title: 'General',

--- a/view/packages/hooks/terminal/use-terminal-state.ts
+++ b/view/packages/hooks/terminal/use-terminal-state.ts
@@ -4,9 +4,9 @@ export const useTerminalState = () => {
   const [isTerminalOpen, setIsTerminalOpen] = useState<boolean>(() => {
     if (typeof window !== 'undefined') {
       const savedState = localStorage.getItem('terminalOpen');
-      return savedState !== null ? JSON.parse(savedState) : true;
+      return savedState !== null ? JSON.parse(savedState) : false;
     }
-    return true;
+    return false;
   });
 
   const toggleTerminal = useCallback((): void => {

--- a/view/packages/layouts/layout.tsx
+++ b/view/packages/layouts/layout.tsx
@@ -95,7 +95,7 @@ function Layout({ children }: LayoutProps) {
   } = useLayout();
 
   return (
-    <SidebarProvider defaultOpen={true}>
+    <SidebarProvider defaultOpen={false}>
       <AppSidebar
         user={user}
         activeOrg={


### PR DESCRIPTION
## Summary
- move Integrations into the Browse sidebar flow and align layout behavior with the sidebar state
- default the app sidebar to collapsed, terminal pane to closed, and tool auto-run to enabled for a smoother first-run UX

## Test plan
- [ ] Verify Browse navigation now includes Integrations in the expected location
- [ ] Confirm defaults on first load: sidebar collapsed, terminal closed, tool auto-run enabled
- [ ] Smoke-test chat and sidebar interactions for regressions