### PR TITLE
feat(chat): add @ mention context chips in chat input

### DIFF
--- a/view/lib/i18n/locales/en/ai.json
+++ b/view/lib/i18n/locales/en/ai.json
@@ -17,6 +17,9 @@
       "attachFile": "Attach file",
       "sendMessage": "Send message"
     },
+    "mentions": {
+      "noResults": "No matching context found"
+    },
     "toolExecution": {
       "label": "Tool execution",
       "askBefore": "Ask before executing",

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -58,12 +58,248 @@ import {
   stripContextFromMessageText
 } from '@/packages/hooks/ai/chat-context';
 import {
+  getActiveMentionToken,
+  flattenMentionItems,
+  filterMentionItems,
+  replaceMentionToken,
+  type MentionItem,
+  type MentionMatch
+} from '@/packages/hooks/ai/chat-mentions';
+import {
   useChatPage,
   useChatMessagesScroll,
   useContextSearch,
   formatTime,
   AVAILABLE_MODELS
 } from '@/packages/hooks/ai/use-chat-page';
+
+function cursorAfterMentionReplace(input: string, match: MentionMatch): number {
+  const left = input.slice(0, match.start);
+  const right = input.slice(match.end);
+  const leftTrim = left.replace(/\s+$/, '');
+  const rightTrim = right.replace(/^\s+/, '');
+  if (leftTrim.length > 0 && rightTrim.length > 0) {
+    return leftTrim.length + 1;
+  }
+  return leftTrim.length;
+}
+
+function ChatMentionSuggestions({
+  open,
+  items,
+  highlightIndex,
+  onHoverIndex,
+  onPick,
+  noResultsText
+}: {
+  open: boolean;
+  items: MentionItem[];
+  highlightIndex: number;
+  onHoverIndex: (index: number) => void;
+  onPick: (item: MentionItem) => void;
+  noResultsText: string;
+}) {
+  if (!open) return null;
+
+  return (
+    <div
+      role="listbox"
+      className="z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-popover text-popover-foreground shadow-md"
+    >
+      {items.length === 0 ? (
+        <div className="px-3 py-2.5 text-xs text-muted-foreground">{noResultsText}</div>
+      ) : (
+        items.map((item, index) => (
+          <button
+            key={item.key}
+            type="button"
+            role="option"
+            aria-selected={index === highlightIndex}
+            onMouseEnter={() => onHoverIndex(index)}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onPick(item);
+            }}
+            className={cn(
+              'flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors',
+              index === highlightIndex ? 'bg-muted' : 'hover:bg-muted/60'
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate">{item.label}</span>
+            <span className="shrink-0 text-xs text-muted-foreground">{item.type}</span>
+          </button>
+        ))
+      )}
+    </div>
+  );
+}
+
+function useChatTextareaMentions({
+  inputValue,
+  setInputValue,
+  contextProviders,
+  onAddContext,
+  textareaRef,
+  onChange,
+  onKeyDown
+}: {
+  inputValue: string;
+  setInputValue: (value: string) => void;
+  contextProviders: ContextProviderData[];
+  onAddContext: (ctx: ChatContext) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}) {
+  const { t } = useTranslation();
+  const noResultsText = t('ai.mentions.noResults' as Parameters<typeof t>[0]);
+
+  const [liveMatch, setLiveMatch] = React.useState<MentionMatch | null>(null);
+  const [highlightIndex, setHighlightIndex] = React.useState(0);
+  const highlightIndexRef = React.useRef(0);
+  const [dismissedMentionStart, setDismissedMentionStart] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    highlightIndexRef.current = highlightIndex;
+  }, [highlightIndex]);
+
+  const allMentionItems = React.useMemo(
+    () => flattenMentionItems(contextProviders),
+    [contextProviders]
+  );
+
+  const filteredItems = React.useMemo(() => {
+    if (!liveMatch) return [];
+    return filterMentionItems(allMentionItems, liveMatch.query);
+  }, [allMentionItems, liveMatch]);
+
+  const listOpen =
+    liveMatch !== null &&
+    !(dismissedMentionStart !== null && liveMatch.start === dismissedMentionStart);
+
+  React.useEffect(() => {
+    setHighlightIndex(0);
+  }, [liveMatch?.start, liveMatch?.query]);
+
+  const syncLiveMatch = React.useCallback((el: HTMLTextAreaElement) => {
+    const m = getActiveMentionToken(el.value, el.selectionStart ?? 0);
+    setLiveMatch(m);
+    setDismissedMentionStart((ds) => {
+      if (ds === null) return null;
+      if (!m || m.start !== ds) return null;
+      return ds;
+    });
+  }, []);
+
+  const pickItem = React.useCallback(
+    (item: MentionItem) => {
+      const el = textareaRef.current;
+      const match = el ? getActiveMentionToken(el.value, el.selectionStart ?? 0) : liveMatch;
+      if (!match) return;
+
+      const value = el?.value ?? inputValue;
+      const next = replaceMentionToken(value, match);
+      onAddContext(item.ctx);
+      setInputValue(next);
+      setDismissedMentionStart(null);
+
+      const pos = cursorAfterMentionReplace(value, match);
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (!ta) return;
+        ta.focus();
+        ta.setSelectionRange(pos, pos);
+        syncLiveMatch(ta);
+      });
+    },
+    [inputValue, liveMatch, onAddContext, setInputValue, syncLiveMatch, textareaRef]
+  );
+
+  const wrappedOnChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(e);
+      syncLiveMatch(e.currentTarget);
+    },
+    [onChange, syncLiveMatch]
+  );
+
+  const wrappedOnKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const el = e.currentTarget;
+      const match = getActiveMentionToken(el.value, el.selectionStart ?? 0);
+      const dismissed =
+        dismissedMentionStart !== null && match && match.start === dismissedMentionStart;
+      const active = Boolean(match && !dismissed);
+      const items = match ? filterMentionItems(allMentionItems, match.query) : [];
+
+      if (active && e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (match) setDismissedMentionStart(match.start);
+        return;
+      }
+
+      if (active && items.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          e.stopPropagation();
+          setHighlightIndex((i) => Math.min(i + 1, items.length - 1));
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          e.stopPropagation();
+          setHighlightIndex((i) => Math.max(i - 1, 0));
+          return;
+        }
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          e.stopPropagation();
+          const idx = Math.min(highlightIndexRef.current, items.length - 1);
+          const item = items[idx];
+          if (item) pickItem(item);
+          return;
+        }
+      }
+
+      onKeyDown(e);
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === 'Home' || e.key === 'End') {
+        queueMicrotask(() => {
+          const ta = textareaRef.current;
+          if (ta) syncLiveMatch(ta);
+        });
+      }
+    },
+    [allMentionItems, dismissedMentionStart, onKeyDown, pickItem, syncLiveMatch, textareaRef]
+  );
+
+  const wrappedOnSelect = React.useCallback(
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+      syncLiveMatch(e.currentTarget);
+    },
+    [syncLiveMatch]
+  );
+
+  const mentionList = (
+    <ChatMentionSuggestions
+      open={listOpen}
+      items={filteredItems}
+      highlightIndex={Math.min(highlightIndex, Math.max(filteredItems.length - 1, 0))}
+      onHoverIndex={setHighlightIndex}
+      onPick={pickItem}
+      noResultsText={noResultsText}
+    />
+  );
+
+  return {
+    mentionList,
+    textareaHandlers: {
+      onChange: wrappedOnChange,
+      onKeyDown: wrappedOnKeyDown,
+      onSelect: wrappedOnSelect
+    }
+  };
+}
 
 function NixopusIcon({ className }: { className?: string }) {
   const { resolvedTheme } = useTheme();
@@ -183,6 +419,7 @@ export function ChatPage() {
             ) : (
               <ChatInput
                 inputValue={page.inputValue}
+                setInputValue={page.setInputValue}
                 isStreaming={page.isStreaming}
                 textareaRef={page.textareaRef}
                 selectedContexts={page.selectedContexts}
@@ -205,6 +442,7 @@ export function ChatPage() {
         ) : showWelcome ? (
           <ChatWelcomeView
             inputValue={page.inputValue}
+            setInputValue={page.setInputValue}
             textareaRef={page.textareaRef}
             selectedContexts={page.selectedContexts}
             contextProviders={page.contextProviders}
@@ -316,6 +554,7 @@ function ToolApprovalBanner({ pending, onApprove, onDecline }: ToolApprovalBanne
 
 interface ChatWelcomeViewProps {
   inputValue: string;
+  setInputValue: (value: string) => void;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   selectedContexts: ChatContext[];
   contextProviders: ContextProviderData[];
@@ -334,6 +573,7 @@ interface ChatWelcomeViewProps {
 
 function ChatWelcomeView({
   inputValue,
+  setInputValue,
   textareaRef,
   selectedContexts,
   contextProviders,
@@ -350,6 +590,15 @@ function ChatWelcomeView({
   onInputFocus
 }: ChatWelcomeViewProps) {
   const { t } = useTranslation();
+  const mentions = useChatTextareaMentions({
+    inputValue,
+    setInputValue,
+    contextProviders,
+    onAddContext,
+    textareaRef,
+    onChange,
+    onKeyDown
+  });
   const currentModelLabel =
     AVAILABLE_MODELS.find((m) => m.id === selectedModel)?.label ?? selectedModel;
 
@@ -374,13 +623,15 @@ function ChatWelcomeView({
             <Textarea
               ref={textareaRef}
               value={inputValue}
-              onChange={onChange}
-              onKeyDown={onKeyDown}
+              onChange={mentions.textareaHandlers.onChange}
+              onKeyDown={mentions.textareaHandlers.onKeyDown}
+              onSelect={mentions.textareaHandlers.onSelect}
               onFocus={onInputFocus}
               placeholder={t('ai.input.placeholder')}
               className="min-h-[52px] max-h-[160px] resize-none border-0 bg-transparent px-4 pt-4 pb-2 text-base focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
               rows={1}
             />
+            <div className="px-4">{mentions.mentionList}</div>
             <div className="flex items-center justify-between px-3 pb-3">
               <div className="flex items-center gap-2 flex-wrap">
                 {selectedContexts.map((ctx) => {
@@ -946,6 +1197,7 @@ function ContextSubMenu({
 
 interface ChatInputProps {
   inputValue: string;
+  setInputValue: (value: string) => void;
   isStreaming: boolean;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   selectedContexts: ChatContext[];
@@ -964,6 +1216,7 @@ interface ChatInputProps {
 
 function ChatInput({
   inputValue,
+  setInputValue,
   isStreaming,
   textareaRef,
   selectedContexts,
@@ -980,6 +1233,15 @@ function ChatInput({
   onStop
 }: ChatInputProps) {
   const { t } = useTranslation();
+  const mentions = useChatTextareaMentions({
+    inputValue,
+    setInputValue,
+    contextProviders,
+    onAddContext,
+    textareaRef,
+    onChange,
+    onKeyDown
+  });
   const currentModelLabel =
     AVAILABLE_MODELS.find((m) => m.id === selectedModel)?.label ?? selectedModel;
 
@@ -1100,16 +1362,20 @@ function ChatInput({
           </DropdownMenu>
         </div>
         <form onSubmit={onSubmit} className="flex gap-3 items-end">
-          <Textarea
-            ref={textareaRef}
-            value={inputValue}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-            placeholder={t('ai.input.placeholder')}
-            className="min-h-[44px] max-h-[120px] resize-none bg-muted/50 border-border/50 focus-visible:ring-primary/30"
-            disabled={isStreaming}
-            rows={1}
-          />
+          <div className="min-w-0 flex-1 flex flex-col gap-0">
+            <Textarea
+              ref={textareaRef}
+              value={inputValue}
+              onChange={mentions.textareaHandlers.onChange}
+              onKeyDown={mentions.textareaHandlers.onKeyDown}
+              onSelect={mentions.textareaHandlers.onSelect}
+              placeholder={t('ai.input.placeholder')}
+              className="min-h-[44px] max-h-[120px] resize-none bg-muted/50 border-border/50 focus-visible:ring-primary/30"
+              disabled={isStreaming}
+              rows={1}
+            />
+            {mentions.mentionList}
+          </div>
           {isStreaming ? (
             <Button
               type="button"

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -88,18 +88,36 @@ function ChatMentionSuggestions({
   onPick: (item: MentionItem) => void;
   noResultsText: string;
 }) {
+  const listRef = React.useRef<HTMLDivElement | null>(null);
+  const optionRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+
+  React.useEffect(() => {
+    if (!open || items.length === 0) return;
+    const option = optionRefs.current[highlightIndex];
+    if (!option) return;
+    option.scrollIntoView({ block: 'nearest' });
+  }, [open, highlightIndex, items.length]);
+
+  React.useEffect(() => {
+    optionRefs.current = optionRefs.current.slice(0, items.length);
+  }, [items.length]);
+
   if (!open) return null;
 
   return (
     <div
+      ref={listRef}
       role="listbox"
-      className="z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-popover text-popover-foreground shadow-md"
+      className="z-10 mt-1 max-h-48 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-md"
     >
       {items.length === 0 ? (
         <div className="px-3 py-2.5 text-xs text-muted-foreground">{noResultsText}</div>
       ) : (
         items.map((item, index) => (
           <button
+            ref={(el) => {
+              optionRefs.current[index] = el;
+            }}
             key={item.key}
             type="button"
             role="option"
@@ -111,7 +129,9 @@ function ChatMentionSuggestions({
             }}
             className={cn(
               'flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors',
-              index === highlightIndex ? 'bg-muted' : 'hover:bg-muted/60'
+              index === highlightIndex
+                ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+                : 'hover:bg-muted/60'
             )}
           >
             <span className="min-w-0 flex-1 truncate">{item.label}</span>

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -141,7 +141,7 @@ function useChatTextareaMentions({
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }) {
   const { t } = useTranslation();
-  const noResultsText = t('ai.context.noItems' as Parameters<typeof t>[0]);
+  const noResultsText = t('ai.mentions.noResults' as Parameters<typeof t>[0]);
 
   const [liveMatch, setLiveMatch] = React.useState<MentionMatch | null>(null);
   const [highlightIndex, setHighlightIndex] = React.useState(0);

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -61,7 +61,7 @@ import {
   getActiveMentionToken,
   flattenMentionItems,
   filterMentionItems,
-  replaceMentionToken,
+  replaceMentionTokenWithCaret,
   type MentionItem,
   type MentionMatch
 } from '@/packages/hooks/ai/chat-mentions';
@@ -72,17 +72,6 @@ import {
   formatTime,
   AVAILABLE_MODELS
 } from '@/packages/hooks/ai/use-chat-page';
-
-function cursorAfterMentionReplace(input: string, match: MentionMatch): number {
-  const left = input.slice(0, match.start);
-  const right = input.slice(match.end);
-  const leftTrim = left.replace(/\s+$/, '');
-  const rightTrim = right.replace(/^\s+/, '');
-  if (leftTrim.length > 0 && rightTrim.length > 0) {
-    return leftTrim.length + 1;
-  }
-  return leftTrim.length;
-}
 
 function ChatMentionSuggestions({
   open,
@@ -237,15 +226,14 @@ function useChatTextareaMentions({
       if (!match) return;
 
       const value = el.value;
-      const next = replaceMentionToken(value, match);
+      const { value: next, caret: pos } = replaceMentionTokenWithCaret(value, match);
       onAddContext(item.ctx);
       setDismissedMentionStart(null);
 
-      const pos = cursorAfterMentionReplace(value, match);
       pendingCaretAfterPickRef.current = { pos, expectedValue: next };
       setInputValue(next);
     },
-    [onAddContext, setInputValue]
+    [onAddContext, setInputValue, textareaRef]
   );
 
   const wrappedOnChange = React.useCallback(

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -152,12 +152,15 @@ function useChatTextareaMentions({
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }) {
   const { t } = useTranslation();
-  const noResultsText = t('ai.mentions.noResults' as Parameters<typeof t>[0]);
+  const noResultsText = t('ai.context.noItems' as Parameters<typeof t>[0]);
 
   const [liveMatch, setLiveMatch] = React.useState<MentionMatch | null>(null);
   const [highlightIndex, setHighlightIndex] = React.useState(0);
   const highlightIndexRef = React.useRef(0);
   const [dismissedMentionStart, setDismissedMentionStart] = React.useState<number | null>(null);
+  const pendingCaretAfterPickRef = React.useRef<{ pos: number; expectedValue: string } | null>(
+    null
+  );
 
   React.useEffect(() => {
     highlightIndexRef.current = highlightIndex;
@@ -181,8 +184,9 @@ function useChatTextareaMentions({
     setHighlightIndex(0);
   }, [liveMatch?.start, liveMatch?.query]);
 
-  const syncLiveMatch = React.useCallback((el: HTMLTextAreaElement) => {
-    const m = getActiveMentionToken(el.value, el.selectionStart ?? 0);
+  const reconcileFromValueAndCursor = React.useCallback((value: string, cursor: number) => {
+    const c = Math.max(0, Math.min(cursor, value.length));
+    const m = getActiveMentionToken(value, c);
     setLiveMatch(m);
     setDismissedMentionStart((ds) => {
       if (ds === null) return null;
@@ -191,28 +195,57 @@ function useChatTextareaMentions({
     });
   }, []);
 
+  const syncLiveMatch = React.useCallback(
+    (el: HTMLTextAreaElement) => {
+      reconcileFromValueAndCursor(el.value, el.selectionStart ?? 0);
+    },
+    [reconcileFromValueAndCursor]
+  );
+
+  React.useLayoutEffect(() => {
+    const pending = pendingCaretAfterPickRef.current;
+    if (pending && inputValue !== pending.expectedValue) {
+      pendingCaretAfterPickRef.current = null;
+    }
+
+    const el = textareaRef.current;
+    const stillPending = pendingCaretAfterPickRef.current;
+
+    if (stillPending && inputValue === stillPending.expectedValue) {
+      pendingCaretAfterPickRef.current = null;
+      const p = Math.max(0, Math.min(stillPending.pos, inputValue.length));
+      if (el) {
+        el.focus();
+        el.setSelectionRange(p, p);
+      }
+      reconcileFromValueAndCursor(inputValue, p);
+      return;
+    }
+
+    let cursor = inputValue.length;
+    if (el && el.value === inputValue) {
+      cursor = Math.min(el.selectionStart ?? inputValue.length, inputValue.length);
+    }
+    reconcileFromValueAndCursor(inputValue, cursor);
+  }, [inputValue, reconcileFromValueAndCursor, textareaRef]);
+
   const pickItem = React.useCallback(
     (item: MentionItem) => {
       const el = textareaRef.current;
-      const match = el ? getActiveMentionToken(el.value, el.selectionStart ?? 0) : liveMatch;
+      if (!el) return;
+      const match = getActiveMentionToken(el.value, el.selectionStart ?? 0);
       if (!match) return;
 
-      const value = el?.value ?? inputValue;
+      const value = el.value;
       const next = replaceMentionToken(value, match);
       onAddContext(item.ctx);
-      setInputValue(next);
       setDismissedMentionStart(null);
 
       const pos = cursorAfterMentionReplace(value, match);
-      requestAnimationFrame(() => {
-        const ta = textareaRef.current;
-        if (!ta) return;
-        ta.focus();
-        ta.setSelectionRange(pos, pos);
-        syncLiveMatch(ta);
-      });
+      pendingCaretAfterPickRef.current = { pos, expectedValue: next };
+      setInputValue(next);
     },
-    [inputValue, liveMatch, onAddContext, setInputValue, syncLiveMatch, textareaRef]
+    [onAddContext, setInputValue]
   );
 
   const wrappedOnChange = React.useCallback(

--- a/view/packages/hooks/ai/chat-mentions.ts
+++ b/view/packages/hooks/ai/chat-mentions.ts
@@ -1,0 +1,110 @@
+import type { ChatContext, ContextProviderData } from './chat-context';
+
+export interface MentionMatch {
+  start: number;
+  end: number;
+  query: string;
+}
+
+export interface MentionItem {
+  key: string;
+  label: string;
+  type: string;
+  ctx: ChatContext;
+}
+
+const OPEN_BRACKETS = new Set(['(', '[', '{', '<']);
+
+function isMentionBoundaryBefore(input: string, atIndex: number): boolean {
+  if (atIndex === 0) return true;
+  const prev = input[atIndex - 1]!;
+  if (/\s/.test(prev)) return true;
+  if (OPEN_BRACKETS.has(prev)) return true;
+  return false;
+}
+
+/**
+ * Nearest @-mention before `cursor`: @ has a valid left boundary, and there is
+ * no whitespace in the query segment between @ and the cursor.
+ */
+export function getActiveMentionToken(input: string, cursor: number): MentionMatch | null {
+  const c = Math.max(0, Math.min(cursor, input.length));
+
+  let at = -1;
+  for (let i = c - 1; i >= 0; i--) {
+    if (input.charCodeAt(i) !== 64 /* @ */) continue;
+    if (isMentionBoundaryBefore(input, i)) {
+      at = i;
+      break;
+    }
+  }
+  if (at === -1) return null;
+
+  const after = input.slice(at + 1, c);
+  if (/\s/.test(after)) return null;
+
+  return {
+    start: at,
+    end: c,
+    query: after.toLowerCase()
+  };
+}
+
+export function flattenMentionItems(providers: ContextProviderData[]): MentionItem[] {
+  const out: MentionItem[] = [];
+  for (const p of providers) {
+    for (const ctx of p.items) {
+      out.push({
+        key: `${ctx.type}:${ctx.id}`,
+        label: ctx.label,
+        type: ctx.type,
+        ctx
+      });
+    }
+  }
+  return out;
+}
+
+type Rank = 0 | 1;
+
+function mentionRank(labelLower: string, q: string): Rank | null {
+  if (q.length === 0) return 0;
+  if (labelLower.startsWith(q)) return 0;
+  if (labelLower.includes(q)) return 1;
+  return null;
+}
+
+export function filterMentionItems(items: MentionItem[], query: string, limit = 8): MentionItem[] {
+  const q = query.toLowerCase();
+  const scored: { item: MentionItem; rank: Rank; labelLower: string }[] = [];
+
+  for (const item of items) {
+    const labelLower = item.label.toLowerCase();
+    const rank = mentionRank(labelLower, q);
+    if (rank === null) continue;
+    scored.push({ item, rank, labelLower });
+  }
+
+  scored.sort((a, b) => {
+    if (a.rank !== b.rank) return a.rank - b.rank;
+    const lbl = a.labelLower.localeCompare(b.labelLower);
+    if (lbl !== 0) return lbl;
+    const typ = a.item.type.localeCompare(b.item.type);
+    if (typ !== 0) return typ;
+    return a.item.key.localeCompare(b.item.key);
+  });
+
+  return scored.slice(0, limit).map((s) => s.item);
+}
+
+/** Remove the matched @token span and collapse spaces at the join. */
+export function replaceMentionToken(input: string, match: MentionMatch): string {
+  const left = input.slice(0, match.start);
+  const right = input.slice(match.end);
+  const leftTrim = left.replace(/\s+$/, '');
+  const rightTrim = right.replace(/^\s+/, '');
+  if (leftTrim.length > 0 && rightTrim.length > 0) {
+    return `${leftTrim} ${rightTrim}`;
+  }
+  return `${leftTrim}${rightTrim}`;
+}

--- a/view/packages/hooks/ai/chat-mentions.ts
+++ b/view/packages/hooks/ai/chat-mentions.ts
@@ -97,14 +97,25 @@ export function filterMentionItems(items: MentionItem[], query: string, limit = 
   return scored.slice(0, limit).map((s) => s.item);
 }
 
-/** Remove the matched @token span and collapse spaces at the join. */
-export function replaceMentionToken(input: string, match: MentionMatch): string {
+/**
+ * Remove the matched @token span, collapse spaces at the join, and return the
+ * caret index suitable for continuing typing after the join.
+ */
+export function replaceMentionTokenWithCaret(
+  input: string,
+  match: MentionMatch
+): { value: string; caret: number } {
   const left = input.slice(0, match.start);
   const right = input.slice(match.end);
   const leftTrim = left.replace(/\s+$/, '');
   const rightTrim = right.replace(/^\s+/, '');
   if (leftTrim.length > 0 && rightTrim.length > 0) {
-    return `${leftTrim} ${rightTrim}`;
+    return { value: `${leftTrim} ${rightTrim}`, caret: leftTrim.length + 1 };
   }
-  return `${leftTrim}${rightTrim}`;
+  return { value: `${leftTrim}${rightTrim}`, caret: leftTrim.length };
+}
+
+/** Remove the matched @token span and collapse spaces at the join. */
+export function replaceMentionToken(input: string, match: MentionMatch): string {
+  return replaceMentionTokenWithCaret(input, match).value;
 }


### PR DESCRIPTION
## Summary
- add `@` mention parsing helpers for active token detection, ranking, filtering, and token replacement
- wire mention suggestions into both welcome and main chat inputs with keyboard support (up/down, enter to pick, escape to dismiss)
- add mention no-results copy and improve combobox UX with visible active-row highlighting, auto-scroll to highlighted item, and hidden scrollbar

## Test plan
- [ ] Type `@` in welcome input and verify suggestion list opens
- [ ] Use ArrowDown/ArrowUp and confirm highlighted option is visible and scrolls into view
- [ ] Press Enter on a highlighted option and verify a context chip is added and `@token` text is removed
- [ ] Verify Escape dismisses the suggestion list
- [ ] Repeat mention flow in main chat input and confirm behavior matches welcome input
- [ ] Type an unmatched query (e.g. `@zzzzzz`) and verify "No matching context found" is shown