### PR TITLE
feat(chat): add guided onboarding prefill flow

### DIFF
--- a/docs/superpowers/specs/2026-04-14-new-user-guided-chat-prefill-design.md
+++ b/docs/superpowers/specs/2026-04-14-new-user-guided-chat-prefill-design.md
@@ -1,0 +1,165 @@
+# New User Guided Chat Prefill Design
+
+Date: 2026-04-14
+Status: Approved for implementation planning
+Owner: Chat onboarding flow
+
+## Goal
+
+Guide first-time users through what Nixopus can do by preloading a starter prompt and attaching a default sample repository context in the chat welcome screen.
+
+The prefill should feel assistive, not forced:
+
+- Never auto-send.
+- Keep the prompt editable.
+- Preserve user control of when to send.
+
+## Product Decision
+
+Chosen behavior:
+
+1. Prefill guided starter prompt + attach sample repository context.
+2. User must click Send manually.
+3. First-time behavior is global to the account experience.
+4. If GitHub is not connected, keep showing the guided prefill on each visit.
+5. Once GitHub is connected and guided prefill has been shown once, stop showing it.
+
+## UX Contract
+
+When the chat page is in welcome state (no current messages):
+
+- If `githubConnected === false`: show guided prefill every visit.
+- If `githubConnected === true` and `guidedPrefillSeen === false`: show guided prefill once and mark as seen.
+- If `githubConnected === true` and `guidedPrefillSeen === true`: show default empty welcome state.
+
+Interaction rules:
+
+- Guided prompt text is prefilled in the input box.
+- Default sample repository is attached as a chat context automatically.
+- Input remains editable.
+- Prompt is not auto-submitted.
+- If user already typed text, do not overwrite it.
+- If user clears/edits prefill, do not re-inject in the same session view.
+- Show helper copy near input: "Starter prompt loaded - edit before sending."
+
+## Architecture and Component Boundaries
+
+Primary integration point:
+
+- `view/packages/hooks/ai/use-chat-page.ts`
+
+Reason:
+
+- Existing prefill behavior (`pendingDeployPrompt`) already lives here.
+- It already orchestrates welcome state, thread setup, and input updates.
+
+UI rendering point:
+
+- `view/packages/components/ai-chat.tsx`
+
+Reason:
+
+- Renders `ChatWelcomeView` and welcome input.
+- Can render helper text and consume guided-prefill state exposed by the hook.
+
+## State Model
+
+Local persisted flag:
+
+- `chat_guided_prefill_seen` (localStorage boolean)
+
+Session-only guard:
+
+- in-memory ref to prevent repeated reinjection after user interaction in a single mounted view.
+
+Derived decision input:
+
+- `githubConnected` (from existing GitHub connection source)
+- `isThreadsInitialized`
+- welcome state (`messages.length === 0` + existing welcome criteria)
+- current input emptiness (`inputValue.trim().length === 0`)
+
+Derived output:
+
+- `shouldInjectGuidedPrefill: boolean`
+- `guidedPrefillPayload` with:
+  - `promptText`
+  - `sampleRepoContext` (`ChatContext` shape)
+
+## Data Flow
+
+1. Chat page reaches welcome-eligible state.
+2. Hook computes eligibility for guided prefill:
+   - `!githubConnected` OR (`githubConnected && !guidedPrefillSeen`)
+3. If eligible and input is empty, hook:
+   - sets input value to guided prompt text.
+   - adds sample repository context (deduped).
+4. If GitHub is connected, mark `chat_guided_prefill_seen = true` after successful injection.
+5. User edits or sends manually via existing submit flow.
+6. No auto-submit path is introduced.
+
+## Precedence Rules
+
+To avoid conflicting prefills:
+
+- Deploy deep-link prefill (`pendingDeployPrompt`) has higher priority.
+- Guided prefill runs only when deploy prefill is not active.
+- Guided prefill runs only in welcome state.
+
+## Error Handling and Fallbacks
+
+- If sample repository context data cannot be built, still inject prompt text.
+- If GitHub connection status is unknown or fails to load, treat as not connected for safe onboarding behavior.
+- If localStorage is unavailable, fallback to session-only behavior (no crash).
+- If sample repo context already exists in selected contexts, do not duplicate.
+
+## Telemetry (Recommended)
+
+Track lightweight events:
+
+- `guided_prefill_shown`
+- `guided_prefill_sent`
+- `guided_prefill_edited_before_send`
+- `guided_prefill_cleared`
+
+Purpose:
+
+- Validate whether onboarding guidance helps activation without increasing friction.
+
+## Verification Strategy (Manual Only)
+
+Per request, no automated tests are required for this change.
+
+Manual verification checklist:
+
+1. New user with GitHub disconnected:
+   - guided prefill appears on welcome.
+   - sample repo context is attached.
+   - no auto-send.
+   - revisiting chat shows prefill again.
+2. User connects GitHub:
+   - guided prefill appears once.
+   - after reload/revisit, prefill no longer appears.
+3. Existing user with seen flag and GitHub connected:
+   - normal empty welcome input.
+4. User starts typing before injection condition resolves:
+   - typed input is preserved (not overwritten).
+5. Deploy deep-link case:
+   - deploy prefill still appears and has precedence.
+
+## Out of Scope
+
+- Server-synced onboarding flags across devices.
+- New backend storage for onboarding state.
+- Full onboarding tour orchestration beyond chat prefill + sample repo context.
+
+## Risks and Mitigations
+
+Risk: Users may feel forced if behavior repeats too often while disconnected.
+Mitigation: Keep prompt editable, never auto-send, and use short helper copy.
+
+Risk: Prefill collisions with existing flows.
+Mitigation: Explicit precedence rules and single hook integration point.
+
+Risk: Local-only seen flag not shared across devices.
+Mitigation: Accept for now; leave migration path open for server-backed flags later.

--- a/view/lib/i18n/locales/en/ai.json
+++ b/view/lib/i18n/locales/en/ai.json
@@ -2,7 +2,8 @@
   "ai": {
     "title": "Nixopus AI",
     "emptyState": {
-      "title": "How can I help you?",
+      "title": "New to Nixopus? Start with a guided sample app deployment.",
+      "returningTitle": "What do you want to do next?",
       "description": "Ask me anything about your deployments, configurations, or get help with troubleshooting.",
       "tryAskingAbout": "Try asking about"
     },
@@ -12,7 +13,8 @@
       "envVars": "Help me configure environment variables"
     },
     "input": {
-      "placeholder": "Ask me anything...",
+      "placeholder": "Type: \"Guide me through deploying the sample app and explain each step.\"",
+      "returningPlaceholder": "Ask about deployments, logs, domains, backups, or troubleshooting.",
       "hint": "Press Enter to send, Shift + Enter for new line",
       "attachFile": "Attach file",
       "sendMessage": "Send message"
@@ -47,6 +49,18 @@
       "title": "Tool approval required",
       "approve": "Approve",
       "decline": "Decline"
+    },
+    "guidedPrefill": {
+      "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
+      "helperText": "Starter prompt loaded - edit before sending.",
+      "suggestions": {
+        "overview": "Explain what this sample repo does in Nixopus",
+        "deploy": "Deploy this sample app step by step",
+        "tour": "Give me a beginner tour from repo to live URL"
+      },
+      "sampleRepo": {
+        "label": "nixopus/sample-app"
+      }
     },
     "threads": {
       "newChat": "New Chat",

--- a/view/lib/i18n/locales/es/ai.json
+++ b/view/lib/i18n/locales/es/ai.json
@@ -13,6 +13,13 @@
     "input": {
       "placeholder": "Pregunta lo que quieras...",
       "hint": "Presiona Enter para enviar, Shift + Enter para nueva línea"
+    },
+    "guidedPrefill": {
+      "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
+      "helperText": "Starter prompt loaded - edit before sending.",
+      "sampleRepo": {
+        "label": "nixopus/sample-app"
+      }
     }
   }
 }

--- a/view/lib/i18n/locales/fr/ai.json
+++ b/view/lib/i18n/locales/fr/ai.json
@@ -13,6 +13,13 @@
     "input": {
       "placeholder": "Demandez n'importe quoi...",
       "hint": "Appuyez sur Entrée pour envoyer, Shift + Entrée pour nouvelle ligne"
+    },
+    "guidedPrefill": {
+      "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
+      "helperText": "Starter prompt loaded - edit before sending.",
+      "sampleRepo": {
+        "label": "nixopus/sample-app"
+      }
     }
   }
 }

--- a/view/lib/i18n/locales/kn/ai.json
+++ b/view/lib/i18n/locales/kn/ai.json
@@ -13,6 +13,13 @@
     "input": {
       "placeholder": "ಏನಾದರೂ ಕೇಳಿ...",
       "hint": "ಕಳುಹಿಸಲು Enter ಒತ್ತಿ, ಹೊಸ ಸಾಲಿಗೆ Shift + Enter"
+    },
+    "guidedPrefill": {
+      "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
+      "helperText": "Starter prompt loaded - edit before sending.",
+      "sampleRepo": {
+        "label": "nixopus/sample-app"
+      }
     }
   }
 }

--- a/view/lib/i18n/locales/ml/ai.json
+++ b/view/lib/i18n/locales/ml/ai.json
@@ -13,6 +13,13 @@
     "input": {
       "placeholder": "എന്തെങ്കിലും ചോദിക്കുക...",
       "hint": "അയയ്ക്കാൻ Enter അമർത്തുക, പുതിയ വരിയിലേക്ക് Shift + Enter"
+    },
+    "guidedPrefill": {
+      "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
+      "helperText": "Starter prompt loaded - edit before sending.",
+      "sampleRepo": {
+        "label": "nixopus/sample-app"
+      }
     }
   }
 }

--- a/view/packages/components/ai-chat.tsx
+++ b/view/packages/components/ai-chat.tsx
@@ -206,6 +206,7 @@ export function ChatPage() {
           <ChatWelcomeView
             inputValue={page.inputValue}
             textareaRef={page.textareaRef}
+            showGuidedPrefillHint={page.showGuidedPrefillHint}
             selectedContexts={page.selectedContexts}
             contextProviders={page.contextProviders}
             autoRunTools={page.autoRunTools}
@@ -330,6 +331,7 @@ interface ChatWelcomeViewProps {
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onSuggestionClick: (text: string) => void;
   onInputFocus?: () => void;
+  showGuidedPrefillHint: boolean;
 }
 
 function ChatWelcomeView({
@@ -347,17 +349,26 @@ function ChatWelcomeView({
   onKeyDown,
   onChange,
   onSuggestionClick,
-  onInputFocus
+  onInputFocus,
+  showGuidedPrefillHint
 }: ChatWelcomeViewProps) {
   const { t } = useTranslation();
   const currentModelLabel =
     AVAILABLE_MODELS.find((m) => m.id === selectedModel)?.label ?? selectedModel;
 
-  const suggestions = [
-    t('ai.suggestions.deploy'),
-    t('ai.suggestions.logs'),
-    t('ai.suggestions.envVars')
-  ];
+  const suggestions = showGuidedPrefillHint
+    ? [
+        t('ai.guidedPrefill.suggestions.overview'),
+        t('ai.guidedPrefill.suggestions.deploy'),
+        t('ai.guidedPrefill.suggestions.tour')
+      ]
+    : [t('ai.suggestions.deploy'), t('ai.suggestions.logs'), t('ai.suggestions.envVars')];
+  const welcomeTitle = showGuidedPrefillHint
+    ? t('ai.emptyState.title')
+    : t('ai.emptyState.returningTitle');
+  const welcomePlaceholder = showGuidedPrefillHint
+    ? t('ai.input.placeholder')
+    : t('ai.input.returningPlaceholder');
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-4 pb-12">
@@ -366,7 +377,7 @@ function ChatWelcomeView({
           <div className="flex items-center justify-center size-12 rounded-2xl bg-primary/10">
             <NixopusIcon className="size-6" />
           </div>
-          <h2 className="text-xl font-semibold text-foreground">{t('ai.emptyState.title')}</h2>
+          <h2 className="text-xl font-semibold text-foreground">{welcomeTitle}</h2>
         </div>
 
         <div className="rounded-2xl border border-border bg-muted/20 shadow-sm focus-within:border-primary/30 focus-within:shadow-md transition-all">
@@ -377,8 +388,8 @@ function ChatWelcomeView({
               onChange={onChange}
               onKeyDown={onKeyDown}
               onFocus={onInputFocus}
-              placeholder={t('ai.input.placeholder')}
-              className="min-h-[52px] max-h-[160px] resize-none border-0 bg-transparent px-4 pt-4 pb-2 text-base focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+              placeholder={welcomePlaceholder}
+              className="min-h-[72px] max-h-[220px] resize-none overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden border-0 bg-transparent px-4 pt-4 pb-2 text-base focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
               rows={1}
             />
             <div className="flex items-center justify-between px-3 pb-3">
@@ -1106,7 +1117,7 @@ function ChatInput({
             onChange={onChange}
             onKeyDown={onKeyDown}
             placeholder={t('ai.input.placeholder')}
-            className="min-h-[44px] max-h-[120px] resize-none bg-muted/50 border-border/50 focus-visible:ring-primary/30"
+            className="min-h-[64px] max-h-[220px] resize-none overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden bg-muted/50 border-border/50 focus-visible:ring-primary/30"
             disabled={isStreaming}
             rows={1}
           />

--- a/view/packages/hooks/ai/guided-prefill.ts
+++ b/view/packages/hooks/ai/guided-prefill.ts
@@ -1,0 +1,41 @@
+import type { ChatContext } from './chat-context';
+
+export interface GuidedPrefillPayload {
+  promptText: string;
+  sampleRepoContext: ChatContext;
+}
+
+export function getDefaultGuidedPrompt(t: (key: string) => string): string {
+  return t('ai.guidedPrefill.defaultPrompt');
+}
+
+export function buildSampleRepoContext(t: (key: string) => string): ChatContext {
+  return {
+    type: 'Repository',
+    id: 'sample-repo-default',
+    label: t('ai.guidedPrefill.sampleRepo.label'),
+    meta: {
+      Language: 'TypeScript',
+      Branch: 'main',
+      Visibility: 'public'
+    }
+  };
+}
+
+/** True when input and contexts still match the guided starter (same rules as injection). */
+export function matchesGuidedPrefillSnapshot(
+  inputValue: string,
+  contexts: ChatContext[],
+  translate: (key: string) => string
+): boolean {
+  const promptText = getDefaultGuidedPrompt((key) =>
+    key === 'ai.guidedPrefill.defaultPrompt' ? translate('ai.guidedPrefill.defaultPrompt') : key
+  );
+  if (inputValue !== promptText) return false;
+  const sampleRepoContext = buildSampleRepoContext((key) =>
+    key === 'ai.guidedPrefill.sampleRepo.label'
+      ? translate('ai.guidedPrefill.sampleRepo.label')
+      : key
+  );
+  return contexts.some((c) => c.type === sampleRepoContext.type && c.id === sampleRepoContext.id);
+}

--- a/view/packages/hooks/ai/use-chat-page.ts
+++ b/view/packages/hooks/ai/use-chat-page.ts
@@ -19,6 +19,13 @@ import {
 } from './chat-context';
 import { useMemorySearch, type MemorySearchResult } from './use-memory-search';
 import { getSelfHosted } from '@/redux/conf';
+import { useGetAllGithubConnectorQuery } from '@/redux/services/connector/githubConnectorApi';
+import { useGetApplicationsQuery } from '@/redux/services/deploy/applicationsApi';
+import {
+  buildSampleRepoContext,
+  getDefaultGuidedPrompt,
+  matchesGuidedPrefillSnapshot
+} from './guided-prefill';
 
 function useLocalStorageState(key: string, defaultValue: boolean) {
   const [value, setValue] = useState(() => {
@@ -89,6 +96,7 @@ export interface UseChatPageReturn {
   readOnly: boolean;
   refreshThreads: () => void;
   isRefreshing: boolean;
+  showGuidedPrefillHint: boolean;
 }
 
 export function useChatPage(): UseChatPageReturn {
@@ -107,6 +115,20 @@ export function useChatPage(): UseChatPageReturn {
   const [pendingDeployPrompt, setPendingDeployPrompt] = useState<string | null>(null);
   const repoParamsHandledRef = useRef(false);
   const [isSelfHosted, setIsSelfHosted] = useState(false);
+
+  const { data: githubConnectors, isLoading: isGithubConnectorsLoading } =
+    useGetAllGithubConnectorQuery();
+  const { data: applicationsData, isLoading: isApplicationsLoading } = useGetApplicationsQuery({
+    page: 1,
+    limit: 1
+  });
+  const githubConnected = Boolean(githubConnectors && githubConnectors.length > 0);
+  const hasDeployedApps = Boolean(
+    (applicationsData?.total_count ?? applicationsData?.applications?.length ?? 0) > 0
+  );
+
+  const guidedPrefillInjectedSessionRef = useRef(false);
+  const [showGuidedPrefillHint, setShowGuidedPrefillHint] = useState(false);
 
   useEffect(() => {
     getSelfHosted().then(setIsSelfHosted);
@@ -201,6 +223,72 @@ export function useChatPage(): UseChatPageReturn {
     }
   }, [pendingDeployPrompt, threads.activeThreadId]);
 
+  useEffect(() => {
+    setShowGuidedPrefillHint(false);
+  }, [threads.activeThreadId]);
+
+  useEffect(() => {
+    if (!showGuidedPrefillHint) return;
+    const translate = (key: string) =>
+      key === 'ai.guidedPrefill.defaultPrompt'
+        ? t('ai.guidedPrefill.defaultPrompt')
+        : key === 'ai.guidedPrefill.sampleRepo.label'
+          ? t('ai.guidedPrefill.sampleRepo.label')
+          : key;
+    if (!matchesGuidedPrefillSnapshot(chat.inputValue, selectedContexts, translate)) {
+      setShowGuidedPrefillHint(false);
+    }
+  }, [showGuidedPrefillHint, chat.inputValue, selectedContexts, t]);
+
+  useEffect(() => {
+    if (!threads.isInitialized) return;
+    if (chat.isLoadingHistory) return;
+    if (chat.messages.length > 0) return;
+    if (chat.inputValue.trim() !== '') return;
+    if (guidedPrefillInjectedSessionRef.current) return;
+    if (pendingDeployPrompt) return;
+    if (isGithubConnectorsLoading) return;
+    if (isApplicationsLoading) return;
+    if (githubConnected || hasDeployedApps) return;
+
+    const promptText = getDefaultGuidedPrompt((key) =>
+      key === 'ai.guidedPrefill.defaultPrompt' ? t('ai.guidedPrefill.defaultPrompt') : key
+    );
+    const sampleRepoContext = buildSampleRepoContext((key) =>
+      key === 'ai.guidedPrefill.sampleRepo.label' ? t('ai.guidedPrefill.sampleRepo.label') : key
+    );
+
+    chat.setInputValue(promptText);
+    setSelectedContexts((prev) => {
+      if (prev.some((c) => c.type === sampleRepoContext.type && c.id === sampleRepoContext.id)) {
+        return prev;
+      }
+      return [...prev, sampleRepoContext];
+    });
+    setShowGuidedPrefillHint(true);
+    guidedPrefillInjectedSessionRef.current = true;
+  }, [
+    threads.isInitialized,
+    chat.messages.length,
+    chat.inputValue,
+    chat.isLoadingHistory,
+    chat.setInputValue,
+    pendingDeployPrompt,
+    isGithubConnectorsLoading,
+    isApplicationsLoading,
+    githubConnected,
+    hasDeployedApps,
+    t
+  ]);
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setShowGuidedPrefillHint(false);
+      chat.handleInputChange(e);
+    },
+    [chat.handleInputChange]
+  );
+
   const handleNewChat = useCallback(() => {
     threads.createThread(t('ai.threads.untitledChat'));
   }, [threads, t]);
@@ -248,7 +336,7 @@ export function useChatPage(): UseChatPageReturn {
     handleSubmit: chat.handleSubmit,
     handleKeyDown: chat.handleKeyDown,
     handleSuggestionClick: chat.handleSuggestionClick,
-    handleInputChange: chat.handleInputChange,
+    handleInputChange,
     handleApproveToolCall: chat.handleApproveToolCall,
     handleDeclineToolCall: chat.handleDeclineToolCall,
     submitQuestionResponse: chat.submitQuestionResponse,
@@ -257,7 +345,8 @@ export function useChatPage(): UseChatPageReturn {
     setInputValue: chat.setInputValue,
     readOnly: chat.readOnly,
     refreshThreads: threads.refreshThreads,
-    isRefreshing: threads.isRefreshing
+    isRefreshing: threads.isRefreshing,
+    showGuidedPrefillHint
   };
 }
 


### PR DESCRIPTION
## Summary
- add guided onboarding prefill for chat by attaching a default sample repository context and preloading a starter prompt
- refine welcome copy and suggestion chips so first-time users get explicit guidance while returning users see concise intent-oriented prompts
- gate onboarding by real product state (GitHub connector + deployed apps) and stabilize hint/input behavior in welcome flow

## Test plan
- [ ] With no GitHub connector and no deployed apps, open `/chats` and confirm guided prefill appears with sample repo chip and no auto-send
- [ ] With GitHub connected or at least one deployed app, open `/chats` and confirm guided prefill does not auto-inject
- [ ] Verify deploy deep-link prefill still takes precedence over guided prefill
- [ ] Verify welcome and regular chat input copy/suggestions match guided vs returning-user states