### PR TITLE
fix(view): close delete dialog on cancel click

### DIFF
--- a/view/components/ui/delete-dialog.tsx
+++ b/view/components/ui/delete-dialog.tsx
@@ -1,6 +1,6 @@
 import { DialogWrapper, DialogAction } from '@nixopus/ui';
 import { LucideIcon } from 'lucide-react';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 interface ConfirmationDialogProps {
   title: string;
@@ -29,10 +29,21 @@ export function DeleteDialog({
   open,
   onOpenChange
 }: ConfirmationDialogProps) {
+  const isControlled = open !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const currentOpen = isControlled ? open : internalOpen;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!isControlled) {
+      setInternalOpen(next);
+    }
+    onOpenChange?.(next);
+  };
+
   const actions: DialogAction[] = [
     {
       label: cancelText,
-      onClick: () => onOpenChange?.(false),
+      onClick: () => handleOpenChange(false),
       variant: 'outline'
     },
     {
@@ -48,8 +59,8 @@ export function DeleteDialog({
 
   return (
     <DialogWrapper
-      open={open}
-      onOpenChange={onOpenChange}
+      open={currentOpen}
+      onOpenChange={handleOpenChange}
       title={title}
       description={description}
       trigger={trigger}


### PR DESCRIPTION
## Summary
- `DeleteDialog` is uncontrolled at most call sites (passed only `trigger`, no `open`/`onOpenChange`), so the Cancel button's `onOpenChange?.(false)` was a no-op and the dialog stayed open.
- Manage open state internally when no controlled props are provided, while still forwarding changes to `onOpenChange` when the parent does control it.
- Fixes the bug seen on the application header delete flow and the same bug across every other delete usage that relies on the `trigger` prop (teams, domains, machines, plugins, etc.).

## Test plan
- [ ] Open an app, click the More menu, choose Delete, click Cancel → dialog closes.
- [ ] Reopen and click Confirm → app is deleted as before.
- [ ] Verify other delete dialogs (teams, domains, machines, plugins) still open/close correctly.