### PR TITLE
fix(chat): default tool execution to auto-run after logout

### DIFF
--- a/view/packages/hooks/ai/use-chat-page.ts
+++ b/view/packages/hooks/ai/use-chat-page.ts
@@ -28,12 +28,16 @@ import {
 } from './guided-prefill';
 
 function useLocalStorageState(key: string, defaultValue: boolean) {
-  const [value, setValue] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem(key) === 'true';
+  const [value, setValue] = useState(defaultValue);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(key);
+    if (stored === 'true' || stored === 'false') {
+      setValue(stored === 'true');
+    } else {
+      localStorage.setItem(key, String(defaultValue));
     }
-    return defaultValue;
-  });
+  }, [key]);
 
   useEffect(() => {
     localStorage.setItem(key, String(value));


### PR DESCRIPTION
## Summary

The chat tool-execution toggle silently reverted to **Ask before executing** every time a user logged out and back in, even though Auto-run is the intended default.

Two things were conspiring:

1. `logoutUser` calls `localStorage.clear()`, removing the `chat_auto_run_tools` key.
2. `useLocalStorageState` initialized state with `localStorage.getItem(key) === 'true'`. When the key was missing, that comparison evaluated to `false`, so the `defaultValue` argument was effectively dead code.

This PR rewrites the hook to:

- Initialize state with `defaultValue` (also avoids SSR/CSR hydration mismatch since `localStorage` is no longer touched during render).
- After mount, only override from storage when a real `'true'`/`'false'` value is present; otherwise persist `defaultValue` so it sticks on subsequent loads.

Net effect: after logout/login the toggle lands on **Auto-run tools** by default, while any explicit user choice continues to be respected.

## Test plan

- [ ] Fresh session (no `chat_auto_run_tools` in localStorage) → toggle shows **Auto-run tools**.
- [ ] Toggle to **Ask before executing** → reload page → still **Ask before executing**.
- [ ] Log out → log back in → toggle shows **Auto-run tools** (default restored).
- [ ] No SSR hydration warning in the console on the chat page.