### PR TITLE
feat(installer): bootstrap admin account during install

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -79,7 +79,9 @@ curl -fsSL install.nixopus.com | sudo DOMAIN=panel.example.com ADMIN_EMAIL=admin
 | `HOST_IP` | *(auto-detected)* | Public IP of the server |
 | `CADDY_HTTP_PORT` | `80` | HTTP port |
 | `CADDY_HTTPS_PORT` | `443` | HTTPS port |
-| `ADMIN_EMAIL` | *(empty)* | Admin account email |
+| `ADMIN_EMAIL` | *(empty)* | Admin account email. When set, the installer pre-creates the admin via the auth API after services start. |
+| `ADMIN_PASSWORD` | *(auto-generated)* | Admin password. Used only when `ADMIN_EMAIL` is set. Auto-generated to satisfy the password rules below if omitted; printed in the install summary and persisted to `.env` (mode `600`). |
+| `ADMIN_BOOTSTRAP_TIMEOUT` | `60` | Seconds the installer waits for the admin sign-up call to succeed. Retry later with `nixopus admin-bootstrap`. |
 | `SSH_HOST` | `$HOST_IP` | SSH host the API connects to |
 | `SSH_PORT` | `22` | SSH port (auto-detected from sshd_config if non-standard) |
 | `SSH_USER` | `root` | SSH user |
@@ -100,6 +102,45 @@ curl -fsSL install.nixopus.com | sudo DOMAIN=panel.example.com ADMIN_EMAIL=admin
 | `NIXOPUS_TELEMETRY` | `on` | Set to `off` to disable anonymous install telemetry |
 | `DO_NOT_TRACK` | `0` | Set to `1` to disable telemetry ([consented.dev](https://consented.dev)) |
 | `LOG_LEVEL` | `debug` | Log level |
+
+## Admin account
+
+When you pass `ADMIN_EMAIL`, the installer creates the initial admin user for you by calling the auth service after the stack is healthy — no need to visit `/register` manually.
+
+```bash
+curl -fsSL install.nixopus.com | sudo \
+  DOMAIN=panel.example.com \
+  ADMIN_EMAIL=admin@example.com \
+  ADMIN_PASSWORD='ChangeMe!23' bash
+```
+
+If you omit `ADMIN_PASSWORD`, the installer generates a 16-character password that satisfies all rules below and prints it once at the end of the install. The same value is written to `/opt/nixopus/.env` so re-runs preserve it.
+
+### Password rules
+
+The auth service enforces these on every credential, including the auto-generated one:
+
+- At least 8 characters
+- At least one uppercase letter (A–Z)
+- At least one lowercase letter (a–z)
+- At least one digit (0–9)
+- At least one special character: `!@#$%^&*(),.?":{}|<>`
+
+### Skipping the bootstrap
+
+If you don't pass `ADMIN_EMAIL`, the installer doesn't create any account. On first visit, the dashboard sends you to `/register` and the first person to sign up becomes the admin.
+
+### Retrying the bootstrap
+
+If the auth service was still warming up when the installer gave up, or you need to recreate the admin, retry without reinstalling:
+
+```bash
+sudo nixopus admin-bootstrap
+# or override the stored values:
+sudo nixopus admin-bootstrap admin@example.com 'NewPass!23'
+```
+
+The retry uses the values stored in `.env` by default, treats `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` as success, and surfaces the auth service's `code` field on validation failures (`PASSWORD_TOO_SHORT`, `INVALID_ORIGIN`, `EMAIL_PASSWORD_SIGN_UP_DISABLED`, etc.).
 
 ## Ports
 
@@ -224,6 +265,7 @@ sudo nixopus status
 | `nixopus ip set <ip>` | Change host IP |
 | `nixopus port set <http\|https\|ssh> <port>` | Change a port |
 | `nixopus backup` | Backup database and config |
+| `nixopus admin-bootstrap [email] [password]` | Create the initial admin via the auth API (uses `ADMIN_EMAIL`/`ADMIN_PASSWORD` from `.env` unless overridden) |
 | `nixopus uninstall` | Remove containers (keeps data) |
 | `nixopus uninstall --purge` | Remove everything including data |
 
@@ -297,6 +339,54 @@ nixopus logs
 ```
 
 Common causes: port conflict (see [Ports](#ports)), DNS not configured (see [HTTPS](#https)), or insufficient resources (see [Requirements](#requirements)).
+
+### Admin bootstrap failed during install
+
+**Symptom:** Install summary shows `Could not auto-create admin (HTTP …)` or `Auth service rejected request: …`.
+
+The installer creates the admin via the auth service after the stack starts. If the auth service is slow, the origin is misconfigured, or the credentials don't pass validation, the bootstrap is skipped — but the install itself succeeds.
+
+**Fix:** Retry without reinstalling.
+
+```bash
+sudo nixopus admin-bootstrap
+```
+
+Common error codes printed by the auth service:
+
+| Code | Meaning | Fix |
+|---|---|---|
+| `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` | Admin already exists | Nothing — log in with the existing credentials |
+| `EMAIL_PASSWORD_SIGN_UP_DISABLED` | Email/password sign-up turned off in the auth service | Enable it in the auth service config or seed via DB |
+| `INVALID_ORIGIN` / `MISSING_OR_NULL_ORIGIN` | Origin header rejected | Check `ALLOWED_ORIGIN` matches your `BASE_URL` in `/opt/nixopus/.env` |
+| `PASSWORD_TOO_SHORT` / `PASSWORD_TOO_LONG` / `INVALID_PASSWORD` | Password rules failed | Pick a password matching the [rules](#password-rules) and re-run with `nixopus admin-bootstrap <email> <password>` |
+| `INVALID_EMAIL` | Email malformed | Re-run with a valid email |
+
+If the auth service is just slow to come up, increase the timeout:
+
+```bash
+sudo ADMIN_BOOTSTRAP_TIMEOUT=120 nixopus admin-bootstrap
+```
+
+### Lost the admin password
+
+The auto-generated admin password is stored in `/opt/nixopus/.env` as `ADMIN_PASSWORD`:
+
+```bash
+sudo grep '^ADMIN_PASSWORD=' /opt/nixopus/.env
+```
+
+If that's missing or the account is locked out, recreate the admin by deleting the existing credential row and re-running the bootstrap:
+
+```bash
+docker exec -it nixopus-db psql -U nixopus -d nixopus -c \
+  "DELETE FROM account WHERE user_id = (SELECT id FROM \"user\" WHERE email='admin@example.com');
+   DELETE FROM \"user\" WHERE email='admin@example.com';"
+
+sudo nixopus admin-bootstrap admin@example.com 'NewPass!23'
+```
+
+> **Warning:** Deleting the user row drops anything tied to that user (org memberships, API keys, audit ownership). Only do this if you understand the impact.
 
 ### Cannot access the dashboard
 

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -204,6 +204,30 @@ check_firewall() {
 
 gen_secret() { openssl rand -hex 32; }
 
+# gen_password generates a 16-char password that satisfies Better Auth's
+# validation rules (>=8 chars, 1 upper, 1 lower, 1 digit, 1 special).
+# Special set is restricted to characters that are JSON- and shell-safe so
+# the resulting value can be embedded in .env and curl payloads without
+# escaping headaches.
+gen_password() {
+    local upper lower digit special rest combined
+    upper=$(LC_ALL=C tr -dc 'A-Z'             </dev/urandom 2>/dev/null | head -c 1)
+    lower=$(LC_ALL=C tr -dc 'a-z'             </dev/urandom 2>/dev/null | head -c 1)
+    digit=$(LC_ALL=C tr -dc '0-9'             </dev/urandom 2>/dev/null | head -c 1)
+    special=$(LC_ALL=C tr -dc '!@#%^&*'       </dev/urandom 2>/dev/null | head -c 1)
+    rest=$(LC_ALL=C tr -dc 'A-Za-z0-9!@#%^&*' </dev/urandom 2>/dev/null | head -c 12)
+    combined="${upper}${lower}${digit}${special}${rest}"
+    echo "$combined" | fold -w1 | shuf | tr -d '\n'
+}
+
+# json_escape escapes a string for embedding inside a JSON double-quoted value.
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    printf '%s' "$s"
+}
+
 prompt_if_tty() {
     local var_name="$1" prompt="$2" default="${3:-}"
     local current_val="${!var_name:-}"
@@ -335,6 +359,16 @@ gather_config() {
         echo -e "  ${BOLD}Admin Account${NC}"
     fi
     prompt_if_tty ADMIN_EMAIL "Admin email" ""
+
+    # Admin password — only relevant when an email is present. Auto-generate
+    # if not supplied so the installer can bootstrap the admin account
+    # non-interactively. The generated value is printed at the end.
+    if [ -n "${ADMIN_EMAIL:-}" ] && [ -z "${ADMIN_PASSWORD:-}" ]; then
+        ADMIN_PASSWORD="$(gen_password)"
+        ADMIN_PASSWORD_GENERATED=true
+    else
+        ADMIN_PASSWORD_GENERATED=false
+    fi
 
     SSH_HOST="${SSH_HOST:-${HOST_IP:-host.docker.internal}}"
     SSH_USER="${SSH_USER:-root}"
@@ -519,6 +553,7 @@ USE_BUNDLED_DB=${USE_BUNDLED_DB}
 USE_BUNDLED_REDIS=${USE_BUNDLED_REDIS}
 
 ADMIN_EMAIL=${ADMIN_EMAIL:-}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
 SELF_HOSTED=true
 NIXOPUS_TELEMETRY=${NIXOPUS_TELEMETRY:-on}
 LOG_LEVEL=${LOG_LEVEL:-debug}
@@ -657,6 +692,89 @@ start_services() {
     log_warn "Health check timed out. Services may still be starting."
     log_info "Check status: nixopus status"
     log_info "Check logs:   nixopus logs"
+}
+
+# bootstrap_admin creates the initial admin user via Better Auth's sign-up
+# endpoint so the operator does not have to register through the browser.
+# Skipped when ADMIN_EMAIL is empty. Treats "user already exists" as success
+# so re-running the installer is idempotent.
+ADMIN_BOOTSTRAPPED=false
+bootstrap_admin() {
+    if [ -z "${ADMIN_EMAIL:-}" ] || [ -z "${ADMIN_PASSWORD:-}" ]; then
+        return 0
+    fi
+
+    local url="$BASE_URL/api/auth/sign-up/email"
+    local name="${ADMIN_EMAIL%@*}"
+    local payload
+    payload=$(printf '{"email":"%s","password":"%s","name":"%s"}' \
+        "$(json_escape "$ADMIN_EMAIL")" \
+        "$(json_escape "$ADMIN_PASSWORD")" \
+        "$(json_escape "$name")")
+
+    log_info "Bootstrapping admin account ($ADMIN_EMAIL)"
+
+    local timeout="${ADMIN_BOOTSTRAP_TIMEOUT:-60}" elapsed=0 interval=3
+    local http_code="000" body code tmp
+    tmp=$(mktemp)
+    while [ "$elapsed" -lt "$timeout" ]; do
+        http_code=$(curl -sS -k -o "$tmp" -w "%{http_code}" \
+            --connect-timeout 5 --max-time 15 \
+            -X POST "$url" \
+            -H "Content-Type: application/json" \
+            -H "Origin: $BASE_URL" \
+            -d "$payload" 2>/dev/null || echo "000")
+
+        body=$(cat "$tmp" 2>/dev/null || true)
+        code=$(printf '%s' "$body" | grep -oE '"code"[[:space:]]*:[[:space:]]*"[^"]+"' | head -n1 | sed -E 's/.*"code"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+
+        case "$http_code" in
+            200|201)
+                rm -f "$tmp"
+                log_ok "Admin account created"
+                ADMIN_BOOTSTRAPPED=true
+                return 0
+                ;;
+            422)
+                if [ "$code" = "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL" ] || [ "$code" = "USER_ALREADY_EXISTS" ]; then
+                    rm -f "$tmp"
+                    log_info "Admin account already exists — skipping bootstrap"
+                    return 0
+                fi
+                ;;
+            400|403)
+                case "$code" in
+                    EMAIL_PASSWORD_SIGN_UP_DISABLED)
+                        rm -f "$tmp"
+                        log_warn "Email/password sign-up is disabled in the auth service — cannot bootstrap admin"
+                        return 0
+                        ;;
+                    INVALID_ORIGIN|MISSING_OR_NULL_ORIGIN|CROSS_SITE_NAVIGATION_LOGIN_BLOCKED)
+                        rm -f "$tmp"
+                        log_warn "Auth service rejected origin '$BASE_URL' ($code). Check ALLOWED_ORIGIN in $NIXOPUS_HOME/.env"
+                        return 0
+                        ;;
+                    PASSWORD_TOO_SHORT|PASSWORD_TOO_LONG|INVALID_PASSWORD|INVALID_EMAIL)
+                        rm -f "$tmp"
+                        log_warn "Auth service rejected credentials ($code). Adjust ADMIN_EMAIL / ADMIN_PASSWORD and re-run: nixopus admin-bootstrap"
+                        return 0
+                        ;;
+                esac
+                ;;
+        esac
+
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+
+    rm -f "$tmp"
+    if [ -n "$code" ]; then
+        log_warn "Could not auto-create admin (HTTP $http_code, code: $code). Retry: nixopus admin-bootstrap"
+    else
+        log_warn "Could not auto-create admin (HTTP $http_code). Retry: nixopus admin-bootstrap"
+    fi
+    [ -n "$body" ] && log_warn "Response: $(printf '%s' "$body" | head -c 200)"
+    return 0
 }
 
 # ── Step 6: Management Script ────────────────────────────────────────────────
@@ -972,6 +1090,94 @@ cmd_info() {
     cmd_status
 }
 
+# cmd_admin_bootstrap creates (or recreates) the initial admin account by
+# calling Better Auth's POST /api/auth/sign-up/email through Caddy. Uses
+# ADMIN_EMAIL/ADMIN_PASSWORD from .env unless overridden by env vars or
+# CLI args:  nixopus admin-bootstrap [email] [password]
+cmd_admin_bootstrap() {
+    load_env
+
+    local email="${1:-${ADMIN_EMAIL:-}}"
+    local password="${2:-${ADMIN_PASSWORD:-}}"
+
+    if [ -z "$email" ]; then
+        echo "ADMIN_EMAIL is not set. Usage: nixopus admin-bootstrap <email> <password>" >&2
+        return 1
+    fi
+    if [ -z "$password" ]; then
+        echo "ADMIN_PASSWORD is not set. Usage: nixopus admin-bootstrap <email> <password>" >&2
+        return 1
+    fi
+
+    local base="${ALLOWED_ORIGIN:-${AUTH_PUBLIC_URL:-}}"
+    if [ -z "$base" ]; then
+        echo "Cannot determine BASE_URL (ALLOWED_ORIGIN missing in .env)" >&2
+        return 1
+    fi
+
+    json_escape() {
+        local s="$1"
+        s="${s//\\/\\\\}"
+        s="${s//\"/\\\"}"
+        printf '%s' "$s"
+    }
+
+    local name="${email%@*}"
+    local payload
+    payload=$(printf '{"email":"%s","password":"%s","name":"%s"}' \
+        "$(json_escape "$email")" "$(json_escape "$password")" "$(json_escape "$name")")
+
+    local timeout="${ADMIN_BOOTSTRAP_TIMEOUT:-30}" elapsed=0 interval=3
+    local http_code="000" body code tmp
+    tmp=$(mktemp)
+    echo "Bootstrapping admin ($email) at $base ..."
+
+    while [ "$elapsed" -lt "$timeout" ]; do
+        http_code=$(curl -sS -k -o "$tmp" -w "%{http_code}" \
+            --connect-timeout 5 --max-time 15 \
+            -X POST "$base/api/auth/sign-up/email" \
+            -H "Content-Type: application/json" \
+            -H "Origin: $base" \
+            -d "$payload" 2>/dev/null || echo "000")
+
+        body=$(cat "$tmp" 2>/dev/null || true)
+        code=$(printf '%s' "$body" | grep -oE '"code"[[:space:]]*:[[:space:]]*"[^"]+"' | head -n1 | sed -E 's/.*"code"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+
+        case "$http_code" in
+            200|201)
+                rm -f "$tmp"
+                echo "Admin account created."
+                return 0
+                ;;
+            422)
+                if [ "$code" = "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL" ] || [ "$code" = "USER_ALREADY_EXISTS" ]; then
+                    rm -f "$tmp"
+                    echo "Admin account already exists — nothing to do."
+                    return 0
+                fi
+                ;;
+            400|403)
+                case "$code" in
+                    EMAIL_PASSWORD_SIGN_UP_DISABLED|INVALID_ORIGIN|MISSING_OR_NULL_ORIGIN|CROSS_SITE_NAVIGATION_LOGIN_BLOCKED|PASSWORD_TOO_SHORT|PASSWORD_TOO_LONG|INVALID_PASSWORD|INVALID_EMAIL)
+                        rm -f "$tmp"
+                        echo "Auth service rejected request: $code" >&2
+                        echo "Response: $(printf '%s' "$body" | head -c 200)" >&2
+                        return 1
+                        ;;
+                esac
+                ;;
+        esac
+
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+
+    rm -f "$tmp"
+    echo "Failed to create admin after ${timeout}s (HTTP $http_code${code:+, code: $code})." >&2
+    [ -n "$body" ] && echo "Response: $(printf '%s' "$body" | head -c 200)" >&2
+    return 1
+}
+
 cmd_help() {
     echo "Usage: nixopus <command> [args]"
     echo ""
@@ -991,6 +1197,7 @@ cmd_help() {
     echo "  port set <type> <n> Change port (http, https, ssh)"
     echo "  backup              Backup database and config"
     echo "  info                Show install info and status"
+    echo "  admin-bootstrap     Create admin account via auth API (uses ADMIN_EMAIL/ADMIN_PASSWORD)"
     echo "  help                Show this help"
 }
 
@@ -1007,6 +1214,7 @@ case "${1:-help}" in
     port)      shift; cmd_port "$@" ;;
     backup)    cmd_backup ;;
     info)      cmd_info ;;
+    admin-bootstrap) shift; cmd_admin_bootstrap "$@" ;;
     help|--help|-h) cmd_help ;;
     *)         echo "Unknown command: $1"; cmd_help; exit 1 ;;
 esac
@@ -1051,6 +1259,19 @@ show_complete() {
     echo -e "  ${BOLD}Access:${NC}    $BASE_URL"
     echo -e "  ${BOLD}Config:${NC}    $NIXOPUS_HOME/.env"
     echo -e "  ${BOLD}Installed:${NC} ${duration}s"
+    if [ -n "${ADMIN_EMAIL:-}" ] && [ "${ADMIN_BOOTSTRAPPED:-false}" = true ]; then
+        echo ""
+        echo -e "  ${BOLD}Admin credentials:${NC}"
+        echo -e "    ${BOLD}Email:${NC}    $ADMIN_EMAIL"
+        echo -e "    ${BOLD}Password:${NC} $ADMIN_PASSWORD"
+        if [ "${ADMIN_PASSWORD_GENERATED:-false}" = true ]; then
+            echo -e "    ${YELLOW}Auto-generated. Save it now and change it after first login.${NC}"
+        fi
+        echo -e "    ${DIM}Also stored in $NIXOPUS_HOME/.env (ADMIN_PASSWORD)${NC}"
+    elif [ -n "${ADMIN_EMAIL:-}" ]; then
+        echo ""
+        echo -e "  ${BOLD}Admin:${NC}     register at $BASE_URL/register"
+    fi
     echo ""
     echo -e "  ${BOLD}Commands:${NC}"
     echo "    nixopus status     Show service health"
@@ -1094,6 +1315,7 @@ main() {
 
     log_step 5 "Starting services"
     start_services
+    bootstrap_admin
 
     log_step 6 "Installing management CLI"
     install_management_script


### PR DESCRIPTION
## Summary

- Generate a Better Auth–compliant admin password when `ADMIN_EMAIL` is set and call `/api/auth/sign-up/email` after the stack is healthy, so operators no longer need to register through the browser. Treats `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` as success for idempotent re-runs and surfaces auth-service error codes (`INVALID_ORIGIN`, `EMAIL_PASSWORD_SIGN_UP_DISABLED`, `PASSWORD_TOO_SHORT`, etc.) in the install summary.
- Persist `ADMIN_PASSWORD` to `/opt/nixopus/.env`, print it once on success (with a warning when auto-generated), and add a configurable `ADMIN_BOOTSTRAP_TIMEOUT` (default `60s`) for slow-starting auth services.
- Expose `nixopus admin-bootstrap [email] [password]` so the bootstrap can be retried without reinstalling, and document the new variables, CLI command, password rules, and troubleshooting steps in the installer `README`.

## Test plan

- [ ] Fresh install with `ADMIN_EMAIL` only — verify auto-generated password is printed and login works
- [ ] Fresh install with `ADMIN_EMAIL` + `ADMIN_PASSWORD` — verify supplied password is used and stored in `.env`
- [ ] Re-run installer on existing stack — verify `USER_ALREADY_EXISTS` is treated as success (no failure)
- [ ] Install without `ADMIN_EMAIL` — verify summary points to `/register` and no bootstrap is attempted
- [ ] Run `nixopus admin-bootstrap` after a failed bootstrap — verify retry succeeds
- [ ] Run `nixopus admin-bootstrap admin@example.com 'Custom!23'` with overrides — verify new credentials work
- [ ] Trigger a `PASSWORD_TOO_SHORT` / `INVALID_ORIGIN` response — verify the error code surfaces in installer output