### PR TITLE
feat(machine): BYOS machine lifecycle operations (pause, resume, restart, status)

### DIFF
--- a/api/internal/features/machine/controller/lifecycle.go
+++ b/api/internal/features/machine/controller/lifecycle.go
@@ -80,6 +80,17 @@ func (c *MachineController) RestartMachine(f fuego.ContextNoBody) (*types.Machin
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
+	userOwned, _ := c.billingService.IsServerUserOwned(orgID, *serverID)
+	if userOwned {
+		ctx := context.WithValue(r.Context(), sharedtypes.ServerIDKey, serverID.String())
+		response, err := c.service.RestartMachine(ctx, orgID)
+		if err != nil {
+			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
+		}
+		return response, nil
+	}
+
 	response, err := c.lifecycleService.Restart(r.Context(), orgID, serverID)
 	if err != nil {
 		return nil, mapLifecycleError(c.logger, err, orgID, "restart")
@@ -106,6 +117,16 @@ func (c *MachineController) PauseMachine(f fuego.ContextNoBody) (*types.MachineA
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
+	userOwned, _ := c.billingService.IsServerUserOwned(orgID, *serverID)
+	if userOwned {
+		response, err := c.service.PauseMachine(r.Context(), orgID, *serverID)
+		if err != nil {
+			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
+		}
+		return response, nil
+	}
+
 	response, err := c.lifecycleService.Pause(r.Context(), orgID, serverID)
 	if err != nil {
 		return nil, mapLifecycleError(c.logger, err, orgID, "pause")
@@ -130,6 +151,16 @@ func (c *MachineController) ResumeMachine(f fuego.ContextNoBody) (*types.Machine
 	serverID := parseServerID(r)
 	if serverID == nil {
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
+	}
+
+	userOwned, _ := c.billingService.IsServerUserOwned(orgID, *serverID)
+	if userOwned {
+		response, err := c.service.ResumeMachine(r.Context(), orgID, *serverID)
+		if err != nil {
+			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
+		}
+		return response, nil
 	}
 
 	response, err := c.lifecycleService.Resume(r.Context(), orgID, serverID)

--- a/api/internal/features/machine/service/init.go
+++ b/api/internal/features/machine/service/init.go
@@ -34,6 +34,17 @@ func NewMachineService(store *shared_storage.Store, ctx context.Context, l logge
 }
 
 func (s *MachineService) GetMachineStatus(ctx context.Context, orgID uuid.UUID) (*types.MachineStateResponse, error) {
+	serverIDStr, _ := ctx.Value(shared_types.ServerIDKey).(string)
+	if serverID, err := uuid.Parse(serverIDStr); err == nil {
+		if active, err := s.regStore.GetMachineIsActive(serverID); err == nil && !active {
+			return &types.MachineStateResponse{
+				Status:  "success",
+				Message: "Machine status retrieved",
+				Data:    &types.MachineState{Active: false, State: "Paused"},
+			}, nil
+		}
+	}
+
 	sshMgr, err := sshpkg.GetSSHManagerFromContext(ctx)
 	if err != nil {
 		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
@@ -124,6 +135,43 @@ func (s *MachineService) GetSystemStats(ctx context.Context, orgID uuid.UUID) (*
 		Status:  "success",
 		Message: "System stats collected successfully",
 		Data:    stats,
+	}, nil
+}
+
+func (s *MachineService) RestartMachine(ctx context.Context, orgID uuid.UUID) (*types.MachineActionResponse, error) {
+	sshMgr, err := sshpkg.GetSSHManagerFromContext(ctx)
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
+		return nil, fmt.Errorf("failed to connect to server: %w", err)
+	}
+
+	_, _ = sshMgr.RunCommand("sudo reboot")
+
+	return &types.MachineActionResponse{
+		Status:  "success",
+		Message: "Machine restart initiated",
+	}, nil
+}
+
+func (s *MachineService) PauseMachine(ctx context.Context, orgID uuid.UUID, serverID uuid.UUID) (*types.MachineActionResponse, error) {
+	if err := s.regStore.SetMachineActive(serverID, false); err != nil {
+		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		return nil, fmt.Errorf("failed to pause machine: %w", err)
+	}
+	return &types.MachineActionResponse{
+		Status:  "success",
+		Message: "Machine paused",
+	}, nil
+}
+
+func (s *MachineService) ResumeMachine(ctx context.Context, orgID uuid.UUID, serverID uuid.UUID) (*types.MachineActionResponse, error) {
+	if err := s.regStore.SetMachineActive(serverID, true); err != nil {
+		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		return nil, fmt.Errorf("failed to resume machine: %w", err)
+	}
+	return &types.MachineActionResponse{
+		Status:  "success",
+		Message: "Machine resumed",
 	}, nil
 }
 

--- a/api/internal/features/machine/storage/registration.go
+++ b/api/internal/features/machine/storage/registration.go
@@ -200,6 +200,32 @@ func (s *RegistrationStorage) GetProvisionDetailsBySSHKeyID(sshKeyID uuid.UUID) 
 	return id, err
 }
 
+func (s *RegistrationStorage) GetMachineIsActive(serverID uuid.UUID) (bool, error) {
+	var key api_types.SSHKey
+	err := s.db.NewSelect().
+		Model(&key).
+		Column("is_active").
+		Where("id = ?", serverID).
+		Where("deleted_at IS NULL").
+		Limit(1).
+		Scan(s.ctx)
+	if err != nil {
+		return false, err
+	}
+	return key.IsActive, nil
+}
+
+func (s *RegistrationStorage) SetMachineActive(serverID uuid.UUID, active bool) error {
+	_, err := s.db.NewUpdate().
+		Model((*api_types.SSHKey)(nil)).
+		Set("is_active = ?", active).
+		Set("updated_at = ?", time.Now()).
+		Where("id = ?", serverID).
+		Where("deleted_at IS NULL").
+		Exec(s.ctx)
+	return err
+}
+
 func (s *RegistrationStorage) GetAnyActiveInfraServerID() (string, error) {
 	var serverID string
 	err := s.db.NewSelect().


### PR DESCRIPTION
## Summary

- **Storage**: Added `GetMachineIsActive` and `SetMachineActive` to `RegistrationStorage`, reading/writing `ssh_keys.is_active` via Bun ORM
- **Service**: Added `RestartMachine` (SSH `sudo reboot`), `PauseMachine` and `ResumeMachine` (DB-only `is_active` toggle) to `MachineService`; updated `GetMachineStatus` to return `"Paused"` immediately when `is_active = false` (skips SSH)
- **Controller**: All four lifecycle handlers (`GetMachineStatus`, `RestartMachine`, `PauseMachine`, `ResumeMachine`) now branch on `IsServerUserOwned` — BYOS machines use the SSH/DB path, provisioned machines continue using the Redis queue (unchanged)

## Why

Previously all lifecycle operations for user-owned (BYOS) machines fell through to the provisioned-machine Redis queue path, which timed out with 504 because no agent was consuming the queue for BYOS machines.

## Behaviour

| Operation | BYOS | Provisioned |
|-----------|------|-------------|
| Status | Checks `is_active` first (returns Paused if false), then SSH uptime | Redis queue (unchanged) |
| Pause | Sets `is_active = false` in DB | Redis queue (unchanged) |
| Resume | Sets `is_active = true` in DB | Redis queue (unchanged) |
| Restart | SSH `sudo reboot` (fire-and-forget) | Redis queue (unchanged) |

## Test plan

- [ ] Insert `user_provision_details` row with `type='user_owned'` for an existing BYOS machine
- [ ] `GET /api/v1/machines/status?server_id=<id>` returns running state (no 504)
- [ ] `POST /api/v1/machines/pause?server_id=<id>` returns success
- [ ] `GET /api/v1/machines/status?server_id=<id>` returns `"Paused"` immediately
- [ ] `POST /api/v1/machines/resume?server_id=<id>` returns success
- [ ] `POST /api/v1/machines/restart?server_id=<id>` returns success, machine reboots
- [ ] Provisioned machine lifecycle routes still work (queue path untouched)

## Related

Companion PR: nixopus/auth — `feat/byos-lifecycle` (inserts `user_provision_details` on new self-hosted registration)