### PR TITLE
feat(machines): add per-machine backups page

### DIFF
--- a/view/app/machines/[machineId]/backups/page.tsx
+++ b/view/app/machines/[machineId]/backups/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/app/backups/page';


### PR DESCRIPTION
## Summary

- Adds `/machines/[machineId]/backups` route so users can view backups scoped to a specific machine
- Re-uses the existing `BackupsWithLayout` component — `useMachineId()` automatically reads the machine ID from the URL and scopes all data/queries/actions to that machine
- Follows the same re-export pattern used by `charts` and `apps` machine sub-pages

## Test plan

- [ ] Navigate to `/machines/<id>/backups` and confirm only backups for that machine are shown
- [ ] Trigger a backup and confirm it appears in the list
- [ ] Verify the schedule dialog opens and saves correctly