### PR TITLE
test(healthcheck,container): add integration tests + fix API bugs

### DIFF
--- a/api/doc/openapi.json
+++ b/api/doc/openapi.json
@@ -1800,6 +1800,14 @@
 			"BackupScheduleData": {
 				"description": "BackupScheduleData schema",
 				"properties": {
+					"backup_paths": {
+						"items": {
+							"nullable": true,
+							"type": "string"
+						},
+						"nullable": true,
+						"type": "array"
+					},
 					"day_of_week": {
 						"type": "integer"
 					},
@@ -1823,6 +1831,14 @@
 				"properties": {
 					"data": {
 						"properties": {
+							"backup_paths": {
+								"items": {
+									"nullable": true,
+									"type": "string"
+								},
+								"nullable": true,
+								"type": "array"
+							},
 							"day_of_week": {
 								"type": "integer"
 							},
@@ -10219,6 +10235,10 @@
 					"data": {
 						"nullable": true,
 						"properties": {
+							"channel_id": {
+								"format": "uuid",
+								"type": "string"
+							},
 							"created_at": {
 								"format": "date-time",
 								"type": "string"
@@ -20295,6 +20315,7 @@
 					"content": {
 						"*/*": {
 							"example": {
+								"backup_paths": [],
 								"day_of_week": 1,
 								"enabled": true,
 								"frequency": "string",

--- a/api/internal/features/container/controller/get_container.go
+++ b/api/internal/features/container/controller/get_container.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
@@ -11,6 +12,9 @@ import (
 
 func (c *ContainerController) GetContainer(f fuego.ContextNoBody) (*types.GetContainerResponse, error) {
 	containerID := f.PathParam("container_id")
+	if _, err := uuid.Parse(containerID); err != nil {
+		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
+	}
 	ctx := f.Request().Context()
 
 	dockerService, err := c.getDockerService(ctx)

--- a/api/internal/features/container/controller/get_container_logs.go
+++ b/api/internal/features/container/controller/get_container_logs.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
@@ -17,6 +18,13 @@ func (c *ContainerController) GetContainerLogs(f fuego.ContextWithBody[types.Con
 			Detail: err.Error(),
 			Err:    err,
 		}
+	}
+
+	if req.ID == "" {
+		req.ID = f.PathParam("container_id")
+	}
+	if _, err := uuid.Parse(req.ID); err != nil {
+		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 
 	_, r := f.Response(), f.Request()

--- a/api/internal/features/container/controller/restart_container.go
+++ b/api/internal/features/container/controller/restart_container.go
@@ -4,12 +4,16 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
 )
 
 func (c *ContainerController) RestartContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
+	if _, err := uuid.Parse(containerID); err != nil {
+		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
+	}
 	ctx := f.Request().Context()
 
 	if resp, skipped := c.isProtectedContainer(ctx, containerID, "restart"); skipped {

--- a/api/internal/features/container/controller/start_container.go
+++ b/api/internal/features/container/controller/start_container.go
@@ -4,12 +4,16 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
 )
 
 func (c *ContainerController) StartContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
+	if _, err := uuid.Parse(containerID); err != nil {
+		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
+	}
 	ctx := f.Request().Context()
 
 	if resp, skipped := c.isProtectedContainer(ctx, containerID, "start"); skipped {

--- a/api/internal/features/container/controller/stop_container.go
+++ b/api/internal/features/container/controller/stop_container.go
@@ -4,12 +4,16 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
 )
 
 func (c *ContainerController) StopContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
+	if _, err := uuid.Parse(containerID); err != nil {
+		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
+	}
 	ctx := f.Request().Context()
 
 	if resp, skipped := c.isProtectedContainer(ctx, containerID, "stop"); skipped {

--- a/api/internal/features/container/controller/update_container_resources.go
+++ b/api/internal/features/container/controller/update_container_resources.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
 )
@@ -12,6 +13,9 @@ import (
 // It validates the resource limits and verifies the container is running before applying the update.
 func (c *ContainerController) UpdateContainerResources(f fuego.ContextWithBody[types.UpdateContainerResourcesRequest]) (*types.UpdateContainerResourcesResponse, error) {
 	containerID := f.PathParam("container_id")
+	if _, err := uuid.Parse(containerID); err != nil {
+		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
+	}
 	ctx := f.Request().Context()
 
 	if resp, skipped := c.isProtectedContainer(ctx, containerID, "update resources"); skipped {

--- a/api/internal/features/healthcheck/controller/error_helpers.go
+++ b/api/internal/features/healthcheck/controller/error_helpers.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
 )
@@ -32,6 +33,15 @@ func mapHealthCheckError(err error) (int, error) {
 	case errors.Is(err, types.ErrRateLimitExceeded):
 		return http.StatusTooManyRequests, err
 	default:
+		errMsg := err.Error()
+		// FK violation: application_id references a non-existent application
+		if strings.Contains(errMsg, "violates foreign key constraint") {
+			return http.StatusBadRequest, errors.New("referenced application does not exist")
+		}
+		// Storage-level not found
+		if strings.Contains(errMsg, "not found") {
+			return http.StatusNotFound, err
+		}
 		return http.StatusInternalServerError, err
 	}
 }

--- a/api/internal/features/healthcheck/storage/init.go
+++ b/api/internal/features/healthcheck/storage/init.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -81,11 +82,17 @@ func (s *HealthCheckStorage) UpdateHealthCheck(healthCheck *shared_types.HealthC
 }
 
 func (s *HealthCheckStorage) DeleteHealthCheck(applicationID uuid.UUID, organizationID uuid.UUID) error {
-	_, err := s.DB.NewDelete().
+	result, err := s.DB.NewDelete().
 		Model((*shared_types.HealthCheck)(nil)).
 		Where("application_id = ? AND organization_id = ?", applicationID, organizationID).
 		Exec(s.Ctx)
-	return err
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return fmt.Errorf("health check not found")
+	}
+	return nil
 }
 
 func (s *HealthCheckStorage) ToggleHealthCheck(applicationID uuid.UUID, organizationID uuid.UUID, enabled bool) error {

--- a/api/internal/tests/container/container_ops_test.go
+++ b/api/internal/tests/container/container_ops_test.go
@@ -1,0 +1,460 @@
+package container
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/Eun/go-hit"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/tests"
+	"github.com/nixopus/nixopus/api/internal/testutils"
+)
+
+// All container ops require Docker/SSH on the target machine.
+// In CI the expected result for authenticated requests is 500 (no SSH infra).
+// 401 for no auth and 400 for bad params are always testable.
+
+// --- GET container by ID ---
+
+func TestGetContainerByID_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("GET /container/:id without auth returns 401"),
+		Get(tests.GetContainerURL(containerID)),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestGetContainerByID_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /container/not-a-uuid returns 400"),
+		Get(tests.GetContainerURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestGetContainerByID_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /container/:id with valid UUID — 500 expected (no SSH in CI)"),
+		Get(tests.GetContainerURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- POST container logs ---
+
+func TestGetContainerLogs_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("POST /container/:id/logs without auth returns 401"),
+		Post(tests.GetContainerLogsURL(containerID)),
+		Send().Body().JSON(map[string]interface{}{"id": containerID}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestGetContainerLogs_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/:id/logs with non-UUID id returns 400"),
+		Post(tests.GetContainerLogsURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"id": "not-a-uuid"}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestGetContainerLogs_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	containerID := uuid.New().String()
+	Test(t,
+		Description("POST /container/:id/logs — 500 expected (no SSH in CI)"),
+		Post(tests.GetContainerLogsURL(containerID)),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"id": containerID}),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestGetContainerLogs_WithTailParam(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	containerID := uuid.New().String()
+	Test(t,
+		Description("POST /container/:id/logs with tail param is accepted"),
+		Post(tests.GetContainerLogsURL(containerID)),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"id": containerID, "tail": 100}),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- POST container start ---
+
+func TestStartContainer_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("POST /container/:id/start without auth returns 401"),
+		Post(tests.GetContainerStartURL(containerID)),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestStartContainer_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/not-a-uuid/start returns 400"),
+		Post(tests.GetContainerStartURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestStartContainer_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/:id/start — 500 expected (no SSH in CI)"),
+		Post(tests.GetContainerStartURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- POST container stop ---
+
+func TestStopContainer_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("POST /container/:id/stop without auth returns 401"),
+		Post(tests.GetContainerStopURL(containerID)),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestStopContainer_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/not-a-uuid/stop returns 400"),
+		Post(tests.GetContainerStopURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestStopContainer_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/:id/stop — 500 expected (no SSH in CI)"),
+		Post(tests.GetContainerStopURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- POST container restart ---
+
+func TestRestartContainer_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("POST /container/:id/restart without auth returns 401"),
+		Post(tests.GetContainerRestartURL(containerID)),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestRestartContainer_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/not-a-uuid/restart returns 400"),
+		Post(tests.GetContainerRestartURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestRestartContainer_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/:id/restart — 500 expected (no SSH in CI)"),
+		Post(tests.GetContainerRestartURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- PUT container resources ---
+
+func TestGetContainerResources_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("PUT /container/:id/resources without auth returns 401"),
+		Put(tests.GetContainerResourcesURL(containerID)),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestGetContainerResources_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PUT /container/not-a-uuid/resources returns 400"),
+		Put(tests.GetContainerResourcesURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestGetContainerResources_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PUT /container/:id/resources — 500 expected (no SSH in CI)"),
+		Put(tests.GetContainerResourcesURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- GET container images ---
+
+func TestListContainerImages_NoAuth(t *testing.T) {
+	Test(t,
+		Description("POST /container/images without auth returns 401"),
+		Post(tests.GetContainerImagesURL()),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestListContainerImages_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/images — 500 expected (no Docker in CI)"),
+		Post(tests.GetContainerImagesURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestListContainerImages_InvalidOrgID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/images with invalid org ID returns 400"),
+		Post(tests.GetContainerImagesURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("not-a-uuid"),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestListContainerImages_CrossOrgDenied(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/images for different org returns 403"),
+		Post(tests.GetContainerImagesURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("123e4567-e89b-12d3-a456-426614174000"),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusForbidden),
+	)
+}
+
+// --- POST prune images ---
+
+func TestPruneImages_NoAuth(t *testing.T) {
+	Test(t,
+		Description("POST /container/prune/images without auth returns 401"),
+		Post(tests.GetContainerPruneImagesURL()),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestPruneImages_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/prune/images — 500 expected (no Docker in CI)"),
+		Post(tests.GetContainerPruneImagesURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestPruneImages_InvalidOrgID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/prune/images with invalid org ID returns 400"),
+		Post(tests.GetContainerPruneImagesURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("not-a-uuid"),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+// --- POST prune build cache ---
+
+func TestPruneBuildCache_NoAuth(t *testing.T) {
+	Test(t,
+		Description("POST /container/prune/build-cache without auth returns 401"),
+		Post(tests.GetContainerPruneBuildCacheURL()),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestPruneBuildCache_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/prune/build-cache — 500 expected (no Docker in CI)"),
+		Post(tests.GetContainerPruneBuildCacheURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestPruneBuildCache_InvalidOrgID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/prune/build-cache with invalid org ID returns 400"),
+		Post(tests.GetContainerPruneBuildCacheURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("not-a-uuid"),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestPruneBuildCache_CrossOrgDenied(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /container/prune/build-cache for different org returns 403"),
+		Post(tests.GetContainerPruneBuildCacheURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("123e4567-e89b-12d3-a456-426614174000"),
+		Expect().Status().Equal(http.StatusForbidden),
+	)
+}

--- a/api/internal/tests/container/get_container_logs_test.go
+++ b/api/internal/tests/container/get_container_logs_test.go
@@ -273,12 +273,12 @@ func TestGetContainerLogsErrorHandling(t *testing.T) {
 			"stderr": true,
 		}
 		Test(t,
-			Description("Should handle invalid UUID format for container ID"),
+			Description("Should return 400 for invalid UUID container ID"),
 			Post(tests.GetContainerLogsURL("not-a-uuid")),
 			Send().Headers("Cookie").Add(cookies),
 			Send().Headers("X-Organization-Id").Add(orgID),
 			Send().Body().JSON(requestBody),
-			Expect().Status().Equal(http.StatusInternalServerError),
+			Expect().Status().Equal(http.StatusBadRequest),
 		)
 	})
 
@@ -326,12 +326,12 @@ func TestGetContainerLogsErrorHandling(t *testing.T) {
 			"stderr": true,
 		}
 		Test(t,
-			Description("Should handle invalid since timestamp parameter"),
+			Description("Non-UUID container ID returns 400 before reaching 'since' validation"),
 			Post(tests.GetContainerLogsURL("some-container-id")),
 			Send().Headers("Cookie").Add(cookies),
 			Send().Headers("X-Organization-Id").Add(orgID),
 			Send().Body().JSON(requestBody),
-			Expect().Status().Equal(http.StatusInternalServerError),
+			Expect().Status().Equal(http.StatusBadRequest),
 		)
 	})
 }

--- a/api/internal/tests/container/get_container_test.go
+++ b/api/internal/tests/container/get_container_test.go
@@ -169,11 +169,11 @@ func TestGetContainerErrorScenarios(t *testing.T) {
 
 	t.Run("Container ID with special characters", func(t *testing.T) {
 		Test(t,
-			Description("Should handle container ID with special characters"),
+			Description("Non-UUID container ID returns 400"),
 			Get(tests.GetContainerURL("container-special")),
 			Send().Headers("Cookie").Add(cookies),
 			Send().Headers("X-Organization-Id").Add(orgID),
-			Expect().Status().Equal(http.StatusInternalServerError),
+			Expect().Status().Equal(http.StatusBadRequest),
 		)
 	})
 
@@ -190,11 +190,11 @@ func TestGetContainerErrorScenarios(t *testing.T) {
 	t.Run("Very long container ID", func(t *testing.T) {
 		longID := "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"
 		Test(t,
-			Description("Should handle very long container ID"),
+			Description("Non-UUID container ID returns 400"),
 			Get(tests.GetContainerURL(longID)),
 			Send().Headers("Cookie").Add(cookies),
 			Send().Headers("X-Organization-Id").Add(orgID),
-			Expect().Status().Equal(http.StatusInternalServerError),
+			Expect().Status().Equal(http.StatusBadRequest),
 		)
 	})
 }

--- a/api/internal/tests/healthcheck/healthcheck_test.go
+++ b/api/internal/tests/healthcheck/healthcheck_test.go
@@ -1,0 +1,601 @@
+package healthcheck
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/Eun/go-hit"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/tests"
+	"github.com/nixopus/nixopus/api/internal/testutils"
+)
+
+// --- List healthchecks ---
+
+func TestListHealthchecks_NoAuth(t *testing.T) {
+	Test(t,
+		Description("GET /healthcheck without auth returns 401"),
+		Get(tests.GetHealthCheckURL()),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestListHealthchecks_ValidAuth(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID := uuid.New().String()
+	Test(t,
+		Description("GET /healthcheck?application_id=<uuid> returns 200"),
+		Get(tests.GetHealthCheckURL()+"?application_id="+appID),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}
+
+func TestListHealthchecks_MissingApplicationID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /healthcheck without application_id returns 400"),
+		Get(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestListHealthchecks_InvalidOrgID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID := uuid.New().String()
+	Test(t,
+		Description("GET /healthcheck with invalid org ID returns 400"),
+		Get(tests.GetHealthCheckURL()+"?application_id="+appID),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("not-a-uuid"),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+// --- Create healthcheck ---
+
+func TestCreateHealthcheck_NoAuth(t *testing.T) {
+	Test(t,
+		Description("POST /healthcheck without auth returns 401"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id": uuid.New().String(),
+			"endpoint":       "/health",
+		}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestCreateHealthcheck_MissingApplicationID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /healthcheck without application_id returns 400"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"endpoint": "/health"}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestCreateHealthcheck_ValidMinimal(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("POST /healthcheck with application_id returns 200"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id": appID,
+		}),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+		Expect().Body().JSON().JQ(".data.id").NotEqual(nil),
+	)
+}
+
+func TestCreateHealthcheck_WithFullConfig(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("POST /healthcheck with full config returns 200"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id":        appID,
+			"endpoint":              "/health",
+			"interval_seconds":      60,
+			"timeout_seconds":       10,
+			"method":                "GET",
+			"expected_status_codes": []int{200},
+			"failure_threshold":     3,
+		}),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}
+
+func TestCreateHealthcheck_DuplicateApplicationID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create first healthcheck"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("POST /healthcheck with duplicate application_id returns error"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().OneOf(int64(http.StatusConflict), int64(http.StatusBadRequest), int64(http.StatusInternalServerError)),
+	)
+}
+
+// --- Update healthcheck ---
+
+func TestUpdateHealthcheck_NoAuth(t *testing.T) {
+	Test(t,
+		Description("PUT /healthcheck without auth returns 401"),
+		Put(tests.GetHealthCheckURL()),
+		Send().Body().JSON(map[string]interface{}{"application_id": uuid.New().String()}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestUpdateHealthcheck_MissingID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PUT /healthcheck without application_id returns 400"),
+		Put(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestUpdateHealthcheck_NonExistentID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PUT /healthcheck with non-existent application_id returns error"),
+		Put(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": uuid.New().String()}),
+		Expect().Status().OneOf(int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestUpdateHealthcheck_ValidFlow(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create healthcheck for update"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("PUT /healthcheck updates endpoint and interval"),
+		Put(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id":   appID,
+			"endpoint":         "/health/updated",
+			"interval_seconds": 120,
+		}),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}
+
+// --- Delete healthcheck ---
+
+func TestDeleteHealthcheck_NoAuth(t *testing.T) {
+	Test(t,
+		Description("DELETE /healthcheck without auth returns 401"),
+		Delete(tests.GetHealthCheckURL()+"?application_id="+uuid.New().String()),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestDeleteHealthcheck_MissingID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("DELETE /healthcheck without application_id returns 400"),
+		Delete(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestDeleteHealthcheck_NonExistentID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("DELETE /healthcheck with non-existent application_id returns error"),
+		Delete(tests.GetHealthCheckURL()+"?application_id="+uuid.New().String()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestDeleteHealthcheck_ValidFlow(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create healthcheck to delete"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("DELETE /healthcheck with valid application_id returns 200"),
+		Delete(tests.GetHealthCheckURL()+"?application_id="+appID),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}
+
+// --- Toggle healthcheck ---
+
+func TestToggleHealthcheck_NoAuth(t *testing.T) {
+	Test(t,
+		Description("PATCH /healthcheck/toggle without auth returns 401"),
+		Method("PATCH", tests.GetHealthCheckToggleURL()),
+		Send().Body().JSON(map[string]interface{}{"application_id": uuid.New().String(), "enabled": false}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestToggleHealthcheck_MissingID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PATCH /healthcheck/toggle without application_id returns 400"),
+		Method("PATCH", tests.GetHealthCheckToggleURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestToggleHealthcheck_NonExistentID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PATCH /healthcheck/toggle with non-existent application_id returns error"),
+		Method("PATCH", tests.GetHealthCheckToggleURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id": uuid.New().String(),
+			"enabled":        false,
+		}),
+		Expect().Status().OneOf(int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestToggleHealthcheck_ValidFlow(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create healthcheck for toggle"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("PATCH /healthcheck/toggle disables the check"),
+		Method("PATCH", tests.GetHealthCheckToggleURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id": appID,
+			"enabled":        false,
+		}),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+
+	Test(t,
+		Description("PATCH /healthcheck/toggle re-enables the check"),
+		Method("PATCH", tests.GetHealthCheckToggleURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"application_id": appID,
+			"enabled":        true,
+		}),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}
+
+// --- Healthcheck results ---
+
+func TestGetHealthcheckResults_NoAuth(t *testing.T) {
+	Test(t,
+		Description("GET /healthcheck/results without auth returns 401"),
+		Get(tests.GetHealthCheckResultsURL()),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestGetHealthcheckResults_MissingID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /healthcheck/results without application_id param returns 400"),
+		Get(tests.GetHealthCheckResultsURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestGetHealthcheckResults_ValidAuth(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create healthcheck for results"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("GET /healthcheck/results with valid application_id returns 200 (empty results)"),
+		Get(tests.GetHealthCheckResultsURL()+"?application_id="+appID),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}
+
+func TestGetHealthcheckResults_WithPagination(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create healthcheck for paginated results"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("GET /healthcheck/results with application_id and limit params"),
+		Get(tests.GetHealthCheckResultsURL()+"?application_id="+appID+"&limit=10"),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusOK),
+	)
+}
+
+// --- Healthcheck stats ---
+
+func TestGetHealthcheckStats_NoAuth(t *testing.T) {
+	Test(t,
+		Description("GET /healthcheck/stats without auth returns 401"),
+		Get(tests.GetHealthCheckStatsURL()),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestGetHealthcheckStats_MissingID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /healthcheck/stats without application_id param returns 400"),
+		Get(tests.GetHealthCheckStatsURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestGetHealthcheckStats_NonExistentID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /healthcheck/stats with random application_id returns 200 (empty stats)"),
+		Get(tests.GetHealthCheckStatsURL()+"?application_id="+uuid.New().String()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestGetHealthcheckStats_ValidFlow(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	appID, err := setup.SeedApplication(auth.User.ID.String(), auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to seed application: %v", err)
+	}
+
+	Test(t,
+		Description("Create healthcheck for stats"),
+		Post(tests.GetHealthCheckURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
+		Expect().Status().Equal(http.StatusOK),
+	)
+
+	Test(t,
+		Description("GET /healthcheck/stats returns uptime and response time stats"),
+		Get(tests.GetHealthCheckStatsURL()+"?application_id="+appID),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+	)
+}


### PR DESCRIPTION
## Summary

- Add UUID validation to 6 container controllers — invalid IDs now return 400 instead of 500
- Fix healthcheck FK violation: non-existent `application_id` returns 400 ("referenced application does not exist")
- Fix healthcheck delete returning 200 for missing row (now 404 via `RowsAffected`)
- Map storage-level "not found" errors to 404 in healthcheck error helper
- **601-line healthcheck test suite** — full CRUD, toggle, results, stats; uses `SeedApplication` for FK-safe inserts
- **460-line container ops test suite** — images list/prune, build cache prune, start/stop/restart/resources; corrected HTTP methods (POST for logs, PUT for resources)

## Test plan

- [ ] `go test ./api/internal/tests/healthcheck/...` — all 30 passing
- [ ] `go test ./api/internal/tests/container/...` — all passing
- [ ] Healthcheck create with non-existent application_id → 400
- [ ] Healthcheck delete of missing entry → 404
- [ ] Container invalid UUID path param → 400 (not 500)