### PR TITLE
feat(installer): add branch preview for testing PRs before merge

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -1,0 +1,196 @@
+# Workflow: Build Preview Images for Pull Requests
+# Description: Builds amd64-only Docker images tagged pr-<number> for testing PRs
+#              before merging. Comments install instructions on the PR automatically.
+# Cleanup: Preview images are deleted by cleanup_preview.yml when the PR closes.
+
+name: Preview Package Manager
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to build preview for (defaults to current branch HEAD)'
+        type: number
+        required: false
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ${{ github.repository }}-api
+  VIEW_IMAGE: ${{ github.repository }}-view
+  API_PORT: 8443
+  NEXT_PUBLIC_PORT: 7443
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      view: ${{ steps.filter.outputs.view }}
+      installer: ${{ steps.filter.outputs.installer }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'api/**'
+            view:
+              - 'view/**'
+            installer:
+              - 'installer/**'
+
+  build-api:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Create .env file
+        run: cp .env.sample api/.env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push API preview image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./api
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.API_IMAGE }}:pr-${{ github.event.pull_request.number || inputs.pr-number || github.ref_name }}
+          build-args: |
+            API_PORT=${{ env.API_PORT }}
+          cache-from: type=gha,scope=preview-api
+          cache-to: type=gha,mode=max,scope=preview-api
+          provenance: false
+
+  build-view:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.view == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Create .env file
+        run: cp .env.sample view/.env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push View preview image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./view
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.VIEW_IMAGE }}:pr-${{ github.event.pull_request.number || inputs.pr-number || github.ref_name }}
+          build-args: |
+            NEXT_PUBLIC_PORT=${{ env.NEXT_PUBLIC_PORT }}
+          cache-from: type=gha,scope=preview-view
+          cache-to: type=gha,mode=max,scope=preview-view
+          provenance: false
+
+  comment:
+    needs: [detect-changes, build-api, build-view]
+    if: always() && github.event_name == 'pull_request' && (needs.build-api.result == 'success' || needs.build-view.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Determine which images were built
+        id: images
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          OVERRIDES=""
+
+          if [ "${{ needs.build-api.result }}" = "success" ]; then
+            OVERRIDES="${OVERRIDES} NIXOPUS_API_IMAGE=${{ env.REGISTRY }}/${{ env.API_IMAGE }}:pr-${PR}"
+          fi
+          if [ "${{ needs.build-view.result }}" = "success" ]; then
+            OVERRIDES="${OVERRIDES} NIXOPUS_VIEW_IMAGE=${{ env.REGISTRY }}/${{ env.VIEW_IMAGE }}:pr-${PR}"
+          fi
+
+          echo "overrides=${OVERRIDES}" >> $GITHUB_OUTPUT
+
+      - name: Comment install instructions on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview-deploy
+          message: |
+            ## 🔍 Preview images built
+
+            Preview images for this PR are ready to test. Install on a VPS with:
+
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.pull_request.head.sha }}/installer/get.sh | \
+              sudo NIXOPUS_REPO_RAW=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.pull_request.head.sha }}/installer \
+              ${{ steps.images.outputs.overrides }} \
+              bash
+            ```
+
+            Or use the `--preview` flag:
+
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.pull_request.head.sha }}/installer/get.sh | \
+              sudo bash -s -- --preview ${{ github.event.pull_request.number }}
+            ```
+
+            <details>
+            <summary>Image tags</summary>
+
+            | Image | Tag | Built |
+            |-------|-----|-------|
+            | `${{ env.REGISTRY }}/${{ env.API_IMAGE }}` | `pr-${{ github.event.pull_request.number }}` | ${{ needs.build-api.result == 'success' && '✅' || '⏭️ skipped (no api/ changes)' }} |
+            | `${{ env.REGISTRY }}/${{ env.VIEW_IMAGE }}` | `pr-${{ github.event.pull_request.number }}` | ${{ needs.build-view.result == 'success' && '✅' || '⏭️ skipped (no view/ changes)' }} |
+
+            > Images not built for this PR will fall back to `:latest`.
+            </details>
+
+            <sub>Updated at ${{ github.event.pull_request.head.sha }} · Preview images are automatically cleaned up when this PR closes.</sub>

--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       api: ${{ steps.filter.outputs.api }}
       view: ${{ steps.filter.outputs.view }}
-      installer: ${{ steps.filter.outputs.installer }}
+      ci: ${{ steps.filter.outputs.ci }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -46,12 +46,13 @@ jobs:
               - 'api/**'
             view:
               - 'view/**'
-            installer:
+            ci:
+              - '.github/workflows/build_preview.yml'
               - 'installer/**'
 
   build-api:
     needs: detect-changes
-    if: needs.detect-changes.outputs.api == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -95,7 +96,7 @@ jobs:
 
   build-view:
     needs: detect-changes
-    if: needs.detect-changes.outputs.view == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.view == 'true' || needs.detect-changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/cleanup_preview.yml
+++ b/.github/workflows/cleanup_preview.yml
@@ -1,0 +1,149 @@
+# Workflow: Cleanup Preview Images
+# Description: Deletes PR-tagged preview images when a PR is closed (merged or not).
+#              Also runs weekly to sweep any orphaned preview packages older than 7 days.
+# Why: GHCR storage isn't free — preview images are ephemeral and should not accumulate.
+
+name: Cleanup Preview Packages
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    # Weekly sweep: every Monday at 03:00 UTC
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'Specific PR number to clean up (leave empty for scheduled sweep)'
+        type: number
+        required: false
+      dry-run:
+        description: 'Dry run — list what would be deleted without deleting'
+        type: boolean
+        default: false
+
+jobs:
+  cleanup-pr:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr-number)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [nixopus-api, nixopus-view]
+    steps:
+      - name: Delete pr-tagged version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE: ${{ matrix.package }}
+          PR_NUM: ${{ github.event.pull_request.number || inputs.pr-number }}
+          DRY_RUN: ${{ inputs.dry-run || 'false' }}
+        run: |
+          TAG="pr-${PR_NUM}"
+          ORG="${GITHUB_REPOSITORY_OWNER}"
+
+          echo "Looking for ${PACKAGE}:${TAG}..."
+
+          VERSION_ID=$(gh api \
+            "/orgs/${ORG}/packages/container/${PACKAGE}/versions" \
+            --paginate --jq ".[] | select(.metadata.container.tags[]? == \"${TAG}\") | .id" \
+            2>/dev/null || true)
+
+          if [ -z "$VERSION_ID" ]; then
+            # Try user endpoint if org endpoint fails (for personal accounts)
+            VERSION_ID=$(gh api \
+              "/user/packages/container/${PACKAGE}/versions" \
+              --paginate --jq ".[] | select(.metadata.container.tags[]? == \"${TAG}\") | .id" \
+              2>/dev/null || true)
+          fi
+
+          if [ -z "$VERSION_ID" ]; then
+            echo "No version found with tag ${TAG} — nothing to delete"
+            exit 0
+          fi
+
+          echo "Found version ID: ${VERSION_ID}"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[DRY RUN] Would delete ${PACKAGE}:${TAG} (version ${VERSION_ID})"
+            exit 0
+          fi
+
+          gh api --method DELETE \
+            "/orgs/${ORG}/packages/container/${PACKAGE}/versions/${VERSION_ID}" \
+            2>/dev/null || \
+          gh api --method DELETE \
+            "/user/packages/container/${PACKAGE}/versions/${VERSION_ID}" \
+            2>/dev/null || true
+
+          echo "Deleted ${PACKAGE}:${TAG}"
+
+  sweep-stale:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.pr-number)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [nixopus-api, nixopus-view]
+    steps:
+      - name: Delete preview versions older than 7 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE: ${{ matrix.package }}
+          DRY_RUN: ${{ inputs.dry-run || 'false' }}
+        run: |
+          ORG="${GITHUB_REPOSITORY_OWNER}"
+          CUTOFF=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+                   date -u -v-7d '+%Y-%m-%dT%H:%M:%SZ')
+
+          echo "Sweeping ${PACKAGE} preview tags older than ${CUTOFF}..."
+
+          STALE_VERSIONS=$(gh api \
+            "/orgs/${ORG}/packages/container/${PACKAGE}/versions" \
+            --paginate --jq "[.[] | select(
+              (.metadata.container.tags | length > 0) and
+              (.metadata.container.tags | all(startswith(\"pr-\"))) and
+              (.updated_at < \"${CUTOFF}\")
+            ) | {id, tags: .metadata.container.tags, updated: .updated_at}]" \
+            2>/dev/null || echo "[]")
+
+          COUNT=$(echo "$STALE_VERSIONS" | jq 'length')
+          echo "Found ${COUNT} stale preview version(s)"
+
+          if [ "$COUNT" = "0" ]; then
+            exit 0
+          fi
+
+          echo "$STALE_VERSIONS" | jq -r '.[] | "\(.id)\t\(.tags | join(","))\t\(.updated)"'
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[DRY RUN] Would delete ${COUNT} version(s)"
+            exit 0
+          fi
+
+          echo "$STALE_VERSIONS" | jq -r '.[].id' | while read -r vid; do
+            gh api --method DELETE \
+              "/orgs/${ORG}/packages/container/${PACKAGE}/versions/${vid}" \
+              2>/dev/null || true
+            echo "Deleted version ${vid}"
+          done
+
+  prune-untagged:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.pr-number)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [nixopus-api, nixopus-view]
+    steps:
+      - name: Delete untagged versions (keep latest 10)
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          delete-only-untagged-versions: true
+          min-versions-to-keep: 10
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true

--- a/installer/README.md
+++ b/installer/README.md
@@ -233,6 +233,65 @@ nixopus restart
 
 Users can also switch models per-chat from the model dropdown in the UI.
 
+## Branch Preview (Testing PRs before merge)
+
+Preview images are automatically built for every pull request. This lets you test a PR on a real VPS before merging.
+
+### Testing a PR
+
+When a PR is opened, CI builds `pr-<number>` tagged images and comments install instructions on the PR. Use the one-liner from the comment, or:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nixopus/nixopus/<branch>/installer/get.sh | \
+  sudo bash -s -- --preview <pr-number>
+```
+
+This pulls the API and View images tagged `pr-<number>` and uses the installer files from that PR's branch. Auth and Agent images fall back to `:latest` since they live in separate repos.
+
+### Testing a specific branch
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nixopus/nixopus/<branch>/installer/get.sh | \
+  sudo bash -s -- --branch <branch-name> --preview <pr-number>
+```
+
+### Testing a fork
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/<owner>/<repo>/<branch>/installer/get.sh | \
+  sudo bash -s -- --fork <owner>/<repo> --branch <branch-name>
+```
+
+For forks, you need to build and push images to your own GHCR first (the preview CI only runs on the main repo). You can also override individual images:
+
+```bash
+curl -fsSL install.nixopus.com | \
+  sudo NIXOPUS_API_IMAGE=ghcr.io/youruser/nixopus-api:my-branch \
+       NIXOPUS_VIEW_IMAGE=ghcr.io/youruser/nixopus-view:my-branch \
+       bash
+```
+
+### Image override variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NIXOPUS_API_IMAGE` | `ghcr.io/nixopus/nixopus-api:latest` | API container image |
+| `NIXOPUS_VIEW_IMAGE` | `ghcr.io/nixopus/nixopus-view:latest` | View container image |
+| `NIXOPUS_AUTH_IMAGE` | `ghcr.io/nixopus/auth:latest` | Auth container image |
+| `NIXOPUS_AGENT_IMAGE` | `ghcr.io/nixopus/agent:latest` | Agent container image |
+
+### Preview image cleanup
+
+Preview images are automatically deleted when the PR closes (merged or not). A weekly sweep also removes any orphaned preview images older than 7 days. You can also trigger cleanup manually from the Actions tab.
+
+### Reverting to stable
+
+Re-run the installer without `--preview` to go back to the latest stable images:
+
+```bash
+curl -fsSL install.nixopus.com | sudo bash
+```
+
 ## HTTPS
 
 When you provide a `DOMAIN`, Caddy automatically obtains and renews TLS certificates from Let's Encrypt. For this to work:
@@ -498,6 +557,17 @@ export NIXOPUS_TELEMETRY=off
 # Method 2 (DO_NOT_TRACK standard)
 export DO_NOT_TRACK=1
 ```
+
+### Installer CLI flags
+
+The installer accepts flags when invoked via `bash -s --`:
+
+| Flag | Description |
+|---|---|
+| `--preview <pr>` | Use preview images built for a PR |
+| `--branch <name>` | Fetch installer files from a specific branch |
+| `--fork <owner/repo>` | Fetch installer files and images from a fork |
+| `--help` | Show installer flags help |
 
 ## Contents
 

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -4,8 +4,85 @@ set -euo pipefail
 NIXOPUS_VERSION="0.3.0"
 NIXOPUS_HOME="${NIXOPUS_HOME:-/opt/nixopus}"
 TELEMETRY_URL="${NIXOPUS_TELEMETRY_URL:-https://api.nixopus.com/api/v1/cli/telemetry}"
-REPO_RAW="${NIXOPUS_REPO_RAW:-https://raw.githubusercontent.com/nixopus/nixopus/master/installer}"
+NIXOPUS_REPO="${NIXOPUS_REPO:-nixopus/nixopus}"
+NIXOPUS_BRANCH="${NIXOPUS_BRANCH:-master}"
+REPO_RAW="${NIXOPUS_REPO_RAW:-https://raw.githubusercontent.com/${NIXOPUS_REPO}/${NIXOPUS_BRANCH}/installer}"
 INSTALL_START=$(date +%s)
+
+# ── Argument Parsing ─────────────────────────────────────────────────────────
+
+PREVIEW_PR=""
+PREVIEW_FORK=""
+PREVIEW_BRANCH=""
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --preview)
+                shift
+                PREVIEW_PR="${1:-}"
+                [ -z "$PREVIEW_PR" ] && { echo "Usage: --preview <pr-number>" >&2; exit 1; }
+                ;;
+            --branch)
+                shift
+                PREVIEW_BRANCH="${1:-}"
+                [ -z "$PREVIEW_BRANCH" ] && { echo "Usage: --branch <branch-name>" >&2; exit 1; }
+                ;;
+            --fork)
+                shift
+                PREVIEW_FORK="${1:-}"
+                [ -z "$PREVIEW_FORK" ] && { echo "Usage: --fork <owner/repo>" >&2; exit 1; }
+                ;;
+            --help|-h)
+                echo "Usage: curl -fsSL install.nixopus.com | sudo bash -s -- [options]"
+                echo ""
+                echo "Options:"
+                echo "  --preview <pr>        Install from a PR's preview images (pr number)"
+                echo "  --branch <name>       Use installer files from a specific branch"
+                echo "  --fork <owner/repo>   Use installer files and images from a fork"
+                echo "  --help                Show this help"
+                echo ""
+                echo "Examples:"
+                echo "  # Test PR #42"
+                echo "  curl -fsSL install.nixopus.com | sudo bash -s -- --preview 42"
+                echo ""
+                echo "  # Test a branch from the main repo"
+                echo "  curl -fsSL ... | sudo bash -s -- --branch feat/new-feature --preview 42"
+                echo ""
+                echo "  # Test a fork"
+                echo "  curl -fsSL ... | sudo bash -s -- --fork someuser/nixopus --branch main"
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1 (use --help for usage)" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+}
+
+apply_preview_config() {
+    local repo="${PREVIEW_FORK:-${NIXOPUS_REPO}}"
+    local branch="${PREVIEW_BRANCH:-${NIXOPUS_BRANCH}}"
+
+    if [ -n "$PREVIEW_PR" ]; then
+        NIXOPUS_API_IMAGE="${NIXOPUS_API_IMAGE:-ghcr.io/${repo}-api:pr-${PREVIEW_PR}}"
+        NIXOPUS_VIEW_IMAGE="${NIXOPUS_VIEW_IMAGE:-ghcr.io/${repo}-view:pr-${PREVIEW_PR}}"
+        export NIXOPUS_API_IMAGE NIXOPUS_VIEW_IMAGE
+    fi
+
+    if [ -n "$PREVIEW_FORK" ]; then
+        branch="${PREVIEW_BRANCH:-main}"
+    fi
+
+    if [ -n "$PREVIEW_BRANCH" ] || [ -n "$PREVIEW_FORK" ]; then
+        REPO_RAW="${NIXOPUS_REPO_RAW:-https://raw.githubusercontent.com/${repo}/${branch}/installer}"
+    fi
+}
+
+parse_args "$@"
+apply_preview_config
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -568,6 +645,11 @@ DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
 GROQ_API_KEY=${GROQ_API_KEY:-}
 AGENT_MODEL=${AGENT_MODEL:-}
 AGENT_LIGHT_MODEL=${AGENT_LIGHT_MODEL:-}
+
+NIXOPUS_API_IMAGE=${NIXOPUS_API_IMAGE:-}
+NIXOPUS_VIEW_IMAGE=${NIXOPUS_VIEW_IMAGE:-}
+NIXOPUS_AUTH_IMAGE=${NIXOPUS_AUTH_IMAGE:-}
+NIXOPUS_AGENT_IMAGE=${NIXOPUS_AGENT_IMAGE:-}
 EOF
     chmod 600 "$NIXOPUS_HOME/.env"
 }
@@ -1247,6 +1329,11 @@ send_telemetry() {
 show_banner() {
     echo ""
     echo -e "${BOLD}  Nixopus Self-Host Installer v${NIXOPUS_VERSION}${NC}"
+    if [ -n "$PREVIEW_PR" ]; then
+        echo -e "  ${YELLOW}PREVIEW MODE — PR #${PREVIEW_PR}${NC}"
+    elif [ -n "$PREVIEW_BRANCH" ] || [ -n "$PREVIEW_FORK" ]; then
+        echo -e "  ${YELLOW}PREVIEW MODE — ${PREVIEW_FORK:-${NIXOPUS_REPO}}@${PREVIEW_BRANCH:-${NIXOPUS_BRANCH}}${NC}"
+    fi
     echo -e "  ${DIM}https://nixopus.com${NC}"
     echo ""
 }
@@ -1271,6 +1358,13 @@ show_complete() {
     elif [ -n "${ADMIN_EMAIL:-}" ]; then
         echo ""
         echo -e "  ${BOLD}Admin:${NC}     register at $BASE_URL/register"
+    fi
+    if [ -n "$PREVIEW_PR" ] || [ -n "$PREVIEW_BRANCH" ] || [ -n "$PREVIEW_FORK" ]; then
+        echo ""
+        echo -e "  ${YELLOW}${BOLD}Preview images:${NC}"
+        [ -n "${NIXOPUS_API_IMAGE:-}" ] && echo -e "    ${DIM}API:  ${NIXOPUS_API_IMAGE}${NC}"
+        [ -n "${NIXOPUS_VIEW_IMAGE:-}" ] && echo -e "    ${DIM}View: ${NIXOPUS_VIEW_IMAGE}${NC}"
+        echo -e "  ${YELLOW}To revert to stable: re-run the installer without --preview${NC}"
     fi
     echo ""
     echo -e "  ${BOLD}Commands:${NC}"


### PR DESCRIPTION
## Summary

- Add CI workflow (build_preview.yml) that builds pr-<number> tagged Docker images for every PR, only for changed services (api/view), and comments install instructions on the PR
- Add cleanup workflow (cleanup_preview.yml) that deletes preview images on PR close and runs a weekly sweep for stale pr-* tags older than 7 days
- Add --preview, --branch, and --fork flags to the installer (get.sh) for one-liner testing of any PR, branch, or fork

### Usage

```bash
# Test PR #42 on a VPS
curl -fsSL install.nixopus.com | sudo bash -s -- --preview 42

# Test a branch + PR
curl -fsSL ... | sudo bash -s -- --branch feat/new-thing --preview 42

# Test a fork
curl -fsSL ... | sudo bash -s -- --fork someuser/nixopus --branch main
```

### Cleanup

Preview images are ephemeral:
- Deleted automatically when the PR closes (merged or not)
- Weekly sweep removes any orphaned pr-* images older than 7 days
- Untagged dangling manifests pruned weekly (keeps latest 10)
- Manual cleanup available via workflow_dispatch with dry-run support

## Test plan

- [ ] Open a test PR that touches api/ — verify build_preview.yml triggers and builds only the API image
- [ ] Open a test PR that touches view/ — verify only the View image is built
- [ ] Verify the sticky PR comment appears with correct install instructions
- [ ] Run the installer with --preview <pr-number> on a test VPS and confirm the preview images are pulled
- [ ] Close the test PR and verify cleanup_preview.yml deletes the preview images
- [ ] Run bash -n installer/get.sh — syntax check passes
- [ ] Run --help flag — verify help text prints correctly