### PR TITLE
feat(machines): make machines page available for self-hosted users

### DIFF
--- a/api/internal/features/deploy/storage/init.go
+++ b/api/internal/features/deploy/storage/init.go
@@ -271,6 +271,7 @@ func (s *DeployStorage) GetApplications(page, pageSize int, sortBy string, sortD
 		Relation("Status").
 		Relation("Deployments.Status").
 		Relation("Domains.ComposeService").
+		Relation("Servers").
 		Limit(pageSize).
 		Offset(offset).
 		Where("a.organization_id = ?", organizationID)

--- a/api/internal/features/machine/service/registration.go
+++ b/api/internal/features/machine/service/registration.go
@@ -21,8 +21,6 @@ import (
 	cryptossh "golang.org/x/crypto/ssh"
 )
 
-const defaultMaxBYOSMachines = 2
-
 type MachineBillingChecker interface {
 	CanProvision(orgID uuid.UUID) error
 }
@@ -61,14 +59,6 @@ func NewRegistrationService(
 }
 
 func (s *RegistrationService) CreateMachine(orgID uuid.UUID, userID uuid.UUID, req types.CreateMachineRequest) (*types.CreateMachineResponse, error) {
-	count, err := s.storage.CountUserOwnedMachines(orgID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to count machines: %w", err)
-	}
-	if count >= defaultMaxBYOSMachines {
-		return nil, types.ErrMachineLimitReached
-	}
-
 	port := req.Port
 	if port == 0 {
 		port = 22

--- a/view/app/machines/page.tsx
+++ b/view/app/machines/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { MachinesScreen } from '@/packages/components/machines/machines-view';
+
+export default function MachinesPage() {
+  return <MachinesScreen />;
+}

--- a/view/lib/i18n/locales/en/navigation.json
+++ b/view/lib/i18n/locales/en/navigation.json
@@ -2,6 +2,7 @@
   "navigation": {
     "dashboard": "Charts",
     "selfHost": "Apps",
+    "machines": "Machines",
     "fileManager": "File Manager",
     "extensions": "Extensions",
     "settings": "Settings",

--- a/view/lib/i18n/locales/es/navigation.json
+++ b/view/lib/i18n/locales/es/navigation.json
@@ -2,6 +2,7 @@
   "navigation": {
     "dashboard": "Gráficos",
     "selfHost": "Apps",
+    "machines": "Máquinas",
     "fileManager": "Gestor de Archivos",
     "extensions": "Extensiones",
     "settings": "Configuración",

--- a/view/lib/i18n/locales/fr/navigation.json
+++ b/view/lib/i18n/locales/fr/navigation.json
@@ -2,6 +2,7 @@
   "navigation": {
     "dashboard": "Graphiques",
     "selfHost": "Apps",
+    "machines": "Machines",
     "fileManager": "Gestionnaire de Fichiers",
     "extensions": "Extensions",
     "settings": "Paramètres",

--- a/view/lib/i18n/locales/kn/navigation.json
+++ b/view/lib/i18n/locales/kn/navigation.json
@@ -2,6 +2,7 @@
   "navigation": {
     "dashboard": "ಚಾರ್ಟ್‌ಗಳು",
     "selfHost": "ಅಪ್ಲಿಕೇಶನ್‌ಗಳು",
+    "machines": "ಯಂತ್ರಗಳು",
     "fileManager": "ಫೈಲ್ ಮ್ಯಾನೇಜರ್",
     "extensions": "ವಿಸ್ತರಣೆಗಳು",
     "settings": "ಸೆಟ್ಟಿಂಗ್ಸ್",

--- a/view/lib/i18n/locales/ml/navigation.json
+++ b/view/lib/i18n/locales/ml/navigation.json
@@ -2,6 +2,7 @@
   "navigation": {
     "dashboard": "ചാർട്ടുകൾ",
     "selfHost": "ആപ്പുകൾ",
+    "machines": "മെഷീനുകൾ",
     "fileManager": "ഫയൽ മാനേജർ",
     "extensions": "എക്സ്റ്റെൻഷനുകൾ",
     "settings": "ക്രമീകരണങ്ങൾ",

--- a/view/middleware.ts
+++ b/view/middleware.ts
@@ -11,6 +11,7 @@ const CORE_PRIVATE_PATHS = [
   '/charts',
   '/chats',
   '/extensions',
+  '/machines',
   '/settings',
   '/activities',
   '/domains',

--- a/view/packages/components/machines/machines-view.tsx
+++ b/view/packages/components/machines/machines-view.tsx
@@ -1,0 +1,965 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import PageLayout from '@/packages/layouts/page-layout';
+import {
+  TypographyMuted,
+  CardWrapper,
+  CardTitle,
+  SearchBar,
+  PaginationWrapper,
+  Skeleton,
+  DataTable,
+  Badge,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@nixopus/ui';
+import {
+  Loader2,
+  AlertCircle,
+  Globe,
+  Plus,
+  RotateCw,
+  LayoutGrid,
+  List,
+  MoreVertical,
+  RefreshCw,
+  Pause,
+  Play,
+  HardDrive,
+  Trash2,
+  ChartColumnDecreasing,
+  DatabaseBackup,
+  Layers
+} from 'lucide-react';
+import { useDeleteMachineMutation } from '@/redux/services/servers/serversApi';
+import { DeleteDialog } from '@/components/ui/delete-dialog';
+import { toast } from 'sonner';
+import { AddMachineWizard } from '@/packages/components/machines/add-machine-wizard';
+import { useMachineCard } from '@/packages/hooks/machines/use-machine-card';
+import { useMachinesView } from '@/packages/hooks/machines/use-machines-view';
+import { useMachineLifecycle } from '@/packages/hooks/machines/use-machine-lifecycle';
+import { useMachineBackup } from '@/packages/hooks/backups/use-machine-backup';
+import type { Machine } from '@/packages/hooks/machines/use-machines';
+import type { Application } from '@/redux/types/applications';
+import type { LiveState } from '@/packages/hooks/machines/use-machine-lifecycle';
+
+export function formatRam(mb: number): string {
+  return mb >= 1024 ? `${(mb / 1024).toFixed(0)} GB` : `${mb} MB`;
+}
+
+const stateConfig: Record<
+  LiveState,
+  { color: string; pulse: boolean; label: string; useBadge?: boolean }
+> = {
+  Running: { color: 'bg-green-500', pulse: true, label: 'Running', useBadge: true },
+  Paused: { color: 'bg-yellow-500', pulse: false, label: 'Paused' },
+  Stopped: { color: 'bg-red-500', pulse: false, label: 'Stopped' },
+  unknown: { color: 'bg-gray-400', pulse: false, label: 'Unknown' }
+};
+
+const MachineStateIndicator = React.memo(function MachineStateIndicator({
+  state
+}: {
+  state: LiveState;
+}) {
+  const config = stateConfig[state];
+
+  if (config.useBadge) {
+    return (
+      <Badge
+        variant="secondary"
+        className="bg-green-500/10 text-green-200 uppercase border-green-500/20 text-xs rounded-full"
+      >
+        {config.label}
+      </Badge>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 shrink-0" title={config.label}>
+      <span className="text-xs text-muted-foreground">{config.label}</span>
+    </div>
+  );
+});
+
+interface MachineActionsDropdownProps {
+  liveState: LiveState;
+  isActionInFlight: boolean;
+  onAction: (action: 'restart' | 'pause' | 'resume') => void;
+  onBackup?: () => void;
+  isBackupInProgress?: boolean;
+  onDelete?: () => void;
+  isDeleting?: boolean;
+  machineLabel: string;
+  /** Extra menu items rendered after the backup action (used by premium for "Upgrade" link) */
+  extraMenuItems?: React.ReactNode;
+}
+
+const MachineActionsDropdown = React.memo(function MachineActionsDropdown({
+  liveState,
+  isActionInFlight,
+  onAction,
+  onBackup,
+  isBackupInProgress,
+  onDelete,
+  isDeleting,
+  machineLabel,
+  extraMenuItems
+}: MachineActionsDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          disabled={isActionInFlight}
+          onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          aria-label={`Actions for ${machineLabel}`}
+        >
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      >
+        <DropdownMenuItem onClick={() => onAction('restart')}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Restart
+        </DropdownMenuItem>
+        {onBackup && (
+          <DropdownMenuItem onClick={onBackup} disabled={isActionInFlight || isBackupInProgress}>
+            <HardDrive className="mr-2 h-4 w-4" />
+            {isBackupInProgress ? 'Backup in progress...' : 'Backup'}
+          </DropdownMenuItem>
+        )}
+        {extraMenuItems}
+        {liveState === 'Running' && (
+          <DropdownMenuItem onClick={() => onAction('pause')} disabled={isActionInFlight}>
+            <Pause className="mr-2 h-4 w-4" />
+            Pause
+          </DropdownMenuItem>
+        )}
+        {liveState === 'Paused' && (
+          <DropdownMenuItem onClick={() => onAction('resume')} disabled={isActionInFlight}>
+            <Play className="mr-2 h-4 w-4" />
+            Resume
+          </DropdownMenuItem>
+        )}
+        {onDelete && (
+          <DropdownMenuItem
+            onClick={onDelete}
+            disabled={isDeleting}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            {isDeleting ? 'Removing...' : 'Remove'}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+});
+
+const actionLabels: Record<string, string> = {
+  restart: 'Restarting...',
+  pause: 'Pausing...',
+  resume: 'Resuming...'
+};
+
+const MachineActionOverlay = React.memo(function MachineActionOverlay({
+  activeAction
+}: {
+  activeAction: string | null;
+}) {
+  if (!activeAction) return null;
+
+  return (
+    <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/60 backdrop-blur-[1px]">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>{actionLabels[activeAction] || 'Processing...'}</span>
+      </div>
+    </div>
+  );
+});
+
+const MACHINE_NAV_OPTIONS = [
+  { label: 'Charts', icon: ChartColumnDecreasing, path: 'charts' },
+  { label: 'Apps', icon: Layers, path: 'apps' },
+  { label: 'Backups', icon: DatabaseBackup, path: 'backups' }
+];
+
+export const MachineCard = React.memo(function MachineCard({ machine }: { machine: Machine }) {
+  const router = useRouter();
+  const { serverApplications, customDomains, isInteractive, isFailed } = useMachineCard(machine);
+  const machineLabel = machine.domain || '';
+  const isProvisioning = machine.status === 'provisioning';
+  const isActive = machine.status === 'active' || (!isProvisioning && !isFailed);
+
+  const { liveState, isActionInFlight, activeAction, handleAction } = useMachineLifecycle(
+    !isActive,
+    machine.ssh_key_id
+  );
+  const { handleTriggerBackup, hasInProgress: isBackupInProgress } = useMachineBackup(
+    machine.ssh_key_id
+  );
+  const [deleteMachine, { isLoading: isDeleting }] = useDeleteMachineMutation();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isNavOpen, setIsNavOpen] = useState(false);
+
+  const handleDeleteConfirm = React.useCallback(async () => {
+    try {
+      await deleteMachine(machine.ssh_key_id).unwrap();
+      toast.success('Machine removed');
+      setIsDeleteDialogOpen(false);
+    } catch (e: unknown) {
+      const err = e as { data?: { error?: string } };
+      toast.error(err?.data?.error || 'Failed to remove machine');
+    }
+  }, [deleteMachine, machine.ssh_key_id]);
+
+  const handleCardClick = React.useCallback((event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-machine-action-zone="true"]')) {
+      return;
+    }
+    setIsNavOpen(true);
+  }, []);
+
+  return (
+    <>
+      <DropdownMenu open={isNavOpen} onOpenChange={setIsNavOpen} modal={false}>
+        <DropdownMenuTrigger asChild>
+          <CardWrapper
+            onClick={handleCardClick}
+            className={`group relative rounded-md p-5 w-full overflow-hidden flex min-h-32 md:min-h-44 h-44 flex-col border-black-900/70 transition-colors cursor-pointer ${!isInteractive ? 'opacity-75' : ''} ${isFailed ? 'border-destructive/30' : ''}`}
+            header={
+              <div className="flex-1 min-w-0 w-full space-y-1.5">
+                <div className="flex w-full min-w-0 items-start justify-between gap-2">
+                  <div className="min-w-0 flex-1 max-w-full">
+                    <div className="flex items-start gap-2 flex-wrap">
+                      <div className="min-w-0 max-w-full">
+                        <CardTitle
+                          className="text-base font-semibold wrap-break-word max-w-full"
+                          style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            maxWidth: '100%'
+                          }}
+                        >
+                          {machineLabel}
+                        </CardTitle>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-machine-action-zone="true"
+                    className="flex items-center gap-1 ml-auto shrink-0"
+                    onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {isActive && (
+                      <MachineActionsDropdown
+                        liveState={liveState}
+                        isActionInFlight={isActionInFlight}
+                        onAction={handleAction}
+                        onBackup={handleTriggerBackup}
+                        isBackupInProgress={isBackupInProgress}
+                        onDelete={() => setIsDeleteDialogOpen(true)}
+                        isDeleting={isDeleting}
+                        machineLabel={machineLabel}
+                      />
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {isActive ? (
+                    <MachineStateIndicator state={liveState} />
+                  ) : (
+                    <MachineStatusBadge status={machine.status} />
+                  )}
+                </div>
+                {machine.is_active === false && machine.status === 'active' && (
+                  <Badge variant="outline" className="text-amber-500 border-amber-500/30 text-xs">
+                    Offline
+                  </Badge>
+                )}
+              </div>
+            }
+            headerClassName="w-full min-w-0 pb-0 px-0"
+            contentClassName="space-y-1.5"
+          >
+            <MachineActionOverlay activeAction={activeAction} />
+            <MachineCardContent
+              status={machine.status}
+              applications={serverApplications}
+              customDomains={customDomains}
+            />
+            {(machine.total_vcpu > 0 || machine.total_ram_mb > 0 || machine.total_disk_gb > 0) && (
+              <div className="flex items-center gap-3 pt-1.5 border-t border-border/50 flex-wrap">
+                {machine.total_vcpu > 0 && (
+                  <span className="text-xs text-muted-foreground">{machine.total_vcpu} CPU</span>
+                )}
+                {machine.total_ram_mb > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    {formatRam(machine.total_ram_mb)} RAM
+                  </span>
+                )}
+                {machine.total_disk_gb > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    {machine.total_disk_gb} GB Disk
+                  </span>
+                )}
+              </div>
+            )}
+          </CardWrapper>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-44">
+          {MACHINE_NAV_OPTIONS.map((opt) => (
+            <DropdownMenuItem
+              key={opt.path}
+              onClick={() => router.push(`/machines/${machine.ssh_key_id}/${opt.path}`)}
+            >
+              <opt.icon className="h-4 w-4 mr-2" />
+              {opt.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DeleteDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={handleDeleteConfirm}
+        isDeleting={isDeleting}
+        title="Remove Machine"
+        description={`Are you sure you want to remove "${machineLabel}"? This action cannot be undone.`}
+        confirmText="Remove"
+        variant="destructive"
+        icon={Trash2}
+      />
+    </>
+  );
+});
+
+const MachineStatusBadge = React.memo(function MachineStatusBadge({
+  status
+}: {
+  status?: Machine['status'];
+}) {
+  if (status === 'provisioning') {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground shrink-0">
+        <Loader2 className="h-3 w-3 animate-spin text-primary" />
+        <span>Provisioning</span>
+      </div>
+    );
+  }
+
+  if (status === 'failed') {
+    return (
+      <div className="flex items-center gap-2 text-xs text-destructive shrink-0">
+        <AlertCircle className="h-3 w-3" />
+        <span>Failed</span>
+      </div>
+    );
+  }
+
+  return null;
+});
+
+const MachineCardContent = React.memo(function MachineCardContent({
+  status,
+  applications = [],
+  customDomains = []
+}: {
+  status?: Machine['status'];
+  applications?: Application[];
+  customDomains?: string[];
+}) {
+  if (status === 'provisioning') {
+    return (
+      <TypographyMuted className="text-xs text-muted-foreground">
+        Your machine is being set up. This may take a few moments...
+      </TypographyMuted>
+    );
+  }
+
+  if (status === 'failed') {
+    return (
+      <TypographyMuted className="text-xs text-destructive/80">
+        Machine setup failed. It will be retried automatically.
+      </TypographyMuted>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {applications.length > 0 && (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="font-medium">{applications.length}</span>
+            <span>{applications.length === 1 ? 'app' : 'apps'} deployed</span>
+          </div>
+          {customDomains.length > 0 && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Globe className="h-3 w-3" />
+                <span className="font-medium">Custom domains:</span>
+              </div>
+              <div className="flex flex-col gap-1 pl-4">
+                {customDomains.slice(0, 3).map((domain, idx) => (
+                  <span key={idx} title={domain} className="truncate">
+                    <TypographyMuted className="text-xs text-muted-foreground truncate">
+                      {domain}
+                    </TypographyMuted>
+                  </span>
+                ))}
+                {customDomains.length > 3 && (
+                  <TypographyMuted className="text-xs text-muted-foreground">
+                    +{customDomains.length - 3} more
+                  </TypographyMuted>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+function MachinesSkeleton({
+  showHeader = true,
+  showSearch = true
+}: {
+  showHeader?: boolean;
+  showSearch?: boolean;
+}) {
+  return (
+    <div>
+      {showHeader && (
+        <>
+          <Skeleton className="h-8 w-36 mb-4" />
+          {showSearch && (
+            <div className="flex items-center justify-between flex-wrap gap-3 pb-4 pt-6">
+              <Skeleton className="h-9 w-64" />
+              <Skeleton className="h-8 w-8 rounded" />
+            </div>
+          )}
+        </>
+      )}
+      {!showHeader && showSearch && (
+        <div className="mb-6">
+          <Skeleton className="h-9 w-64" />
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <CardWrapper
+            key={i}
+            className="group relative rounded-md p-5 w-full overflow-hidden flex min-h-32 md:min-h-44 h-44 flex-col border-black-900/70"
+            header={
+              <div className="flex-1 min-w-0 w-full space-y-1.5">
+                <div className="flex w-full min-w-0 items-start justify-between gap-2">
+                  <Skeleton className="h-5 w-40" />
+                </div>
+                <Skeleton className="h-3.5 w-16" />
+              </div>
+            }
+            headerClassName="w-full min-w-0 pb-0 px-0"
+            contentClassName="space-y-1.5"
+          >
+            <div className="space-y-2">
+              <div className="space-y-1.5">
+                <Skeleton className="h-3.5 w-28" />
+                <Skeleton className="h-3.5 w-36" />
+              </div>
+            </div>
+            <div className="flex items-center gap-3 pt-1.5 border-t border-border/50">
+              <Skeleton className="h-3.5 w-12" />
+              <Skeleton className="h-3.5 w-16" />
+              <Skeleton className="h-3.5 w-16" />
+            </div>
+          </CardWrapper>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const ProvisioningMachineCard = React.memo(function ProvisioningMachineCard({
+  progress = 0
+}: {
+  progress?: number;
+}) {
+  const clampedProgress = Math.min(100, Math.max(0, progress));
+
+  return (
+    <CardWrapper
+      className="group relative rounded-md p-5 w-full overflow-hidden flex min-h-32 md:min-h-44 h-44 flex-col border-black-900/70 cursor-default opacity-75"
+      header={
+        <div className="flex-1 min-w-0 w-full space-y-1.5">
+          <div className="flex w-full min-w-0 items-start justify-between gap-2">
+            <div className="min-w-0 flex-1 max-w-full">
+              <CardTitle
+                className="text-base font-semibold wrap-break-word max-w-full"
+                style={{ wordBreak: 'break-word', overflowWrap: 'break-word', maxWidth: '100%' }}
+              >
+                Domain pending
+              </CardTitle>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground shrink-0">
+              <Loader2 className="h-3 w-3 animate-spin text-primary" />
+              <span>Provisioning</span>
+              {clampedProgress > 0 && (
+                <span className="text-primary font-medium">{clampedProgress}%</span>
+              )}
+            </div>
+          </div>
+        </div>
+      }
+      headerClassName="w-full min-w-0 pb-0 px-0"
+      contentClassName="relative flex-1"
+    >
+      <div
+        className="absolute bottom-0 left-0 right-0 bg-primary/10 transition-[height] duration-700 ease-in-out rounded-b-md"
+        style={{ height: `${clampedProgress}%` }}
+      />
+    </CardWrapper>
+  );
+});
+
+interface MachinesEmptyStateProps {
+  isProvisioning?: boolean;
+  provisioningHasError?: boolean;
+  onRetry?: () => void;
+  canRetry?: boolean;
+  isRetrying?: boolean;
+  retryCount?: number;
+  maxRetries?: number;
+}
+
+function MachinesEmptyState({
+  isProvisioning,
+  provisioningHasError,
+  onRetry,
+  canRetry = true,
+  isRetrying,
+  retryCount = 0,
+  maxRetries = 3
+}: MachinesEmptyStateProps) {
+  if (isProvisioning || isRetrying) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px] gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <TypographyMuted className="text-sm text-muted-foreground">
+          Setting up your machine...
+        </TypographyMuted>
+      </div>
+    );
+  }
+
+  if (provisioningHasError) {
+    const exhaustedRetries = retryCount >= maxRetries;
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px] gap-3">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <TypographyMuted className="text-sm text-muted-foreground text-center max-w-md">
+          {exhaustedRetries
+            ? 'Machine provisioning failed after multiple attempts. Please '
+            : 'Machine provisioning failed. You can retry or '}
+          <a
+            href="mailto:raghav@nixopus.com?subject=Machine%20Provisioning%20Issue"
+            className="text-primary hover:underline"
+          >
+            contact support
+          </a>
+          {exhaustedRetries ? '.' : ' if the issue persists.'}
+        </TypographyMuted>
+        {onRetry && canRetry && (
+          <button
+            onClick={onRetry}
+            className="mt-2 px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Retry Provisioning ({maxRetries - retryCount} left)
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] gap-3">
+      <TypographyMuted className="text-lg">No machines yet</TypographyMuted>
+      <TypographyMuted className="text-sm text-muted-foreground text-center max-w-md">
+        Machines are your servers where apps are deployed and run. Get started by adding your first
+        machine.
+      </TypographyMuted>
+    </div>
+  );
+}
+
+function AddMachineCard({ onClick }: { onClick?: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="group relative w-full h-full min-h-[120px] rounded-lg border-2 border-dashed border-border/50 hover:border-primary/40 hover:bg-muted/50 transition-colors cursor-pointer flex flex-col items-center justify-center gap-2 p-6"
+    >
+      <div className="h-10 w-10 rounded-full bg-muted group-hover:bg-primary/10 flex items-center justify-center transition-colors">
+        <Plus className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+      </div>
+      <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground transition-colors">
+        Add Machine
+      </span>
+    </button>
+  );
+}
+
+const MachineRowActions = React.memo(function MachineRowActions({ machine }: { machine: Machine }) {
+  const { isFailed } = useMachineCard(machine);
+  const isProvisioning = machine.status === 'provisioning';
+  const isActive = machine.status === 'active' || (!isProvisioning && !isFailed);
+  const { liveState, isActionInFlight, handleAction } = useMachineLifecycle(
+    !isActive,
+    machine.ssh_key_id
+  );
+  const { handleTriggerBackup, hasInProgress: isBackupInProgress } = useMachineBackup(
+    machine.ssh_key_id
+  );
+
+  if (!isActive) return null;
+
+  return (
+    <div className="flex items-center justify-end" onClick={(e) => e.stopPropagation()}>
+      <MachineActionsDropdown
+        liveState={liveState}
+        isActionInFlight={isActionInFlight}
+        onAction={handleAction}
+        onBackup={handleTriggerBackup}
+        isBackupInProgress={isBackupInProgress}
+        machineLabel={machine.domain || 'Domain pending'}
+      />
+    </div>
+  );
+});
+
+const MachineRowStatus = React.memo(function MachineRowStatus({ machine }: { machine: Machine }) {
+  const { isFailed } = useMachineCard(machine);
+  const isProvisioning = machine.status === 'provisioning';
+  const isActive = machine.status === 'active' || (!isProvisioning && !isFailed);
+  const { liveState } = useMachineLifecycle(!isActive, machine.ssh_key_id);
+
+  if (isActive) return <MachineStateIndicator state={liveState} />;
+  if (isProvisioning) {
+    return (
+      <Badge variant="secondary" className="rounded-sm opacity-80">
+        <Loader2 className="h-3 w-3 animate-spin mr-1" />
+        Provisioning
+      </Badge>
+    );
+  }
+  if (isFailed) {
+    return (
+      <Badge variant="destructive" className="rounded-sm opacity-80">
+        Failed
+      </Badge>
+    );
+  }
+  return null;
+});
+
+const MACHINE_TABLE_COLUMNS = [
+  {
+    key: 'domain',
+    title: 'Domain',
+    render: (_: unknown, machine: Machine) => (
+      <span className="text-sm font-medium truncate block max-w-[260px]">
+        {machine.domain || 'Domain pending'}
+      </span>
+    )
+  },
+  {
+    key: 'status',
+    title: 'Status',
+    render: (_: unknown, machine: Machine) => <MachineRowStatus machine={machine} />
+  },
+  {
+    key: 'cpu',
+    title: 'CPU',
+    render: (_: unknown, machine: Machine) => (
+      <span className="text-sm text-muted-foreground tabular-nums">
+        {machine.total_vcpu > 0 ? `${machine.total_vcpu} vCPU` : '—'}
+      </span>
+    )
+  },
+  {
+    key: 'ram',
+    title: 'RAM',
+    render: (_: unknown, machine: Machine) => (
+      <span className="text-sm text-muted-foreground tabular-nums">
+        {machine.total_ram_mb > 0 ? formatRam(machine.total_ram_mb) : '—'}
+      </span>
+    )
+  },
+  {
+    key: 'disk',
+    title: 'Disk',
+    render: (_: unknown, machine: Machine) => (
+      <span className="text-sm text-muted-foreground tabular-nums">
+        {machine.total_disk_gb > 0 ? `${machine.total_disk_gb} GB` : '—'}
+      </span>
+    )
+  },
+  {
+    key: 'actions',
+    title: '',
+    render: (_: unknown, machine: Machine) => <MachineRowActions machine={machine} />
+  }
+];
+
+function MachinesTable({
+  machines,
+  tableClassName
+}: {
+  machines: Machine[];
+  tableClassName?: string;
+}) {
+  const router = useRouter();
+  return (
+    <div className={`overflow-hidden rounded-md border ${tableClassName || ''}`}>
+      <DataTable
+        data={machines}
+        columns={MACHINE_TABLE_COLUMNS}
+        showBorder={false}
+        onRowClick={(machine: Machine) => router.push(`/machines/${machine.ssh_key_id}/charts`)}
+        hoverable
+      />
+    </div>
+  );
+}
+
+export interface MachinesViewProps {
+  showHeader?: boolean;
+  showSearch?: boolean;
+  headerTitle?: string;
+  searchLabel?: string;
+  className?: string;
+  isLoading?: boolean;
+  isProvisioning?: boolean;
+  provisioningHasError?: boolean;
+  onRetryProvisioning?: () => void;
+  canRetry?: boolean;
+  isRetrying?: boolean;
+  retryCount?: number;
+  maxRetries?: number;
+  provisioningProgress?: number;
+  tableClassName?: string;
+  /** Override the default data hook. Premium injects its billing-gated version here. */
+  useDataHook?: (isLoadingProp?: boolean) => ReturnType<typeof useMachinesView>;
+}
+
+export function MachinesView({
+  showHeader = true,
+  showSearch = true,
+  headerTitle = 'Machines',
+  searchLabel = 'Search machines...',
+  className = '',
+  isLoading: isLoadingProp,
+  isProvisioning,
+  provisioningHasError,
+  onRetryProvisioning,
+  canRetry,
+  isRetrying,
+  retryCount,
+  maxRetries,
+  provisioningProgress = 0,
+  tableClassName,
+  useDataHook = useMachinesView
+}: MachinesViewProps) {
+  const {
+    searchTerm,
+    currentPage,
+    machines,
+    paginatedMachines,
+    totalPages,
+    isLoading,
+    error,
+    handleSearchChange,
+    handlePageChange,
+    isFetching,
+    refetch
+  } = useDataHook(isLoadingProp);
+
+  const [isWizardOpen, setIsWizardOpen] = React.useState(false);
+  const [viewMode, setViewMode] = React.useState<'grid' | 'table'>('grid');
+
+  if (isLoading) {
+    return <MachinesSkeleton showHeader={showHeader} showSearch={showSearch} />;
+  }
+
+  if (error) {
+    return (
+      <div className={className}>
+        {showHeader && <h1 className="text-2xl tracking-wide pb-4 sm:pb-6">{headerTitle}</h1>}
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center space-y-3">
+            <AlertCircle className="h-10 w-10 text-destructive mx-auto" />
+            <TypographyMuted className="text-lg">Failed to load machines</TypographyMuted>
+            <TypographyMuted className="text-sm text-muted-foreground">
+              Something went wrong while loading your machines. Please try again.
+            </TypographyMuted>
+            <Button variant="outline" size="sm" onClick={() => refetch()} className="gap-2">
+              <RefreshCw className="h-4 w-4" />
+              Retry
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const headerContent = showHeader && (
+    <>
+      <h1 className="text-2xl tracking-wide pb-4 sm:pb-6">{headerTitle}</h1>
+      <div className="flex items-center justify-between flex-wrap gap-3 pb-4 pt-6">
+        <div className="w-full max-w-xs">
+          {showSearch && machines.length > 0 && (
+            <SearchBar
+              searchTerm={searchTerm}
+              handleSearchChange={handleSearchChange}
+              label={searchLabel}
+              isLoading={false}
+              className="[&_input]:w-full!"
+            />
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center border rounded-md">
+            <Button
+              variant={viewMode === 'grid' ? 'secondary' : 'ghost'}
+              size="icon"
+              className="h-8 w-8 rounded-r-none border-0"
+              onClick={() => setViewMode('grid')}
+              aria-label="Grid view"
+            >
+              <LayoutGrid className="h-4 w-4" />
+            </Button>
+            <Button
+              variant={viewMode === 'table' ? 'secondary' : 'ghost'}
+              size="icon"
+              className="h-8 w-8 rounded-l-none border-0"
+              onClick={() => setViewMode('table')}
+              aria-label="Table view"
+            >
+              <List className="h-4 w-4" />
+            </Button>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => refetch()}
+            className="h-8 w-8"
+            aria-label="Refresh machines"
+          >
+            <RotateCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+
+  if (machines.length === 0) {
+    if (isProvisioning || isRetrying) {
+      return (
+        <div className={className}>
+          {headerContent}
+          <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+            <ProvisioningMachineCard progress={provisioningProgress} />
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className={className}>
+        {headerContent}
+        <MachinesEmptyState
+          isProvisioning={false}
+          provisioningHasError={provisioningHasError}
+          onRetry={onRetryProvisioning}
+          canRetry={canRetry}
+          isRetrying={false}
+          retryCount={retryCount}
+          maxRetries={maxRetries}
+        />
+        {!provisioningHasError && (
+          <div className="flex justify-center mt-4">
+            <Button onClick={() => setIsWizardOpen(true)} className="gap-2">
+              <Plus className="h-4 w-4" />
+              Add Machine
+            </Button>
+          </div>
+        )}
+        <AddMachineWizard open={isWizardOpen} onOpenChange={setIsWizardOpen} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      {headerContent}
+      {!showHeader && showSearch && (
+        <div className="mb-6">
+          <SearchBar
+            searchTerm={searchTerm}
+            handleSearchChange={handleSearchChange}
+            label={searchLabel}
+            isLoading={false}
+          />
+        </div>
+      )}
+
+      {viewMode === 'grid' ? (
+        <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+          {paginatedMachines.map((machine) => (
+            <MachineCard key={machine.id} machine={machine} />
+          ))}
+          <AddMachineCard onClick={() => setIsWizardOpen(true)} />
+        </div>
+      ) : (
+        <MachinesTable machines={paginatedMachines} tableClassName={tableClassName} />
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-8 flex justify-center">
+          <PaginationWrapper
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      )}
+      <AddMachineWizard open={isWizardOpen} onOpenChange={setIsWizardOpen} />
+    </div>
+  );
+}
+
+export function MachinesScreen() {
+  return (
+    <PageLayout maxWidth="6xl" padding="md" spacing="lg">
+      <MachinesView />
+    </PageLayout>
+  );
+}

--- a/view/packages/hooks/machines/use-machine-card.ts
+++ b/view/packages/hooks/machines/use-machine-card.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useGetApplicationsQuery } from '@/redux/services/deploy/applicationsApi';
+import type { Application } from '@/redux/types/applications';
+import type { Machine } from './use-machines';
+
+export function useMachineCard(machine: Machine) {
+  const isProvisioning = machine.status === 'provisioning';
+  const isFailed = machine.status === 'failed';
+
+  const { data: applicationsData } = useGetApplicationsQuery(
+    { page: 1, limit: 1000 },
+    { skip: isProvisioning || isFailed }
+  );
+
+  const serverApplications = useMemo(() => {
+    if (!applicationsData?.applications || !machine.ssh_key_id) return [];
+    return applicationsData.applications.filter((app: Application) =>
+      app.servers?.some((s) => s.server_id === machine.ssh_key_id)
+    );
+  }, [applicationsData, machine.ssh_key_id]);
+
+  const customDomains = useMemo(() => {
+    const domains = new Set<string>();
+    serverApplications.forEach((app: Application) => {
+      if (app.domains && app.domains.length > 0) {
+        app.domains.forEach((domain) => {
+          domains.add(domain.domain);
+        });
+      }
+    });
+    return Array.from(domains);
+  }, [serverApplications]);
+
+  return {
+    serverApplications,
+    customDomains,
+    isProvisioning,
+    isFailed,
+    isInteractive: !isProvisioning && !isFailed
+  };
+}

--- a/view/packages/hooks/machines/use-machine-lifecycle.ts
+++ b/view/packages/hooks/machines/use-machine-lifecycle.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  useGetMachineStatusQuery,
+  useRestartMachineMutation,
+  usePauseMachineMutation,
+  useResumeMachineMutation
+} from '@/redux/services/servers/serversApi';
+
+export type LiveState = 'Running' | 'Paused' | 'Stopped' | 'unknown';
+
+const BASE_POLL_MS = 30_000;
+const MAX_POLL_MS = 5 * 60_000;
+
+export function useMachineLifecycle(skip: boolean, serverId?: string) {
+  const [consecutiveErrors, setConsecutiveErrors] = useState(0);
+  const prevFetchingRef = useRef(false);
+
+  const pollingInterval = useMemo(() => {
+    if (consecutiveErrors === 0) return BASE_POLL_MS;
+    return Math.min(BASE_POLL_MS * Math.pow(2, consecutiveErrors), MAX_POLL_MS);
+  }, [consecutiveErrors]);
+
+  const queryArg = serverId ? { server_id: serverId } : undefined;
+
+  const {
+    data: machineStatus,
+    isLoading: isStatusLoading,
+    isFetching: isStatusFetching,
+    isError: isStatusError
+  } = useGetMachineStatusQuery(queryArg, {
+    skip,
+    pollingInterval,
+    refetchOnMountOrArgChange: 30
+  });
+
+  useEffect(() => {
+    const wasFetching = prevFetchingRef.current;
+    prevFetchingRef.current = isStatusFetching;
+
+    if (wasFetching && !isStatusFetching && !skip) {
+      if (isStatusError) {
+        setConsecutiveErrors((c: number) => c + 1);
+      } else {
+        setConsecutiveErrors(0);
+      }
+    }
+  }, [isStatusFetching, isStatusError, skip]);
+
+  const [restartMachine, restartState] = useRestartMachineMutation();
+  const [pauseMachine, pauseState] = usePauseMachineMutation();
+  const [resumeMachine, resumeState] = useResumeMachineMutation();
+
+  const isActionInFlight = restartState.isLoading || pauseState.isLoading || resumeState.isLoading;
+
+  const activeAction: string | null = restartState.isLoading
+    ? 'restart'
+    : pauseState.isLoading
+      ? 'pause'
+      : resumeState.isLoading
+        ? 'resume'
+        : null;
+
+  const liveState: LiveState = useMemo(() => {
+    if (!machineStatus) return 'unknown';
+    if (!machineStatus.active) return 'Stopped';
+    return (machineStatus.state as LiveState) || 'unknown';
+  }, [machineStatus]);
+
+  const handleAction = useCallback(
+    async (action: 'restart' | 'pause' | 'resume') => {
+      const actionLabels = {
+        restart: { ing: 'Restarting', ed: 'restarted' },
+        pause: { ing: 'Pausing', ed: 'paused' },
+        resume: { ing: 'Resuming', ed: 'resumed' }
+      };
+      const label = actionLabels[action];
+      const params = serverId ? { server_id: serverId } : undefined;
+      const mutationFn =
+        action === 'restart'
+          ? () => restartMachine(params)
+          : action === 'pause'
+            ? () => pauseMachine(params)
+            : () => resumeMachine(params);
+
+      try {
+        await mutationFn().unwrap();
+        toast.success(`Machine ${label.ed} successfully`);
+      } catch (err: unknown) {
+        const e = err as { data?: { detail?: string; message?: string } };
+        const detail = e?.data?.detail || e?.data?.message || `Failed to ${action} machine`;
+        toast.error(detail);
+      }
+    },
+    [restartMachine, pauseMachine, resumeMachine, serverId]
+  );
+
+  return {
+    liveState,
+    isStatusLoading,
+    isStatusFetching,
+    isActionInFlight,
+    activeAction,
+    machineStatus,
+    handleAction
+  };
+}

--- a/view/packages/hooks/machines/use-machines-view.ts
+++ b/view/packages/hooks/machines/use-machines-view.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useMachines } from './use-machines';
+
+export function useMachinesView(isLoadingProp?: boolean) {
+  const machinesData = useMachines();
+  const isLoading = isLoadingProp !== undefined ? isLoadingProp : machinesData.isLoading;
+
+  return {
+    ...machinesData,
+    isLoading
+  };
+}

--- a/view/packages/hooks/machines/use-machines.ts
+++ b/view/packages/hooks/machines/use-machines.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useGetServersQuery } from '@/redux/services/servers/serversApi';
+import type { Server } from '@/redux/types/servers';
+
+export type Machine = {
+  id: string;
+  ssh_key_id: string;
+  name: string;
+  domain: string;
+  status?: 'provisioning' | 'active' | 'failed';
+  is_active?: boolean;
+  total_vcpu: number;
+  total_ram_mb: number;
+  total_disk_gb: number;
+};
+
+const PAGE_SIZE = 6;
+
+function mapServerToMachine(server: Server): Machine {
+  const { provision } = server;
+
+  let status: 'provisioning' | 'active' | 'failed' | undefined;
+  if (provision) {
+    if (provision.status === 'ACTIVE') {
+      status = 'active';
+    } else if (provision.status === 'FAILED') {
+      status = 'failed';
+    } else if (provision.status === 'PROVISIONING' || provision.status === 'NOT_STARTED') {
+      status = 'provisioning';
+    }
+  }
+
+  const domain = provision?.domain?.trim() || server.host?.trim() || server.name;
+
+  return {
+    id: provision?.id || server.id,
+    ssh_key_id: server.id,
+    name: server.name,
+    domain,
+    status,
+    is_active: server.is_active,
+    total_vcpu: server.total_vcpu,
+    total_ram_mb: server.total_ram_mb,
+    total_disk_gb: server.total_disk_gb
+  };
+}
+
+export function useMachines() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const {
+    data: serversData,
+    isLoading,
+    isFetching,
+    error,
+    refetch
+  } = useGetServersQuery({
+    sort_by: 'created_at',
+    sort_order: 'desc'
+  });
+
+  const machines = useMemo(() => {
+    if (!serversData?.servers) return [];
+    return serversData.servers.map(mapServerToMachine);
+  }, [serversData]);
+
+  const filteredMachines = useMemo(
+    () =>
+      machines.filter(
+        (machine) =>
+          machine.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          machine.domain.toLowerCase().includes(searchTerm.toLowerCase())
+      ),
+    [machines, searchTerm]
+  );
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(filteredMachines.length / PAGE_SIZE)),
+    [filteredMachines.length]
+  );
+
+  const paginatedMachines = useMemo(() => {
+    const startIndex = (currentPage - 1) * PAGE_SIZE;
+    const endIndex = startIndex + PAGE_SIZE;
+    return filteredMachines.slice(startIndex, endIndex);
+  }, [filteredMachines, currentPage]);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return {
+    searchTerm,
+    machines,
+    currentPage,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+    filteredMachines,
+    paginatedMachines,
+    totalPages,
+    handleSearchChange,
+    handlePageChange
+  };
+}

--- a/view/packages/hooks/shared/use-app-sidebar.ts
+++ b/view/packages/hooks/shared/use-app-sidebar.ts
@@ -19,7 +19,7 @@ import { apiKeysApi } from '@/redux/services/api-keys/apiKeysApi';
 import { machineBackupApi } from '@/redux/services/machine/machineBackupApi';
 import { customDomainsApi } from '@/redux/services/domains/customDomainsApi';
 import { useState, useMemo, useEffect } from 'react';
-import { Globe, HardDrive, KeyRound, Layers, Plug, Settings, Shield } from 'lucide-react';
+import { Globe, HardDrive, KeyRound, Layers, Plug, Server, Settings, Shield } from 'lucide-react';
 import { getPluginNavItems } from '@/plugins/registry';
 
 const BROWSE_HIDDEN_URLS = ['/backups', '/chats'];
@@ -31,6 +31,13 @@ const coreNavItems = [
     icon: Layers,
     resource: 'deploy',
     order: 10
+  },
+  {
+    title: 'navigation.machines',
+    url: '/machines',
+    icon: Server,
+    resource: 'machine',
+    order: 15
   },
   {
     title: 'navigation.integrations',
@@ -169,7 +176,16 @@ export function useAppSidebar() {
   const [showLogoutDialog, setShowLogoutDialog] = useState(false);
 
   const hasAnyPermission = useMemo(() => {
-    const allowedResources = ['dashboard', 'settings', 'extensions', 'ai', 'domain', 'api-key', 'security', 'backup'];
+    const allowedResources = [
+      'dashboard',
+      'settings',
+      'extensions',
+      'ai',
+      'domain',
+      'api-key',
+      'security',
+      'backup'
+    ];
 
     return (resource: string) => {
       if (!user || !activeOrg) return false;

--- a/view/packages/utils/rbac.ts
+++ b/view/packages/utils/rbac.ts
@@ -18,6 +18,7 @@ export type Resource =
   | 'github-connector'
   | 'container'
   | 'terminal'
+  | 'machine'
   | 'mcp'
   | 'update'
   | 'extensions';

--- a/view/redux/services/servers/serversApi.ts
+++ b/view/redux/services/servers/serversApi.ts
@@ -13,7 +13,10 @@ import type {
   ProvisionMachineRequest,
   ProvisionStatusResponse,
   MachineSshStatusResponse,
-  DeleteMachineResponse
+  DeleteMachineResponse,
+  MachineState,
+  MachineStateResponse,
+  MachineActionResponse
 } from '@/redux/types/servers';
 
 export const machinesApi = createApi({
@@ -79,11 +82,12 @@ export const machinesApi = createApi({
       transformResponse: (response: { status: string; data: MachineSshStatusResponse }) =>
         response.data
     }),
-    getMachineStatus: builder.query<unknown, { server_id?: string } | void>({
+    getMachineStatus: builder.query<MachineState, { server_id?: string } | void>({
       query: (params) => ({
         url: `${MACHINEHOSTURLS.STATUS}${machineHostQuery(params?.server_id)}`,
         method: 'GET'
-      })
+      }),
+      transformResponse: (response: MachineStateResponse) => response.data
     }),
     getMachineStats: builder.query<unknown, { server_id?: string } | void>({
       query: (params) => ({
@@ -98,19 +102,19 @@ export const machinesApi = createApi({
         body: { command }
       })
     }),
-    restartMachine: builder.mutation<unknown, { server_id?: string } | void>({
+    restartMachine: builder.mutation<MachineActionResponse, { server_id?: string } | void>({
       query: (params) => ({
         url: `${MACHINEHOSTURLS.RESTART}${machineHostQuery(params?.server_id)}`,
         method: 'POST'
       })
     }),
-    pauseMachine: builder.mutation<unknown, { server_id?: string } | void>({
+    pauseMachine: builder.mutation<MachineActionResponse, { server_id?: string } | void>({
       query: (params) => ({
         url: `${MACHINEHOSTURLS.PAUSE}${machineHostQuery(params?.server_id)}`,
         method: 'POST'
       })
     }),
-    resumeMachine: builder.mutation<unknown, { server_id?: string } | void>({
+    resumeMachine: builder.mutation<MachineActionResponse, { server_id?: string } | void>({
       query: (params) => ({
         url: `${MACHINEHOSTURLS.RESUME}${machineHostQuery(params?.server_id)}`,
         method: 'POST'

--- a/view/redux/types/servers.ts
+++ b/view/redux/types/servers.ts
@@ -100,3 +100,21 @@ export interface MachineSshStatusResponse {
 export interface DeleteMachineResponse {
   status: string;
 }
+
+export interface MachineState {
+  active: boolean;
+  state: string;
+  pid: number;
+  uptime_sec: number;
+}
+
+export interface MachineStateResponse {
+  status: string;
+  message: string;
+  data: MachineState;
+}
+
+export interface MachineActionResponse {
+  status: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary

- Make the machines page available for self-hosted users (previously premium-only)
- Remove the 2-machine BYOS limit (`defaultMaxBYOSMachines`) so self-hosted gets unlimited machines
- Add core frontend: machines list UI, hooks for lifecycle/backup/card, sidebar nav, i18n, RBAC, middleware
- Core `MachinesView` accepts optional `useDataHook` and provisioning props so premium wraps it as a thin ~45-line file instead of duplicating ~900 lines of UI
- Fix `use-machine-card` to filter apps by `application_servers` join table instead of stale `domain_id` field
- Load `Servers` relation in `GetApplications` query so app-to-machine mapping works

### Backend changes
- `api/internal/features/machine/service/registration.go` — remove machine count limit
- `api/internal/features/deploy/storage/init.go` — add `Relation("Servers")` to `GetApplications`

### Frontend changes
- New: `view/packages/components/machines/machines-view.tsx` — full machines UI (cards, table, skeleton, actions, provisioning support)
- New: `view/packages/hooks/machines/` — `use-machines`, `use-machines-view`, `use-machine-card`, `use-machine-lifecycle`
- `view/app/machines/page.tsx` — core machines page entry point
- `view/middleware.ts` — add `/machines` to private paths
- `view/packages/utils/rbac.ts` — add `machine` resource type
- `view/packages/hooks/shared/use-app-sidebar.ts` — add Machines nav item (after Apps)
- `view/redux/services/servers/serversApi.ts` — type lifecycle endpoints properly
- `view/redux/types/servers.ts` — add `MachineState`, `MachineStateResponse`, `MachineActionResponse`
- i18n: add "machines" translation in en, es, fr, kn, ml

## Self-hosted behavior
- No billing gates, no provisioning UI, no credit checks
- Unlimited machine registration
- Lifecycle (restart/pause/resume), backups, and machine detail pages work as-is
- Domain resolution: `provision.domain → server.host → server.name`

## Premium compatibility
- Premium plugin wraps core `MachinesView` via `useDataHook` prop (injects billing-gated data source)
- Premium passes provisioning state + table styling through props
- Premium's `machines-view.tsx` reduced from ~900 lines to ~45 lines
- No collision: plugin system overrides core page when premium is installed

## Test plan
- [ ] Self-hosted: verify machines page appears in sidebar after Apps
- [ ] Self-hosted: add a BYOS machine (no limit enforced)
- [ ] Self-hosted: verify machine card shows correct app count
- [ ] Self-hosted: lifecycle actions (restart, pause, resume) work
- [ ] Self-hosted: backup trigger works from machine card
- [ ] Self-hosted: machine detail sub-pages (charts, apps, backups) load
- [ ] Premium: verify premium machines page still loads with provisioning UI
- [ ] Premium: verify billing gates still prevent machine creation for non-subscribers