### PR TITLE
fix(view): keep sidebar open by default for new users

### DIFF
--- a/view/packages/layouts/layout.tsx
+++ b/view/packages/layouts/layout.tsx
@@ -95,7 +95,7 @@ function Layout({ children }: LayoutProps) {
   } = useLayout();
 
   return (
-    <SidebarProvider defaultOpen={false}>
+    <SidebarProvider defaultOpen={true}>
       <AppSidebar
         user={user}
         activeOrg={


### PR DESCRIPTION
## Summary
- Changed `SidebarProvider` `defaultOpen` from `false` to `true` so new users see the sidebar expanded on first visit
- Existing users who previously collapsed the sidebar retain their preference via localStorage

## Test plan
- [ ] Clear localStorage (`sidebar_state` key) and verify sidebar opens expanded
- [ ] Collapse sidebar, refresh, and verify it stays collapsed (localStorage respected)
- [ ] Verify mobile sidebar behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now opens by default on initial launch, providing improved accessibility to navigation on first use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->