### PR TITLE
fix: multi-server deployment fan-out and Caddy routing

### DIFF
--- a/api/doc/openapi.json
+++ b/api/doc/openapi.json
@@ -2645,6 +2645,14 @@
 					"name": {
 						"type": "string"
 					},
+					"primary_server_id": {
+						"format": "uuid",
+						"type": "string"
+					},
+					"routing_strategy": {
+						"nullable": true,
+						"type": "string"
+					},
 					"server_ids": {
 						"items": {
 							"format": "uuid",
@@ -14941,6 +14949,8 @@
 							"example": {
 								"environment": "string",
 								"name": "string",
+								"primary_server_id": "00000000-0000-0000-0000-000000000000",
+								"routing_strategy": "string",
 								"server_ids": [],
 								"template_id": "00000000-0000-0000-0000-000000000000",
 								"variables": {}

--- a/api/go.mod
+++ b/api/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/moby/term v0.5.2
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/sftp v1.13.5
-	github.com/raghavyuva/caddygo v0.0.0-20260420091323-5535e8e09c1d
+	github.com/raghavyuva/caddygo v0.0.0-20260421075009-799160652657
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/viper v1.21.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -485,6 +485,8 @@ github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SA
 github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/raghavyuva/caddygo v0.0.0-20260420091323-5535e8e09c1d h1:69YO9SO98fuqGkbn6iw2+C2MqQLs9hW9bIXerVGL3wI=
 github.com/raghavyuva/caddygo v0.0.0-20260420091323-5535e8e09c1d/go.mod h1:nXAW//4ImRs0bC/UHcqsdYpif2YCvgFdxUAHE7JqdCc=
+github.com/raghavyuva/caddygo v0.0.0-20260421075009-799160652657 h1:jUChxrQOTZYjK6DjbsB9ezhgaLtaYAfOFiuAr8fxm0g=
+github.com/raghavyuva/caddygo v0.0.0-20260421075009-799160652657/go.mod h1:nXAW//4ImRs0bC/UHcqsdYpif2YCvgFdxUAHE7JqdCc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/api/internal/features/deploy/caddy/operations.go
+++ b/api/internal/features/deploy/caddy/operations.go
@@ -49,9 +49,12 @@ func AddDomainsWithRetry(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Lo
 					targets[i] = caddygo.UpstreamTarget{Host: host, Port: port}
 				}
 				lbOpts := caddygo.LoadBalancingOptions{Policy: d.LBPolicy}
-				if d.LBPolicy == "first" {
-					lbOpts.HealthCheckPath = "/health"
-					lbOpts.HealthCheckIntervalSec = 10
+				if len(d.Upstreams) > 1 {
+					lbOpts.PassiveFailDurationSec = 30
+					lbOpts.PassiveMaxFails = 2
+					lbOpts.PassiveUnhealthyStatus = []int{502, 503}
+					lbOpts.TryDurationSec = 5
+					lbOpts.TryIntervalMs = 250
 				}
 				if err := client.AddDomainWithUpstreams(d.Domain, targets, lbOpts, caddygo.DomainOptions{}); err != nil {
 					return fmt.Errorf("failed to add domain %s: %w", d.Domain, err)

--- a/api/internal/features/deploy/caddy/reconciler.go
+++ b/api/internal/features/deploy/caddy/reconciler.go
@@ -245,9 +245,12 @@ func addRouteToClient(client *caddygo.Client, route DomainRoute) error {
 			targets[i] = caddygo.UpstreamTarget{Host: host, Port: port}
 		}
 		lbOpts := caddygo.LoadBalancingOptions{Policy: route.LBPolicy}
-		if route.LBPolicy == "first" {
-			lbOpts.HealthCheckPath = "/health"
-			lbOpts.HealthCheckIntervalSec = 10
+		if len(route.Upstreams) > 1 {
+			lbOpts.PassiveFailDurationSec = 30
+			lbOpts.PassiveMaxFails = 2
+			lbOpts.PassiveUnhealthyStatus = []int{502, 503}
+			lbOpts.TryDurationSec = 5
+			lbOpts.TryIntervalMs = 250
 		}
 		return client.AddDomainWithUpstreams(route.Domain, targets, lbOpts, caddygo.DomainOptions{})
 	}

--- a/api/internal/features/deploy/caddy/route_builder.go
+++ b/api/internal/features/deploy/caddy/route_builder.go
@@ -29,13 +29,13 @@ func BuildMultiUpstreamRoutes(
 
 	lbPolicy := mapRoutingStrategy(app.RoutingStrategy)
 
-	upstreams, primaryUpstreamIndex, err := resolveServerUpstreams(ctx, servers, fallbackPort, lgr)
-	if err != nil || len(upstreams) == 0 {
+	hosts, primaryHostIndex := resolveServerHosts(servers, lgr)
+	if len(hosts) == 0 {
 		return buildSingleUpstreamRoutes(domains, fallbackUpstream, fallbackPort, app.BuildPack)
 	}
 
 	if app.RoutingStrategy == shared_types.RoutingStrategyPrimaryFailover {
-		upstreams = orderPrimaryFirst(upstreams, primaryUpstreamIndex)
+		hosts = orderPrimaryFirst(hosts, primaryHostIndex)
 	}
 
 	var routes []DomainRoute
@@ -50,18 +50,10 @@ func BuildMultiUpstreamRoutes(
 				continue
 			}
 		}
-		var domainUpstreams []string
-		if app.BuildPack == shared_types.DockerCompose {
-			for _, u := range upstreams {
-				host, _, err := parseDial(u)
-				if err != nil {
-					lgr.Log(logger.Warning, fmt.Sprintf("skipping malformed upstream %s: %v", u, err), "")
-					continue
-				}
-				domainUpstreams = append(domainUpstreams, FormatDial(host, port))
-			}
-		} else {
-			domainUpstreams = upstreams
+
+		domainUpstreams := make([]string, 0, len(hosts))
+		for _, h := range hosts {
+			domainUpstreams = append(domainUpstreams, FormatDial(h, port))
 		}
 
 		if len(domainUpstreams) == 0 {
@@ -104,25 +96,28 @@ func buildSingleUpstreamRoutes(
 	return routes
 }
 
-func resolveServerUpstreams(ctx context.Context, servers []shared_types.ApplicationServer, port int, lgr *logger.Logger) ([]string, int, error) {
-	var upstreams []string
-	primaryUpstreamIndex := -1
+func resolveServerHosts(servers []shared_types.ApplicationServer, lgr *logger.Logger) ([]string, int) {
+	multiServer := len(servers) > 1
+	var hosts []string
+	primaryIndex := -1
 	for _, srv := range servers {
 		if srv.Server == nil || srv.Server.Host == nil {
 			continue
 		}
-		host := ""
-		if srv.Server.ProxyHost != nil && *srv.Server.ProxyHost != "" {
+		var host string
+		if multiServer && !srv.Server.IsDefault {
+			host = *srv.Server.Host
+		} else if srv.Server.ProxyHost != nil && *srv.Server.ProxyHost != "" {
 			host = *srv.Server.ProxyHost
 		} else {
 			host = *srv.Server.Host
 		}
 		if srv.IsPrimary {
-			primaryUpstreamIndex = len(upstreams)
+			primaryIndex = len(hosts)
 		}
-		upstreams = append(upstreams, FormatDial(host, port))
+		hosts = append(hosts, host)
 	}
-	return upstreams, primaryUpstreamIndex, nil
+	return hosts, primaryIndex
 }
 
 func orderPrimaryFirst(upstreams []string, primaryUpstreamIndex int) []string {

--- a/api/internal/features/deploy/controller/handle_template_deploy.go
+++ b/api/internal/features/deploy/controller/handle_template_deploy.go
@@ -78,6 +78,8 @@ func (c *DeployController) HandleTemplateDeploy(f fuego.ContextWithBody[types.Cr
 		EnvironmentVariables: envVars,
 		Source:               shared_types.SourceTemplate,
 		ServerIDs:            data.ServerIDs,
+		PrimaryServerID:      data.PrimaryServerID,
+		RoutingStrategy:      data.RoutingStrategy,
 	}
 
 	if proxyDomain != "" {

--- a/api/internal/features/deploy/docker/init.go
+++ b/api/internal/features/deploy/docker/init.go
@@ -87,8 +87,8 @@ type DockerRepository interface {
 
 	ComposeUp(composeFilePath string, envVars map[string]string) (string, error)
 	ComposeUpWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) (string, error)
-	ComposeDown(composeFilePath string) error
-	ComposeDownWithCallback(composeFilePath string, outputCallback func(string)) error
+	ComposeDown(composeFilePath string, envVars map[string]string) error
+	ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) error
 	ComposeRestart(composeFilePath string, envVars map[string]string, outputCallback func(string)) error
 	ComposeBuild(composeFilePath string, envVars map[string]string) error
 	RemoveImage(imageName string, opts image.RemoveOptions) error
@@ -134,6 +134,9 @@ func NewDockerServiceWithServer(db *bun.DB, ctx context.Context, organizationID 
 	}
 
 	orgCtx := context.WithValue(context.Background(), shared_types.OrganizationIDKey, organizationID.String())
+	if serverIDStr, ok := ctx.Value(shared_types.ServerIDKey).(string); ok && serverIDStr != "" {
+		orgCtx = context.WithValue(orgCtx, shared_types.ServerIDKey, serverIDStr)
+	}
 	svc := &DockerService{
 		Cli:       cli,
 		Ctx:       orgCtx,
@@ -551,13 +554,13 @@ func (s *DockerService) ComposeUpWithCallback(composeFilePath string, envVars ma
 }
 
 // ComposeDown stops and removes the Docker Compose services
-func (s *DockerService) ComposeDown(composeFilePath string) error {
-	return s.ComposeDownWithCallback(composeFilePath, nil)
+func (s *DockerService) ComposeDown(composeFilePath string, envVars map[string]string) error {
+	return s.ComposeDownWithCallback(composeFilePath, envVars, nil)
 }
 
 // ComposeDownWithCallback stops and removes Docker Compose services with streaming output
-func (s *DockerService) ComposeDownWithCallback(composeFilePath string, outputCallback func(string)) error {
-	command, err := s.buildComposeCommand("down", composeFilePath, nil)
+func (s *DockerService) ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) error {
+	command, err := s.buildComposeCommand("down", composeFilePath, envVars)
 	if err != nil {
 		return err
 	}

--- a/api/internal/features/deploy/tasks/compose.go
+++ b/api/internal/features/deploy/tasks/compose.go
@@ -92,7 +92,7 @@ func (t *TaskService) executeComposeDeployment(ctx context.Context, deploymentTy
 		return t.composeUp(ctx, composeFilePath, envVars, outputCallback, taskCtx, "Starting Docker Compose services", "Docker Compose services started successfully")
 
 	case shared_types.DeploymentTypeReDeploy, shared_types.DeploymentTypeUpdate, shared_types.DeploymentTypeRollback:
-		if err := t.composeDown(ctx, composeFilePath, outputCallback, taskCtx); err != nil {
+		if err := t.composeDown(ctx, composeFilePath, envVars, outputCallback, taskCtx); err != nil {
 			return err
 		}
 		taskCtx.AddLog("Existing services stopped, starting with new code")
@@ -137,7 +137,7 @@ func (t *TaskService) composeUp(ctx context.Context, composeFilePath string, env
 	return nil
 }
 
-func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, outputCallback func(string), taskCtx *TaskContext) error {
+func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext) error {
 	taskCtx.AddLog("Stopping existing Docker Compose services")
 
 	dockerSvc, err := t.getDockerService(ctx)
@@ -147,13 +147,13 @@ func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, o
 	}
 
 	if ds, ok := dockerSvc.(*docker.DockerService); ok {
-		err := ds.ComposeDownWithCallback(composeFilePath, outputCallback)
+		err := ds.ComposeDownWithCallback(composeFilePath, envVars, outputCallback)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to stop docker compose services: "+err.Error(), shared_types.Failed)
 			return err
 		}
 	} else {
-		err := dockerSvc.ComposeDown(composeFilePath)
+		err := dockerSvc.ComposeDown(composeFilePath, envVars)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to stop docker compose services: "+err.Error(), shared_types.Failed)
 			return err
@@ -179,7 +179,7 @@ func (t *TaskService) composeRestart(ctx context.Context, composeFilePath string
 			return err
 		}
 	} else {
-		if err := t.composeDown(ctx, composeFilePath, outputCallback, taskCtx); err != nil {
+		if err := t.composeDown(ctx, composeFilePath, envVars, outputCallback, taskCtx); err != nil {
 			return err
 		}
 		output, err := dockerSvc.ComposeUp(composeFilePath, envVars)

--- a/api/internal/features/deploy/tasks/fanout.go
+++ b/api/internal/features/deploy/tasks/fanout.go
@@ -66,7 +66,7 @@ func (t *TaskService) updateParentStatus(ctx context.Context, parentDepID uuid.U
 	case failCount == len(errs):
 		status = shared_types.Failed
 	default:
-		status = shared_types.PartialFailure
+		status = shared_types.Failed
 	}
 
 	now := time.Now()

--- a/api/internal/features/deploy/types/init.go
+++ b/api/internal/features/deploy/types/init.go
@@ -287,11 +287,13 @@ type ApplicationServersResponse struct {
 }
 
 type CreateTemplateDeploymentRequest struct {
-	TemplateID  string                   `json:"template_id"`
-	Name        string                   `json:"name"`
-	Variables   map[string]interface{}   `json:"variables"`
-	ServerIDs   []uuid.UUID              `json:"server_ids,omitempty"`
-	Environment shared_types.Environment `json:"environment,omitempty"`
+	TemplateID      string                       `json:"template_id"`
+	Name            string                       `json:"name"`
+	Variables       map[string]interface{}       `json:"variables"`
+	ServerIDs       []uuid.UUID                  `json:"server_ids,omitempty"`
+	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty"`
+	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
+	Environment     shared_types.Environment     `json:"environment,omitempty"`
 }
 
 type CancelDeploymentRequest struct {

--- a/api/internal/utils/sftp_pool.go
+++ b/api/internal/utils/sftp_pool.go
@@ -109,8 +109,13 @@ func WithSFTPClientFromPool(ctx context.Context, fn func(*sftp.Client) error) er
 		return err
 	}
 
+	cacheKey := orgID
+	if serverIDStr, ok := ctx.Value(types.ServerIDKey).(string); ok && serverIDStr != "" {
+		cacheKey = orgID + ":" + serverIDStr
+	}
+
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		client, release, fromPool, createErr := pool.getOrCreate(ctx, orgID, sshMgr)
+		client, release, fromPool, createErr := pool.getOrCreate(ctx, cacheKey, sshMgr)
 		if client == nil {
 			if createErr != nil && isClosedConnectionError(createErr) && attempt < maxRetries-1 {
 				// Stale connection (e.g. "use of closed network connection"); evicted by getOrCreate, retry
@@ -129,7 +134,7 @@ func WithSFTPClientFromPool(ctx context.Context, fn func(*sftp.Client) error) er
 		if err != nil {
 			if isClosedConnectionError(err) {
 				doRelease() // Release before evict so refcount is accurate
-				pool.evict(orgID, client)
+				pool.evict(cacheKey, client)
 				if fromPool {
 					sshMgr.CloseConnection("")
 				}
@@ -139,7 +144,7 @@ func WithSFTPClientFromPool(ctx context.Context, fn func(*sftp.Client) error) er
 			}
 			return err
 		}
-		pool.touch(orgID)
+		pool.touch(cacheKey)
 		return nil
 	}
 	return fmt.Errorf("SFTP operation failed after %d attempts", maxRetries)


### PR DESCRIPTION
## Summary

- **ServerIDKey context propagation**: DockerService and SFTP pool now preserve `ServerIDKey` so fan-out goroutines target the correct remote server instead of all hitting the default
- **composeDown env vars**: Pass environment variables to `docker compose down` so variable-interpolated container names (e.g. `${CONTAINER_NAME}`) resolve correctly during teardown
- **Caddy route builder**: Use actual server IP for remote upstreams instead of `ProxyHost` (which resolves to `localhost` for all servers), fixing round-robin routing to only hit one host
- **Passive health checks + retry**: Replace active health checks (which fail for apps returning 302 on `/`) with passive health checks and `try_duration` retry logic via upgraded caddygo library
- **Template deploy**: Forward `routing_strategy` and `primary_server_id` from template deployment requests
- **Fanout status**: Use `Failed` instead of non-existent `PartialFailure` DB enum

## Test plan

Manually tested on two servers (trial + contabo) with Uptime Kuma template deployment:

- [x] `round_robin`: 10/10 requests return 200 with both servers up
- [x] `round_robin`: failover works when one server is stopped (retry handles first hit, then passive health check removes dead upstream)
- [x] `round_robin`: auto-recovery after `fail_duration` (30s) expires
- [x] `primary_failover`: all traffic routes to primary with both servers up
- [x] `primary_failover`: automatic failover to secondary when primary is stopped
- [x] `primary_failover`: traffic returns to primary after recovery
- [x] Both servers down returns 502→503 (correct behavior)