### PR TITLE
fix(deploy): attach nixopus labels to compose containers

### DIFF
--- a/api/internal/features/deploy/docker/init.go
+++ b/api/internal/features/deploy/docker/init.go
@@ -85,12 +85,12 @@ type DockerRepository interface {
 	RestartContainer(containerID string, opts container.StopOptions) error
 	UpdateContainerResources(containerID string, resources container.UpdateConfig) (container.ContainerUpdateOKBody, error)
 
-	ComposeUp(composeFilePath string, envVars map[string]string) (string, error)
-	ComposeUpWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) (string, error)
-	ComposeDown(composeFilePath string, envVars map[string]string) error
-	ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) error
-	ComposeRestart(composeFilePath string, envVars map[string]string, outputCallback func(string)) error
-	ComposeBuild(composeFilePath string, envVars map[string]string) error
+	ComposeUp(composeFilePath string, envVars map[string]string, overrideFiles ...string) (string, error)
+	ComposeUpWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) (string, error)
+	ComposeDown(composeFilePath string, envVars map[string]string, overrideFiles ...string) error
+	ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) error
+	ComposeRestart(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) error
+	ComposeBuild(composeFilePath string, envVars map[string]string, overrideFiles ...string) error
 	RemoveImage(imageName string, opts image.RemoveOptions) error
 	PruneBuildCache(opts types.BuildCachePruneOptions) error
 	PruneImages(opts filters.Args) (image.PruneReport, error)
@@ -540,13 +540,13 @@ func (s *DockerService) ContainerLogs(Ctx context.Context, containerID string, o
 }
 
 // ComposeUp starts the Docker Compose services defined in the specified compose file
-func (s *DockerService) ComposeUp(composeFilePath string, envVars map[string]string) (string, error) {
-	return s.ComposeUpWithCallback(composeFilePath, envVars, nil)
+func (s *DockerService) ComposeUp(composeFilePath string, envVars map[string]string, overrideFiles ...string) (string, error) {
+	return s.ComposeUpWithCallback(composeFilePath, envVars, nil, overrideFiles...)
 }
 
 // ComposeUpWithCallback starts Docker Compose services and streams output in real-time via callback
-func (s *DockerService) ComposeUpWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) (string, error) {
-	command, err := s.buildComposeCommand("up -d --remove-orphans", composeFilePath, envVars)
+func (s *DockerService) ComposeUpWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) (string, error) {
+	command, err := s.buildComposeCommand("up -d --remove-orphans", composeFilePath, envVars, overrideFiles...)
 	if err != nil {
 		return "", err
 	}
@@ -554,13 +554,13 @@ func (s *DockerService) ComposeUpWithCallback(composeFilePath string, envVars ma
 }
 
 // ComposeDown stops and removes the Docker Compose services
-func (s *DockerService) ComposeDown(composeFilePath string, envVars map[string]string) error {
-	return s.ComposeDownWithCallback(composeFilePath, envVars, nil)
+func (s *DockerService) ComposeDown(composeFilePath string, envVars map[string]string, overrideFiles ...string) error {
+	return s.ComposeDownWithCallback(composeFilePath, envVars, nil, overrideFiles...)
 }
 
 // ComposeDownWithCallback stops and removes Docker Compose services with streaming output
-func (s *DockerService) ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string)) error {
-	command, err := s.buildComposeCommand("down", composeFilePath, envVars)
+func (s *DockerService) ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) error {
+	command, err := s.buildComposeCommand("down", composeFilePath, envVars, overrideFiles...)
 	if err != nil {
 		return err
 	}
@@ -569,8 +569,8 @@ func (s *DockerService) ComposeDownWithCallback(composeFilePath string, envVars 
 }
 
 // ComposeRestart restarts Docker Compose services with streaming output
-func (s *DockerService) ComposeRestart(composeFilePath string, envVars map[string]string, outputCallback func(string)) error {
-	command, err := s.buildComposeCommand("restart", composeFilePath, envVars)
+func (s *DockerService) ComposeRestart(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) error {
+	command, err := s.buildComposeCommand("restart", composeFilePath, envVars, overrideFiles...)
 	if err != nil {
 		return err
 	}
@@ -579,12 +579,16 @@ func (s *DockerService) ComposeRestart(composeFilePath string, envVars map[strin
 }
 
 // buildComposeCommand builds a docker compose command with safe environment variables
-func (s *DockerService) buildComposeCommand(composeAction string, composeFilePath string, envVars map[string]string) (string, error) {
+func (s *DockerService) buildComposeCommand(composeAction string, composeFilePath string, envVars map[string]string, overrideFiles ...string) (string, error) {
 	envVarsStr, err := buildSafeEnvExports(envVars)
 	if err != nil {
 		return "", fmt.Errorf("invalid environment variables: %w", err)
 	}
-	return fmt.Sprintf("%sdocker compose -f %s %s 2>&1", envVarsStr, utils.ShellQuote(composeFilePath), composeAction), nil
+	fileFlags := fmt.Sprintf("-f %s", utils.ShellQuote(composeFilePath))
+	for _, f := range overrideFiles {
+		fileFlags += fmt.Sprintf(" -f %s", utils.ShellQuote(f))
+	}
+	return fmt.Sprintf("%sdocker compose %s %s 2>&1", envVarsStr, fileFlags, composeAction), nil
 }
 
 func (s *DockerService) executeSSHCommandWithOutput(command string, outputCallback func(string), errorMsgPrefix string) (string, error) {
@@ -647,16 +651,15 @@ func (s *DockerService) streamOutput(reader io.Reader, outputBuilder *strings.Bu
 }
 
 // ComposeBuild builds the Docker Compose services
-func (s *DockerService) ComposeBuild(composeFilePath string, envVars map[string]string) error {
+func (s *DockerService) ComposeBuild(composeFilePath string, envVars map[string]string, overrideFiles ...string) error {
 	manager, err := ssh.GetSSHManagerFromContext(s.Ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get SSH manager: %w", err)
 	}
-	envVarsStr, err := buildSafeEnvExports(envVars)
+	command, err := s.buildComposeCommand("build", composeFilePath, envVars, overrideFiles...)
 	if err != nil {
 		return fmt.Errorf("invalid environment variables: %w", err)
 	}
-	command := fmt.Sprintf("%sdocker compose -f %s build", envVarsStr, utils.ShellQuote(composeFilePath))
 	output, err := manager.RunCommand(command)
 	if err != nil {
 		return fmt.Errorf("failed to build docker compose services: %v, output: %s", err, output)

--- a/api/internal/features/deploy/tasks/compose.go
+++ b/api/internal/features/deploy/tasks/compose.go
@@ -251,7 +251,15 @@ func (t *TaskService) getComposeServiceNames(ctx context.Context, composeFilePat
 	var err error
 
 	if payload.Application.Source == shared_types.SourceTemplate && payload.Application.TemplateID != "" {
-		localPath := filepath.Join(".", "templates", payload.Application.TemplateID, "docker-compose.yml")
+		basePath := payload.Application.BasePath
+		if basePath == "" || basePath == "/" {
+			basePath = "."
+		}
+		composeFileName := "docker-compose.yml"
+		if payload.Application.DockerfilePath != "" && payload.Application.DockerfilePath != "Dockerfile" {
+			composeFileName = payload.Application.DockerfilePath
+		}
+		localPath := filepath.Join(".", "templates", payload.Application.TemplateID, basePath, composeFileName)
 		data, err = os.ReadFile(localPath)
 	} else {
 		data, err = utils.ReadFileBytes(ctx, composeFilePath)
@@ -302,7 +310,15 @@ func (t *TaskService) discoverAndPersistComposeServices(ctx context.Context, com
 	var err error
 
 	if TaskPayload.Application.Source == shared_types.SourceTemplate && TaskPayload.Application.TemplateID != "" {
-		localPath := filepath.Join(".", "templates", TaskPayload.Application.TemplateID, "docker-compose.yml")
+		basePath := TaskPayload.Application.BasePath
+		if basePath == "" || basePath == "/" {
+			basePath = "."
+		}
+		composeFileName := "docker-compose.yml"
+		if TaskPayload.Application.DockerfilePath != "" && TaskPayload.Application.DockerfilePath != "Dockerfile" {
+			composeFileName = TaskPayload.Application.DockerfilePath
+		}
+		localPath := filepath.Join(".", "templates", TaskPayload.Application.TemplateID, basePath, composeFileName)
 		data, readErr := os.ReadFile(localPath)
 		if readErr != nil {
 			return fmt.Errorf("failed to read template compose file: %w", readErr)

--- a/api/internal/features/deploy/tasks/compose.go
+++ b/api/internal/features/deploy/tasks/compose.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/nixopus/nixopus/api/internal/features/deploy/caddy"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+	"github.com/pkg/sftp"
 )
 
 func (t *TaskService) deployDockerCompose(ctx context.Context, TaskPayload shared_types.TaskPayload, deploymentType string) error {
@@ -28,10 +31,20 @@ func (t *TaskService) deployDockerCompose(ctx context.Context, TaskPayload share
 	if err := t.discoverAndPersistComposeServices(orgCtx, composeFilePath, TaskPayload, taskCtx, envVars); err != nil {
 		taskCtx.AddLog("Warning: failed to discover compose services: " + err.Error())
 	}
+
+	overrideFile, err := t.writeComposeLabelsOverride(orgCtx, composeFilePath, TaskPayload, taskCtx)
+	if err != nil {
+		taskCtx.AddLog("Warning: failed to write labels override: " + err.Error())
+	}
+	var overrideFiles []string
+	if overrideFile != "" {
+		overrideFiles = append(overrideFiles, overrideFile)
+	}
+
 	outputCallback := t.createOutputCallback(taskCtx)
 
 	deploymentTypeEnum := shared_types.DeploymentType(deploymentType)
-	if err := t.executeComposeDeployment(orgCtx, deploymentTypeEnum, composeFilePath, envVars, outputCallback, taskCtx); err != nil {
+	if err := t.executeComposeDeployment(orgCtx, deploymentTypeEnum, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles); err != nil {
 		return err
 	}
 
@@ -86,20 +99,20 @@ func (t *TaskService) createOutputCallback(taskCtx *TaskContext) func(string) {
 	}
 }
 
-func (t *TaskService) executeComposeDeployment(ctx context.Context, deploymentType shared_types.DeploymentType, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext) error {
+func (t *TaskService) executeComposeDeployment(ctx context.Context, deploymentType shared_types.DeploymentType, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, overrideFiles []string) error {
 	switch deploymentType {
 	case shared_types.DeploymentTypeCreate:
-		return t.composeUp(ctx, composeFilePath, envVars, outputCallback, taskCtx, "Starting Docker Compose services", "Docker Compose services started successfully")
+		return t.composeUp(ctx, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles, "Starting Docker Compose services", "Docker Compose services started successfully")
 
 	case shared_types.DeploymentTypeReDeploy, shared_types.DeploymentTypeUpdate, shared_types.DeploymentTypeRollback:
-		if err := t.composeDown(ctx, composeFilePath, envVars, outputCallback, taskCtx); err != nil {
+		if err := t.composeDown(ctx, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles); err != nil {
 			return err
 		}
 		taskCtx.AddLog("Existing services stopped, starting with new code")
-		return t.composeUp(ctx, composeFilePath, envVars, outputCallback, taskCtx, "Starting Docker Compose services", "Docker Compose services restarted successfully")
+		return t.composeUp(ctx, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles, "Starting Docker Compose services", "Docker Compose services restarted successfully")
 
 	case shared_types.DeploymentTypeRestart:
-		return t.composeRestart(ctx, composeFilePath, envVars, outputCallback, taskCtx)
+		return t.composeRestart(ctx, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles)
 
 	default:
 		taskCtx.LogAndUpdateStatus("Unknown deployment type: "+string(deploymentType), shared_types.Failed)
@@ -107,7 +120,7 @@ func (t *TaskService) executeComposeDeployment(ctx context.Context, deploymentTy
 	}
 }
 
-func (t *TaskService) composeUp(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, startMsg, successMsg string) error {
+func (t *TaskService) composeUp(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, overrideFiles []string, startMsg, successMsg string) error {
 	taskCtx.AddLog(startMsg)
 
 	dockerSvc, err := t.getDockerService(ctx)
@@ -117,13 +130,13 @@ func (t *TaskService) composeUp(ctx context.Context, composeFilePath string, env
 	}
 
 	if ds, ok := dockerSvc.(*docker.DockerService); ok {
-		_, err := ds.ComposeUpWithCallback(composeFilePath, envVars, outputCallback)
+		_, err := ds.ComposeUpWithCallback(composeFilePath, envVars, outputCallback, overrideFiles...)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to start docker compose services: "+err.Error(), shared_types.Failed)
 			return err
 		}
 	} else {
-		output, err := dockerSvc.ComposeUp(composeFilePath, envVars)
+		output, err := dockerSvc.ComposeUp(composeFilePath, envVars, overrideFiles...)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to start docker compose services: "+err.Error(), shared_types.Failed)
 			return err
@@ -137,7 +150,7 @@ func (t *TaskService) composeUp(ctx context.Context, composeFilePath string, env
 	return nil
 }
 
-func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext) error {
+func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, overrideFiles []string) error {
 	taskCtx.AddLog("Stopping existing Docker Compose services")
 
 	dockerSvc, err := t.getDockerService(ctx)
@@ -147,13 +160,13 @@ func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, e
 	}
 
 	if ds, ok := dockerSvc.(*docker.DockerService); ok {
-		err := ds.ComposeDownWithCallback(composeFilePath, envVars, outputCallback)
+		err := ds.ComposeDownWithCallback(composeFilePath, envVars, outputCallback, overrideFiles...)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to stop docker compose services: "+err.Error(), shared_types.Failed)
 			return err
 		}
 	} else {
-		err := dockerSvc.ComposeDown(composeFilePath, envVars)
+		err := dockerSvc.ComposeDown(composeFilePath, envVars, overrideFiles...)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to stop docker compose services: "+err.Error(), shared_types.Failed)
 			return err
@@ -163,7 +176,7 @@ func (t *TaskService) composeDown(ctx context.Context, composeFilePath string, e
 	return nil
 }
 
-func (t *TaskService) composeRestart(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext) error {
+func (t *TaskService) composeRestart(ctx context.Context, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, overrideFiles []string) error {
 	taskCtx.AddLog("Restarting Docker Compose services")
 
 	dockerSvc, err := t.getDockerService(ctx)
@@ -173,16 +186,16 @@ func (t *TaskService) composeRestart(ctx context.Context, composeFilePath string
 	}
 
 	if ds, ok := dockerSvc.(*docker.DockerService); ok {
-		err := ds.ComposeRestart(composeFilePath, envVars, outputCallback)
+		err := ds.ComposeRestart(composeFilePath, envVars, outputCallback, overrideFiles...)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to restart docker compose services: "+err.Error(), shared_types.Failed)
 			return err
 		}
 	} else {
-		if err := t.composeDown(ctx, composeFilePath, envVars, outputCallback, taskCtx); err != nil {
+		if err := t.composeDown(ctx, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles); err != nil {
 			return err
 		}
-		output, err := dockerSvc.ComposeUp(composeFilePath, envVars)
+		output, err := dockerSvc.ComposeUp(composeFilePath, envVars, overrideFiles...)
 		if err != nil {
 			taskCtx.LogAndUpdateStatus("Failed to start docker compose services: "+err.Error(), shared_types.Failed)
 			return err
@@ -194,6 +207,94 @@ func (t *TaskService) composeRestart(ctx context.Context, composeFilePath string
 
 	taskCtx.AddLog("Docker Compose services restarted successfully")
 	return nil
+}
+
+func (t *TaskService) writeComposeLabelsOverride(ctx context.Context, composeFilePath string, payload shared_types.TaskPayload, taskCtx *TaskContext) (string, error) {
+	overridePath := strings.TrimSuffix(composeFilePath, filepath.Ext(composeFilePath)) + ".nixopus-labels.yml"
+
+	serviceNames, err := t.getComposeServiceNames(ctx, composeFilePath, payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to read compose services: %w", err)
+	}
+	if len(serviceNames) == 0 {
+		return "", nil
+	}
+
+	labels := map[string]string{
+		"com.application.id":   payload.Application.ID.String(),
+		"com.application.name": payload.Application.Name,
+		"com.deployment.id":    payload.ApplicationDeployment.ID.String(),
+		"com.commit_hash":      payload.ApplicationDeployment.CommitHash,
+		"com.user_id":          payload.Application.UserID.String(),
+	}
+	overrideYAML := generateComposeLabelsOverrideYAML(serviceNames, labels)
+
+	err = utils.WithSFTPClientFromPool(ctx, func(sftpClient *sftp.Client) error {
+		f, createErr := sftpClient.Create(overridePath)
+		if createErr != nil {
+			return fmt.Errorf("failed to create labels override file: %w", createErr)
+		}
+		defer f.Close()
+		_, writeErr := f.Write(overrideYAML)
+		return writeErr
+	})
+	if err != nil {
+		return "", err
+	}
+
+	taskCtx.AddLog("Wrote Nixopus labels override: " + overridePath)
+	return overridePath, nil
+}
+
+func (t *TaskService) getComposeServiceNames(ctx context.Context, composeFilePath string, payload shared_types.TaskPayload) ([]string, error) {
+	var data []byte
+	var err error
+
+	if payload.Application.Source == shared_types.SourceTemplate && payload.Application.TemplateID != "" {
+		localPath := filepath.Join(".", "templates", payload.Application.TemplateID, "docker-compose.yml")
+		data, err = os.ReadFile(localPath)
+	} else {
+		data, err = utils.ReadFileBytes(ctx, composeFilePath)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	envVars := GetMapFromString(payload.Application.EnvironmentVariables)
+	parsed, err := ParseComposeYAML(data, envVars)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(parsed))
+	for _, svc := range parsed {
+		names = append(names, svc.ServiceName)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func generateComposeLabelsOverrideYAML(serviceNames []string, labels map[string]string) []byte {
+	var b strings.Builder
+	b.WriteString("services:\n")
+	for _, name := range serviceNames {
+		b.WriteString("  ")
+		b.WriteString(name)
+		b.WriteString(":\n    labels:\n")
+		keys := make([]string, 0, len(labels))
+		for k := range labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			b.WriteString("      ")
+			b.WriteString(k)
+			b.WriteString(": \"")
+			b.WriteString(strings.ReplaceAll(labels[k], "\"", "\\\""))
+			b.WriteString("\"\n")
+		}
+	}
+	return []byte(b.String())
 }
 
 func (t *TaskService) discoverAndPersistComposeServices(ctx context.Context, composeFilePath string, TaskPayload shared_types.TaskPayload, taskCtx *TaskContext, envVars map[string]string) error {


### PR DESCRIPTION
## Summary
- Docker Compose deployments were not attaching `com.application.id`, `com.application.name`, `com.deployment.id`, `com.commit_hash`, or `com.user_id` labels to containers, unlike regular Dockerfile/Swarm deployments
- Generates a compose override YAML with Nixopus labels for every service, writes it to the remote server via SFTP, and passes it as an additional `-f` flag to all `docker compose` commands
- Uses Docker Compose native multi-file merge so the user's original compose file is never modified

## Test plan
- [x] Deploy an app via Docker Compose and verify containers have `com.application.id` and `com.application.name` labels (`docker inspect <container>`)
- [x] Verify compose containers now appear grouped correctly in the Nixopus container listing UI
- [x] Verify regular Dockerfile deployments are unaffected (variadic `overrideFiles` defaults to empty)
- [x] Test redeploy/restart/rollback flows for compose apps to ensure override file is included in all operations
- [x] Test template-based compose deployments still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker Compose operations now accept and apply override files for deployments, enabling layered configuration.
  * Deployments can auto-generate and persist a labels override file (derived from task metadata) to improve service identification and orchestration.
  * Compose template discovery enhanced to correctly locate template-based compose files for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->