### PR TITLE
fix(machine): unify GET /machines/status for all provision types

### DIFF
--- a/api/internal/features/machine/controller/lifecycle.go
+++ b/api/internal/features/machine/controller/lifecycle.go
@@ -43,22 +43,12 @@ func (c *MachineController) GetMachineStatus(f fuego.ContextNoBody) (*types.Mach
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
-	userOwned, _ := c.billingService.IsServerUserOwned(orgID, *serverID)
-	if userOwned {
-		ctx := context.WithValue(r.Context(), sharedtypes.ServerIDKey, serverID.String())
-		response, err := c.service.GetMachineStatus(ctx, orgID)
-		if err != nil {
-			c.logger.Log(logger.Error, err.Error(), orgID.String())
-			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
-		}
-		return response, nil
-	}
-
-	response, err := c.lifecycleService.GetStatus(r.Context(), orgID, serverID)
+	ctx := context.WithValue(r.Context(), sharedtypes.ServerIDKey, serverID.String())
+	response, err := c.service.GetMachineStatus(ctx, orgID)
 	if err != nil {
-		return nil, mapLifecycleError(c.logger, err, orgID, "get status")
+		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
-
 	return response, nil
 }
 

--- a/api/internal/tests/machine/lifecycle_test.go
+++ b/api/internal/tests/machine/lifecycle_test.go
@@ -121,6 +121,13 @@ func TestRestartMachine_MissingServerID(t *testing.T) {
 // Pause and resume are pure DB flag flips, safe to run in CI without a real SSH host.
 func seedBYOSMachine(t *testing.T, setup *testutils.TestSetup, orgID uuid.UUID, userID uuid.UUID, isActive bool) uuid.UUID {
 	t.Helper()
+	return seedTestSSHMachine(t, setup, orgID, userID, isActive, "user_owned")
+}
+
+// seedTestSSHMachine inserts an SSH key and user_provision_details row.
+// provisionType is e.g. user_owned, trial (non-user-owned uses the same GET /machines/status path as BYOS).
+func seedTestSSHMachine(t *testing.T, setup *testutils.TestSetup, orgID uuid.UUID, userID uuid.UUID, isActive bool, provisionType string) uuid.UUID {
+	t.Helper()
 
 	keyID := uuid.New()
 	key := &api_types.SSHKey{
@@ -144,7 +151,7 @@ func seedBYOSMachine(t *testing.T, setup *testutils.TestSetup, orgID uuid.UUID, 
 		UserID:         userID,
 		OrganizationID: orgID,
 		SSHKeyID:       &keyID,
-		Type:           "user_owned",
+		Type:           provisionType,
 		Step:           &step,
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -280,6 +287,34 @@ func TestBYOSGetStatus_PausedMachine(t *testing.T) {
 
 	Test(t,
 		Description("GET /machines/status for paused BYOS machine returns 200 with Paused state"),
+		Get(tests.GetMachineStatusURL(keyID.String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+		Expect().Body().JSON().JQ(".data.state").Equal("Paused"),
+	)
+}
+
+// TestNonUserOwnedGetStatus_PausedMachine verifies GET /machines/status uses the same
+// MachineService path as BYOS for non-user_owned provisions (no LXD lifecycle lookup).
+func TestNonUserOwnedGetStatus_PausedMachine(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	orgID, err := uuid.Parse(auth.OrganizationID)
+	if err != nil {
+		t.Fatalf("failed to parse org ID: %v", err)
+	}
+	userID := auth.User.ID
+
+	keyID := seedTestSSHMachine(t, setup, orgID, userID, false, "trial")
+
+	Test(t,
+		Description("GET /machines/status for paused non-user-owned machine returns 200 with Paused state"),
 		Get(tests.GetMachineStatusURL(keyID.String())),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),


### PR DESCRIPTION
## Summary
- **GET /api/v1/machines/status** always uses `MachineService.GetMachineStatus` (SSH + `ssh_keys.is_active`) for every `server_id`, matching BYOS behavior.
- Removes the non–user-owned branch that called `LifecycleService.GetStatus` (LXC/RPC), which could return **404** when org-level non–`user_owned` provision metadata was missing even though SSH to the server was valid.

## Tests
- Refactor `seedTestSSHMachine` in lifecycle integration tests; add `TestNonUserOwnedGetStatus_PausedMachine` (trial provision, paused = Paused state without SSH).

## Verify locally
```bash
cd api && go test -count=1 ./internal/features/machine/tests/
cd api && go test -count=1 ./internal/tests/machine/ -run "GetStatus|NonUserOwned"   # needs test DB
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Machine status retrieval now uniformly routes through a centralized service, enabling consistent behavior across all machine provision types.

* **Tests**
  * Extended test coverage to verify machine status behavior works consistently for all machine provision types, including trial machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->