### PR TITLE
refactor(deploy): pipeline stages for Dockerfile and Compose

### DIFF
--- a/api/internal/features/deploy/tasks/compose.go
+++ b/api/internal/features/deploy/tasks/compose.go
@@ -18,20 +18,23 @@ import (
 func (t *TaskService) deployDockerCompose(ctx context.Context, TaskPayload shared_types.TaskPayload, deploymentType string) error {
 	taskCtx := t.NewTaskContext(TaskPayload)
 
-	repoPath, err := t.composeStageResolveRepo(ctx, TaskPayload, deploymentType, taskCtx)
+	repoPath, err := t.cloneRepositoryForCompose(ctx, TaskPayload, deploymentType, taskCtx)
 	if err != nil {
 		return err
 	}
 
 	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, TaskPayload.Application.OrganizationID.String())
 
-	composeFilePath, overrideFiles, envVars, err := t.composeStagePrepareProject(orgCtx, TaskPayload, repoPath, taskCtx)
-	if err != nil {
-		return err
+	deploymentTypeEnum := shared_types.DeploymentType(deploymentType)
+	switch deploymentTypeEnum {
+	case shared_types.DeploymentTypeCreate, shared_types.DeploymentTypeReDeploy, shared_types.DeploymentTypeUpdate, shared_types.DeploymentTypeRollback, shared_types.DeploymentTypeRestart:
+	default:
+		return fmt.Errorf("unknown deployment type: %q", deploymentType)
 	}
 
+	composeFilePath, overrideFiles, envVars := t.composeStagePrepareProject(orgCtx, TaskPayload, repoPath, taskCtx)
+
 	outputCallback := t.createOutputCallback(taskCtx)
-	deploymentTypeEnum := shared_types.DeploymentType(deploymentType)
 	if err := t.composeStageExecuteStack(orgCtx, deploymentTypeEnum, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles); err != nil {
 		return err
 	}
@@ -42,7 +45,11 @@ func (t *TaskService) deployDockerCompose(ctx context.Context, TaskPayload share
 }
 
 func (t *TaskService) cloneRepositoryForCompose(ctx context.Context, TaskPayload shared_types.TaskPayload, deploymentType string, taskCtx *TaskContext) (string, error) {
-	taskCtx.LogAndUpdateStatus("Starting deployment process", shared_types.Cloning)
+	if deploymentType == string(shared_types.DeploymentTypeReDeploy) {
+		taskCtx.LogAndUpdateStatus("Starting redeploy process", shared_types.Cloning)
+	} else {
+		taskCtx.LogAndUpdateStatus("Starting deployment process", shared_types.Cloning)
+	}
 
 	resolver := t.GetSourceResolver(TaskPayload.Application.Source)
 	repoPath, err := resolver.Resolve(ctx, SourceResolveConfig{

--- a/api/internal/features/deploy/tasks/compose.go
+++ b/api/internal/features/deploy/tasks/compose.go
@@ -18,46 +18,27 @@ import (
 func (t *TaskService) deployDockerCompose(ctx context.Context, TaskPayload shared_types.TaskPayload, deploymentType string) error {
 	taskCtx := t.NewTaskContext(TaskPayload)
 
-	repoPath, err := t.cloneRepositoryForCompose(ctx, TaskPayload, deploymentType, taskCtx)
+	repoPath, err := t.composeStageResolveRepo(ctx, TaskPayload, deploymentType, taskCtx)
 	if err != nil {
 		return err
 	}
 
 	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, TaskPayload.Application.OrganizationID.String())
 
-	composeFilePath := t.buildComposeFilePath(TaskPayload, repoPath, taskCtx)
-	envVars := GetMapFromString(TaskPayload.Application.EnvironmentVariables)
-
-	if err := t.discoverAndPersistComposeServices(orgCtx, composeFilePath, TaskPayload, taskCtx, envVars); err != nil {
-		taskCtx.AddLog("Warning: failed to discover compose services: " + err.Error())
-	}
-
-	overrideFile, err := t.writeComposeLabelsOverride(orgCtx, composeFilePath, TaskPayload, taskCtx)
+	composeFilePath, overrideFiles, envVars, err := t.composeStagePrepareProject(orgCtx, TaskPayload, repoPath, taskCtx)
 	if err != nil {
-		taskCtx.AddLog("Warning: failed to write labels override: " + err.Error())
-	}
-	var overrideFiles []string
-	if overrideFile != "" {
-		overrideFiles = append(overrideFiles, overrideFile)
+		return err
 	}
 
 	outputCallback := t.createOutputCallback(taskCtx)
-
 	deploymentTypeEnum := shared_types.DeploymentType(deploymentType)
-	if err := t.executeComposeDeployment(orgCtx, deploymentTypeEnum, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles); err != nil {
+	if err := t.composeStageExecuteStack(orgCtx, deploymentTypeEnum, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles); err != nil {
 		return err
 	}
 
-	if TaskPayload.Application.Source != shared_types.SourceTemplate {
-		t.ExportComposeImagesToS3(orgCtx, TaskPayload, composeFilePath, envVars, taskCtx)
-	}
+	t.composeStagePublishArtifacts(orgCtx, TaskPayload, composeFilePath, envVars, taskCtx)
 
-	if err := t.addDomainsForCompose(orgCtx, TaskPayload, taskCtx); err != nil {
-		return err
-	}
-
-	taskCtx.LogAndUpdateStatus("Docker Compose deployment completed successfully", shared_types.Deployed)
-	return nil
+	return t.composeStageConfigureProxy(orgCtx, TaskPayload, taskCtx)
 }
 
 func (t *TaskService) cloneRepositoryForCompose(ctx context.Context, TaskPayload shared_types.TaskPayload, deploymentType string, taskCtx *TaskContext) (string, error) {

--- a/api/internal/features/deploy/tasks/compose_pipeline.go
+++ b/api/internal/features/deploy/tasks/compose_pipeline.go
@@ -1,0 +1,47 @@
+package tasks
+
+import (
+	"context"
+
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+)
+
+func (t *TaskService) composeStageResolveRepo(ctx context.Context, payload shared_types.TaskPayload, deploymentType string, taskCtx *TaskContext) (string, error) {
+	return t.cloneRepositoryForCompose(ctx, payload, deploymentType, taskCtx)
+}
+
+func (t *TaskService) composeStagePrepareProject(orgCtx context.Context, payload shared_types.TaskPayload, repoPath string, taskCtx *TaskContext) (composeFilePath string, overrideFiles []string, envVars map[string]string, err error) {
+	composeFilePath = t.buildComposeFilePath(payload, repoPath, taskCtx)
+	envVars = GetMapFromString(payload.Application.EnvironmentVariables)
+
+	if err := t.discoverAndPersistComposeServices(orgCtx, composeFilePath, payload, taskCtx, envVars); err != nil {
+		taskCtx.AddLog("Warning: failed to discover compose services: " + err.Error())
+	}
+
+	overrideFile, werr := t.writeComposeLabelsOverride(orgCtx, composeFilePath, payload, taskCtx)
+	if werr != nil {
+		taskCtx.AddLog("Warning: failed to write labels override: " + werr.Error())
+	}
+	if overrideFile != "" {
+		overrideFiles = append(overrideFiles, overrideFile)
+	}
+	return composeFilePath, overrideFiles, envVars, nil
+}
+
+func (t *TaskService) composeStageExecuteStack(orgCtx context.Context, deploymentTypeEnum shared_types.DeploymentType, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, overrideFiles []string) error {
+	return t.executeComposeDeployment(orgCtx, deploymentTypeEnum, composeFilePath, envVars, outputCallback, taskCtx, overrideFiles)
+}
+
+func (t *TaskService) composeStagePublishArtifacts(orgCtx context.Context, payload shared_types.TaskPayload, composeFilePath string, envVars map[string]string, taskCtx *TaskContext) {
+	if payload.Application.Source != shared_types.SourceTemplate {
+		t.ExportComposeImagesToS3(orgCtx, payload, composeFilePath, envVars, taskCtx)
+	}
+}
+
+func (t *TaskService) composeStageConfigureProxy(orgCtx context.Context, payload shared_types.TaskPayload, taskCtx *TaskContext) error {
+	if err := t.addDomainsForCompose(orgCtx, payload, taskCtx); err != nil {
+		return err
+	}
+	taskCtx.LogAndUpdateStatus("Docker Compose deployment completed successfully", shared_types.Deployed)
+	return nil
+}

--- a/api/internal/features/deploy/tasks/compose_pipeline.go
+++ b/api/internal/features/deploy/tasks/compose_pipeline.go
@@ -1,3 +1,5 @@
+// Compose deploy broken into stages (resolve repo, prepare compose project, execute stack, S3 export, proxy).
+// Same extension idea as dockerfile_pipeline: future split host / DAG can call stages with different context.
 package tasks
 
 import (
@@ -6,11 +8,7 @@ import (
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
-func (t *TaskService) composeStageResolveRepo(ctx context.Context, payload shared_types.TaskPayload, deploymentType string, taskCtx *TaskContext) (string, error) {
-	return t.cloneRepositoryForCompose(ctx, payload, deploymentType, taskCtx)
-}
-
-func (t *TaskService) composeStagePrepareProject(orgCtx context.Context, payload shared_types.TaskPayload, repoPath string, taskCtx *TaskContext) (composeFilePath string, overrideFiles []string, envVars map[string]string, err error) {
+func (t *TaskService) composeStagePrepareProject(orgCtx context.Context, payload shared_types.TaskPayload, repoPath string, taskCtx *TaskContext) (composeFilePath string, overrideFiles []string, envVars map[string]string) {
 	composeFilePath = t.buildComposeFilePath(payload, repoPath, taskCtx)
 	envVars = GetMapFromString(payload.Application.EnvironmentVariables)
 
@@ -25,7 +23,7 @@ func (t *TaskService) composeStagePrepareProject(orgCtx context.Context, payload
 	if overrideFile != "" {
 		overrideFiles = append(overrideFiles, overrideFile)
 	}
-	return composeFilePath, overrideFiles, envVars, nil
+	return composeFilePath, overrideFiles, envVars
 }
 
 func (t *TaskService) composeStageExecuteStack(orgCtx context.Context, deploymentTypeEnum shared_types.DeploymentType, composeFilePath string, envVars map[string]string, outputCallback func(string), taskCtx *TaskContext, overrideFiles []string) error {

--- a/api/internal/features/deploy/tasks/create.go
+++ b/api/internal/features/deploy/tasks/create.go
@@ -3,10 +3,8 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/google/uuid"
-	"github.com/nixopus/nixopus/api/internal/features/deploy/caddy"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
@@ -67,112 +65,7 @@ func (t *TaskService) CreateTemplateDeploymentTask(deployment *types.CreateDeplo
 }
 
 func (t *TaskService) HandleCreateDockerfileDeployment(ctx context.Context, TaskPayload shared_types.TaskPayload) error {
-	taskCtx := t.NewTaskContext(TaskPayload)
-
-	taskCtx.LogAndUpdateStatus("Starting deployment process", shared_types.Cloning)
-
-	resolver := t.GetSourceResolver(TaskPayload.Application.Source)
-	repoPath, err := resolver.Resolve(ctx, SourceResolveConfig{
-		TaskPayload:    TaskPayload,
-		DeploymentType: string(shared_types.DeploymentTypeCreate),
-		TaskContext:    taskCtx,
-	})
-	if err != nil {
-		taskCtx.LogAndUpdateStatus("Failed to resolve source: "+err.Error(), shared_types.Failed)
-		t.emitDeployFailed(TaskPayload, err)
-		return err
-	}
-
-	taskCtx.LogAndUpdateStatus("Source resolved successfully", shared_types.Building)
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	// Add organization ID to context for docker service
-	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, TaskPayload.Application.OrganizationID.String())
-
-	taskCtx.AddLog("Building image from Dockerfile " + repoPath + " for application " + TaskPayload.Application.Name)
-	buildImageResult, err := t.BuildImage(BuildConfig{
-		TaskPayload:       TaskPayload,
-		ContextPath:       repoPath,
-		Force:             false,
-		ForceWithoutCache: false,
-		TaskContext:       taskCtx,
-		Context:           orgCtx,
-	})
-	if err != nil {
-		if ctx.Err() != nil {
-			taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-			return ctx.Err()
-		}
-		taskCtx.LogAndUpdateStatus("Failed to build image: "+err.Error(), shared_types.Failed)
-		return err
-	}
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	taskCtx.AddLog("Image built successfully: " + buildImageResult + " for application " + TaskPayload.Application.Name)
-
-	t.ExportAndRecordImage(orgCtx, TaskPayload, buildImageResult, taskCtx)
-
-	taskCtx.UpdateStatus(shared_types.Deploying)
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	containerResult, err := t.AtomicUpdateContainer(orgCtx, TaskPayload, taskCtx)
-	if err != nil {
-		taskCtx.LogAndUpdateStatus("Failed to update container: "+err.Error(), shared_types.Failed)
-		t.emitDeployFailed(TaskPayload, err)
-		return err
-	}
-
-	taskCtx.AddLog("Container updated successfully for application " + TaskPayload.Application.Name + " with container id " + containerResult.ContainerID)
-	taskCtx.LogAndUpdateStatus("Deployment completed successfully", shared_types.Deployed)
-
-	if len(TaskPayload.Application.Domains) > 0 {
-		port, err := strconv.Atoi(containerResult.AvailablePort)
-		if err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to convert port to int: "+err.Error(), shared_types.Failed)
-			t.emitDeployFailed(TaskPayload, err)
-			return err
-		}
-
-		upstreamHost, err := GetSSHHostForOrganization(ctx, TaskPayload.Application.OrganizationID)
-		if err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to get SSH host: "+err.Error(), shared_types.Failed)
-			t.emitDeployFailed(TaskPayload, err)
-			return err
-		}
-
-		appDomains := make([]shared_types.ApplicationDomain, len(TaskPayload.Application.Domains))
-		for i, d := range TaskPayload.Application.Domains {
-			appDomains[i] = *d
-		}
-		routes := caddy.BuildMultiUpstreamRoutes(
-			ctx, t.Storage, &t.Logger,
-			TaskPayload.Application, appDomains,
-			upstreamHost, port,
-		)
-
-		if err := caddy.AddDomainsAtomic(orgCtx, nil, &t.Logger, routes); err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to configure proxy: "+err.Error(), shared_types.Failed)
-			t.emitDeployFailed(TaskPayload, err)
-			t.cleanupServiceOnFailure(orgCtx, TaskPayload.Application.Name, taskCtx)
-			return err
-		}
-		for _, r := range routes {
-			taskCtx.AddLog("Domain " + r.Domain + " added successfully with TLS")
-		}
-	}
-	return nil
+	return t.runDockerfilePipelineFromSource(ctx, TaskPayload, dockerfilePipelineCreate)
 }
 
 // HandleCreateDockerComposeDeployment handles the deployment of a Docker Compose application

--- a/api/internal/features/deploy/tasks/dockerfile_pipeline.go
+++ b/api/internal/features/deploy/tasks/dockerfile_pipeline.go
@@ -1,6 +1,12 @@
 package tasks
 
-import shared_types "github.com/nixopus/nixopus/api/internal/types"
+import (
+	"context"
+	"strconv"
+
+	"github.com/nixopus/nixopus/api/internal/features/deploy/caddy"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+)
 
 type dockerfilePipelineMode byte
 
@@ -26,4 +32,157 @@ func dockerfileBuildFlagsForMode(mode dockerfilePipelineMode, payload shared_typ
 		return false, false
 	}
 	return payload.UpdateOptions.Force, payload.UpdateOptions.ForceWithoutCache
+}
+
+func (t *TaskService) dockerfileStageResolveSource(ctx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, mode dockerfilePipelineMode) (string, error) {
+	if mode == dockerfilePipelineReDeploy {
+		taskCtx.LogAndUpdateStatus("Starting redeploy process", shared_types.Cloning)
+	} else {
+		taskCtx.LogAndUpdateStatus("Starting deployment process", shared_types.Cloning)
+	}
+
+	resolver := t.GetSourceResolver(payload.Application.Source)
+	repoPath, err := resolver.Resolve(ctx, SourceResolveConfig{
+		TaskPayload:    payload,
+		DeploymentType: string(mode.deploymentType()),
+		TaskContext:    taskCtx,
+	})
+	if err != nil {
+		taskCtx.LogAndUpdateStatus("Failed to resolve source: "+err.Error(), shared_types.Failed)
+		return "", err
+	}
+
+	taskCtx.LogAndUpdateStatus("Source resolved successfully", shared_types.Building)
+	return repoPath, nil
+}
+
+func (t *TaskService) dockerfileStageBuildImage(ctx context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, repoPath string, mode dockerfilePipelineMode) (string, error) {
+	force, forceNoCache := dockerfileBuildFlagsForMode(mode, payload)
+	taskCtx.AddLog("Building image from Dockerfile " + repoPath + " for application " + payload.Application.Name)
+	buildImageResult, err := t.BuildImage(BuildConfig{
+		TaskPayload:       payload,
+		ContextPath:       repoPath,
+		Force:             force,
+		ForceWithoutCache: forceNoCache,
+		TaskContext:       taskCtx,
+		Context:           orgCtx,
+	})
+	if err != nil {
+		return "", err
+	}
+	taskCtx.AddLog("Image built successfully: " + buildImageResult + " for application " + payload.Application.Name)
+	return buildImageResult, nil
+}
+
+func (t *TaskService) dockerfileStagePublishArtifactAsync(orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, imageTag string) {
+	t.ExportAndRecordImage(orgCtx, payload, imageTag, taskCtx)
+}
+
+func (t *TaskService) dockerfileStageAtomicUpdateContainer(ctx context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, mode dockerfilePipelineMode) (AtomicUpdateContainerResult, error) {
+	containerResult, err := t.AtomicUpdateContainer(orgCtx, payload, taskCtx)
+	if err != nil {
+		taskCtx.LogAndUpdateStatus("Failed to update container: "+err.Error(), shared_types.Failed)
+		return AtomicUpdateContainerResult{}, err
+	}
+	taskCtx.AddLog("Container updated successfully for application " + payload.Application.Name + " with container id " + containerResult.ContainerID)
+	successMsg := "Deployment completed successfully"
+	if mode == dockerfilePipelineReDeploy {
+		successMsg = "Redeploy completed successfully"
+	}
+	taskCtx.LogAndUpdateStatus(successMsg, shared_types.Deployed)
+	return containerResult, nil
+}
+
+func (t *TaskService) dockerfileStageConfigureDomains(ctx context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, containerResult AtomicUpdateContainerResult) error {
+	if len(payload.Application.Domains) == 0 {
+		return nil
+	}
+	port, err := strconv.Atoi(containerResult.AvailablePort)
+	if err != nil {
+		taskCtx.LogAndUpdateStatus("Failed to convert port to int: "+err.Error(), shared_types.Failed)
+		return err
+	}
+
+	upstreamHost, err := GetSSHHostForOrganization(ctx, payload.Application.OrganizationID)
+	if err != nil {
+		taskCtx.LogAndUpdateStatus("Failed to get SSH host: "+err.Error(), shared_types.Failed)
+		return err
+	}
+
+	appDomains := make([]shared_types.ApplicationDomain, len(payload.Application.Domains))
+	for i, d := range payload.Application.Domains {
+		appDomains[i] = *d
+	}
+	routes := caddy.BuildMultiUpstreamRoutes(
+		ctx, t.Storage, &t.Logger,
+		payload.Application, appDomains,
+		upstreamHost, port,
+	)
+
+	if err := caddy.AddDomainsAtomic(orgCtx, nil, &t.Logger, routes); err != nil {
+		taskCtx.LogAndUpdateStatus("Failed to configure proxy: "+err.Error(), shared_types.Failed)
+		t.cleanupServiceOnFailure(orgCtx, payload.Application.Name, taskCtx)
+		return err
+	}
+	for _, r := range routes {
+		taskCtx.AddLog("Domain " + r.Domain + " added successfully with TLS")
+	}
+	return nil
+}
+
+// runDockerfilePipelineFromSource runs resolve → build → async S3 export → container update → optional Caddy domains.
+// Stages are ordered to match the previous HandleCreateDockerfileDeployment / redeploy / update handlers exactly.
+func (t *TaskService) runDockerfilePipelineFromSource(ctx context.Context, payload shared_types.TaskPayload, mode dockerfilePipelineMode) error {
+	taskCtx := t.NewTaskContext(payload)
+
+	repoPath, err := t.dockerfileStageResolveSource(ctx, taskCtx, payload, mode)
+	if err != nil {
+		t.emitDeployFailed(payload, err)
+		return err
+	}
+
+	if err := checkCancelled(ctx); err != nil {
+		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
+		return err
+	}
+
+	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, payload.Application.OrganizationID.String())
+
+	imageTag, err := t.dockerfileStageBuildImage(ctx, orgCtx, taskCtx, payload, repoPath, mode)
+	if err != nil {
+		if ctx.Err() != nil {
+			taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
+			return ctx.Err()
+		}
+		taskCtx.LogAndUpdateStatus("Failed to build image: "+err.Error(), shared_types.Failed)
+		return err
+	}
+
+	if err := checkCancelled(ctx); err != nil {
+		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
+		return err
+	}
+
+	t.dockerfileStagePublishArtifactAsync(orgCtx, taskCtx, payload, imageTag)
+	taskCtx.UpdateStatus(shared_types.Deploying)
+
+	if err := checkCancelled(ctx); err != nil {
+		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
+		return err
+	}
+
+	containerResult, err := t.dockerfileStageAtomicUpdateContainer(ctx, orgCtx, taskCtx, payload, mode)
+	if err != nil {
+		t.emitDeployFailed(payload, err)
+		return err
+	}
+
+	if len(payload.Application.Domains) > 0 {
+		if err := t.dockerfileStageConfigureDomains(ctx, orgCtx, taskCtx, payload, containerResult); err != nil {
+			t.emitDeployFailed(payload, err)
+			return err
+		}
+	}
+
+	return nil
 }

--- a/api/internal/features/deploy/tasks/dockerfile_pipeline.go
+++ b/api/internal/features/deploy/tasks/dockerfile_pipeline.go
@@ -1,3 +1,8 @@
+// Dockerfile deploy flows are expressed as explicit stages in this file (resolve source, build image,
+// best-effort async S3 export, Swarm container update, optional Caddy domains). A future split
+// build/run mode or workflow/DAG runner can execute subsets of these stages on different machines
+// by swapping context (for example ServerIDKey) between calls; the ordering and side effects here
+// intentionally match the pre-refactor handlers.
 package tasks
 
 import (
@@ -78,7 +83,7 @@ func (t *TaskService) dockerfileStagePublishArtifactAsync(orgCtx context.Context
 	t.ExportAndRecordImage(orgCtx, payload, imageTag, taskCtx)
 }
 
-func (t *TaskService) dockerfileStageAtomicUpdateContainer(ctx context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, mode dockerfilePipelineMode) (AtomicUpdateContainerResult, error) {
+func (t *TaskService) dockerfileStageAtomicUpdateContainer(_ context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, mode dockerfilePipelineMode) (AtomicUpdateContainerResult, error) {
 	containerResult, err := t.AtomicUpdateContainer(orgCtx, payload, taskCtx)
 	if err != nil {
 		taskCtx.LogAndUpdateStatus("Failed to update container: "+err.Error(), shared_types.Failed)
@@ -130,8 +135,6 @@ func (t *TaskService) dockerfileStageConfigureDomains(ctx context.Context, orgCt
 	return nil
 }
 
-// runDockerfilePipelineFromSource runs resolve → build → async S3 export → container update → optional Caddy domains.
-// Stages are ordered to match the previous HandleCreateDockerfileDeployment / redeploy / update handlers exactly.
 func (t *TaskService) runDockerfilePipelineFromSource(ctx context.Context, payload shared_types.TaskPayload, mode dockerfilePipelineMode) error {
 	taskCtx := t.NewTaskContext(payload)
 

--- a/api/internal/features/deploy/tasks/dockerfile_pipeline.go
+++ b/api/internal/features/deploy/tasks/dockerfile_pipeline.go
@@ -1,0 +1,29 @@
+package tasks
+
+import shared_types "github.com/nixopus/nixopus/api/internal/types"
+
+type dockerfilePipelineMode byte
+
+const (
+	dockerfilePipelineCreate dockerfilePipelineMode = iota
+	dockerfilePipelineReDeploy
+	dockerfilePipelineUpdate
+)
+
+func (m dockerfilePipelineMode) deploymentType() shared_types.DeploymentType {
+	switch m {
+	case dockerfilePipelineReDeploy:
+		return shared_types.DeploymentTypeReDeploy
+	case dockerfilePipelineUpdate:
+		return shared_types.DeploymentTypeUpdate
+	default:
+		return shared_types.DeploymentTypeCreate
+	}
+}
+
+func dockerfileBuildFlagsForMode(mode dockerfilePipelineMode, payload shared_types.TaskPayload) (force, forceWithoutCache bool) {
+	if mode == dockerfilePipelineCreate {
+		return false, false
+	}
+	return payload.UpdateOptions.Force, payload.UpdateOptions.ForceWithoutCache
+}

--- a/api/internal/features/deploy/tasks/dockerfile_pipeline.go
+++ b/api/internal/features/deploy/tasks/dockerfile_pipeline.go
@@ -61,7 +61,7 @@ func (t *TaskService) dockerfileStageResolveSource(ctx context.Context, taskCtx 
 	return repoPath, nil
 }
 
-func (t *TaskService) dockerfileStageBuildImage(ctx context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, repoPath string, mode dockerfilePipelineMode) (string, error) {
+func (t *TaskService) dockerfileStageBuildImage(orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, repoPath string, mode dockerfilePipelineMode) (string, error) {
 	force, forceNoCache := dockerfileBuildFlagsForMode(mode, payload)
 	taskCtx.AddLog("Building image from Dockerfile " + repoPath + " for application " + payload.Application.Name)
 	buildImageResult, err := t.BuildImage(BuildConfig{
@@ -83,7 +83,7 @@ func (t *TaskService) dockerfileStagePublishArtifactAsync(orgCtx context.Context
 	t.ExportAndRecordImage(orgCtx, payload, imageTag, taskCtx)
 }
 
-func (t *TaskService) dockerfileStageAtomicUpdateContainer(_ context.Context, orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, mode dockerfilePipelineMode) (AtomicUpdateContainerResult, error) {
+func (t *TaskService) dockerfileStageAtomicUpdateContainer(orgCtx context.Context, taskCtx *TaskContext, payload shared_types.TaskPayload, mode dockerfilePipelineMode) (AtomicUpdateContainerResult, error) {
 	containerResult, err := t.AtomicUpdateContainer(orgCtx, payload, taskCtx)
 	if err != nil {
 		taskCtx.LogAndUpdateStatus("Failed to update container: "+err.Error(), shared_types.Failed)
@@ -151,7 +151,7 @@ func (t *TaskService) runDockerfilePipelineFromSource(ctx context.Context, paylo
 
 	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, payload.Application.OrganizationID.String())
 
-	imageTag, err := t.dockerfileStageBuildImage(ctx, orgCtx, taskCtx, payload, repoPath, mode)
+	imageTag, err := t.dockerfileStageBuildImage(orgCtx, taskCtx, payload, repoPath, mode)
 	if err != nil {
 		if ctx.Err() != nil {
 			taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
@@ -174,17 +174,15 @@ func (t *TaskService) runDockerfilePipelineFromSource(ctx context.Context, paylo
 		return err
 	}
 
-	containerResult, err := t.dockerfileStageAtomicUpdateContainer(ctx, orgCtx, taskCtx, payload, mode)
+	containerResult, err := t.dockerfileStageAtomicUpdateContainer(orgCtx, taskCtx, payload, mode)
 	if err != nil {
 		t.emitDeployFailed(payload, err)
 		return err
 	}
 
-	if len(payload.Application.Domains) > 0 {
-		if err := t.dockerfileStageConfigureDomains(ctx, orgCtx, taskCtx, payload, containerResult); err != nil {
-			t.emitDeployFailed(payload, err)
-			return err
-		}
+	if err := t.dockerfileStageConfigureDomains(ctx, orgCtx, taskCtx, payload, containerResult); err != nil {
+		t.emitDeployFailed(payload, err)
+		return err
 	}
 
 	return nil

--- a/api/internal/features/deploy/tasks/dockerfile_pipeline_test.go
+++ b/api/internal/features/deploy/tasks/dockerfile_pipeline_test.go
@@ -16,9 +16,11 @@ func TestDockerfilePipelineMode_deploymentType(t *testing.T) {
 		{dockerfilePipelineUpdate, shared_types.DeploymentTypeUpdate},
 	}
 	for _, tt := range tests {
-		if got := tt.mode.deploymentType(); got != tt.want {
-			t.Fatalf("mode %v: got %v want %v", tt.mode, got, tt.want)
-		}
+		t.Run(string(tt.want), func(t *testing.T) {
+			if got := tt.mode.deploymentType(); got != tt.want {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -29,16 +31,22 @@ func TestDockerfilePipeline_buildFlags_fromPayload(t *testing.T) {
 			ForceWithoutCache: true,
 		},
 	}
-	force, noCache := dockerfileBuildFlagsForMode(dockerfilePipelineCreate, payload)
-	if force || noCache {
-		t.Fatalf("create mode must ignore UpdateOptions: force=%v noCache=%v", force, noCache)
-	}
-	force, noCache = dockerfileBuildFlagsForMode(dockerfilePipelineReDeploy, payload)
-	if !force || !noCache {
-		t.Fatalf("redeploy must pass UpdateOptions through: force=%v noCache=%v", force, noCache)
-	}
-	force, noCache = dockerfileBuildFlagsForMode(dockerfilePipelineUpdate, payload)
-	if !force || !noCache {
-		t.Fatalf("update must pass UpdateOptions through: force=%v noCache=%v", force, noCache)
-	}
+	t.Run("create_ignores_update_options", func(t *testing.T) {
+		force, noCache := dockerfileBuildFlagsForMode(dockerfilePipelineCreate, payload)
+		if force || noCache {
+			t.Fatalf("force=%v noCache=%v", force, noCache)
+		}
+	})
+	t.Run("redeploy_uses_update_options", func(t *testing.T) {
+		force, noCache := dockerfileBuildFlagsForMode(dockerfilePipelineReDeploy, payload)
+		if !force || !noCache {
+			t.Fatalf("force=%v noCache=%v", force, noCache)
+		}
+	})
+	t.Run("update_uses_update_options", func(t *testing.T) {
+		force, noCache := dockerfileBuildFlagsForMode(dockerfilePipelineUpdate, payload)
+		if !force || !noCache {
+			t.Fatalf("force=%v noCache=%v", force, noCache)
+		}
+	})
 }

--- a/api/internal/features/deploy/tasks/dockerfile_pipeline_test.go
+++ b/api/internal/features/deploy/tasks/dockerfile_pipeline_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestDockerfilePipelineMode_deploymentType(t *testing.T) {
+	tests := []struct {
+		mode dockerfilePipelineMode
+		want shared_types.DeploymentType
+	}{
+		{dockerfilePipelineCreate, shared_types.DeploymentTypeCreate},
+		{dockerfilePipelineReDeploy, shared_types.DeploymentTypeReDeploy},
+		{dockerfilePipelineUpdate, shared_types.DeploymentTypeUpdate},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.deploymentType(); got != tt.want {
+			t.Fatalf("mode %v: got %v want %v", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestDockerfilePipeline_buildFlags_fromPayload(t *testing.T) {
+	payload := shared_types.TaskPayload{
+		UpdateOptions: shared_types.UpdateOptions{
+			Force:             true,
+			ForceWithoutCache: true,
+		},
+	}
+	force, noCache := dockerfileBuildFlagsForMode(dockerfilePipelineCreate, payload)
+	if force || noCache {
+		t.Fatalf("create mode must ignore UpdateOptions: force=%v noCache=%v", force, noCache)
+	}
+	force, noCache = dockerfileBuildFlagsForMode(dockerfilePipelineReDeploy, payload)
+	if !force || !noCache {
+		t.Fatalf("redeploy must pass UpdateOptions through: force=%v noCache=%v", force, noCache)
+	}
+	force, noCache = dockerfileBuildFlagsForMode(dockerfilePipelineUpdate, payload)
+	if !force || !noCache {
+		t.Fatalf("update must pass UpdateOptions through: force=%v noCache=%v", force, noCache)
+	}
+}

--- a/api/internal/features/deploy/tasks/redeploy.go
+++ b/api/internal/features/deploy/tasks/redeploy.go
@@ -2,11 +2,8 @@ package tasks
 
 import (
 	"context"
-	"strconv"
-
 	"fmt"
 
-	"github.com/nixopus/nixopus/api/internal/features/deploy/caddy"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
@@ -53,114 +50,7 @@ func (s *TaskService) handleReDeploySingle(ctx context.Context, TaskPayload shar
 
 // HandleReDeployDockerfileDeployment handles redeployment of a Dockerfile-based application
 func (s *TaskService) HandleReDeployDockerfileDeployment(ctx context.Context, TaskPayload shared_types.TaskPayload) error {
-	taskCtx := s.NewTaskContext(TaskPayload)
-
-	taskCtx.LogAndUpdateStatus("Starting redeploy process", shared_types.Cloning)
-
-	resolver := s.GetSourceResolver(TaskPayload.Application.Source)
-	repoPath, err := resolver.Resolve(ctx, SourceResolveConfig{
-		TaskPayload:    TaskPayload,
-		DeploymentType: string(shared_types.DeploymentTypeReDeploy),
-		TaskContext:    taskCtx,
-	})
-	if err != nil {
-		taskCtx.LogAndUpdateStatus("Failed to resolve source: "+err.Error(), shared_types.Failed)
-		s.emitDeployFailed(TaskPayload, err)
-		return err
-	}
-
-	taskCtx.LogAndUpdateStatus("Source resolved successfully", shared_types.Building)
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	// Add organization ID to context for docker service
-	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, TaskPayload.Application.OrganizationID.String())
-
-	taskCtx.AddLog("Building image from Dockerfile " + repoPath + " for application " + TaskPayload.Application.Name)
-
-	buildImageResult, err := s.BuildImage(BuildConfig{
-		TaskPayload:       TaskPayload,
-		ContextPath:       repoPath,
-		Force:             TaskPayload.UpdateOptions.Force,
-		ForceWithoutCache: TaskPayload.UpdateOptions.ForceWithoutCache,
-		TaskContext:       taskCtx,
-		Context:           orgCtx,
-	})
-	if err != nil {
-		if ctx.Err() != nil {
-			taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-			return ctx.Err()
-		}
-		taskCtx.LogAndUpdateStatus("Failed to build image: "+err.Error(), shared_types.Failed)
-		return err
-	}
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	taskCtx.AddLog("Image built successfully: " + buildImageResult + " for application " + TaskPayload.Application.Name)
-
-	s.ExportAndRecordImage(orgCtx, TaskPayload, buildImageResult, taskCtx)
-
-	taskCtx.UpdateStatus(shared_types.Deploying)
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	containerResult, err := s.AtomicUpdateContainer(orgCtx, TaskPayload, taskCtx)
-	if err != nil {
-		taskCtx.LogAndUpdateStatus("Failed to update container: "+err.Error(), shared_types.Failed)
-		s.emitDeployFailed(TaskPayload, err)
-		return err
-	}
-
-	taskCtx.AddLog("Container updated successfully for application " + TaskPayload.Application.Name + " with container id " + containerResult.ContainerID)
-	taskCtx.LogAndUpdateStatus("Redeploy completed successfully", shared_types.Deployed)
-
-	if len(TaskPayload.Application.Domains) > 0 {
-		port, err := strconv.Atoi(containerResult.AvailablePort)
-		if err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to convert port to int: "+err.Error(), shared_types.Failed)
-			s.emitDeployFailed(TaskPayload, err)
-			return err
-		}
-
-		upstreamHost, err := GetSSHHostForOrganization(ctx, TaskPayload.Application.OrganizationID)
-		if err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to get SSH host: "+err.Error(), shared_types.Failed)
-			s.emitDeployFailed(TaskPayload, err)
-			return err
-		}
-
-		appDomains := make([]shared_types.ApplicationDomain, len(TaskPayload.Application.Domains))
-		for i, d := range TaskPayload.Application.Domains {
-			appDomains[i] = *d
-		}
-		routes := caddy.BuildMultiUpstreamRoutes(
-			ctx, s.Storage, &s.Logger,
-			TaskPayload.Application, appDomains,
-			upstreamHost, port,
-		)
-
-		if err := caddy.AddDomainsAtomic(orgCtx, nil, &s.Logger, routes); err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to configure proxy: "+err.Error(), shared_types.Failed)
-			s.emitDeployFailed(TaskPayload, err)
-			s.cleanupServiceOnFailure(orgCtx, TaskPayload.Application.Name, taskCtx)
-			return err
-		}
-		for _, r := range routes {
-			taskCtx.AddLog("Domain " + r.Domain + " added successfully with TLS")
-		}
-	}
-
-	return nil
+	return s.runDockerfilePipelineFromSource(ctx, TaskPayload, dockerfilePipelineReDeploy)
 }
 
 // HandleReDeployDockerComposeDeployment handles redeployment of a Docker Compose application

--- a/api/internal/features/deploy/tasks/update.go
+++ b/api/internal/features/deploy/tasks/update.go
@@ -3,10 +3,8 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/google/uuid"
-	"github.com/nixopus/nixopus/api/internal/features/deploy/caddy"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
@@ -89,113 +87,7 @@ func (s *TaskService) HandleUpdateDeployment(ctx context.Context, TaskPayload sh
 
 // HandleUpdateDockerfileDeployment handles update deployment of a Dockerfile-based application
 func (s *TaskService) HandleUpdateDockerfileDeployment(ctx context.Context, TaskPayload shared_types.TaskPayload) error {
-	taskCtx := s.NewTaskContext(TaskPayload)
-
-	taskCtx.LogAndUpdateStatus("Starting deployment process", shared_types.Cloning)
-
-	resolver := s.GetSourceResolver(TaskPayload.Application.Source)
-	repoPath, err := resolver.Resolve(ctx, SourceResolveConfig{
-		TaskPayload:    TaskPayload,
-		DeploymentType: string(shared_types.DeploymentTypeUpdate),
-		TaskContext:    taskCtx,
-	})
-	if err != nil {
-		taskCtx.LogAndUpdateStatus("Failed to resolve source: "+err.Error(), shared_types.Failed)
-		s.emitDeployFailed(TaskPayload, err)
-		return err
-	}
-
-	taskCtx.LogAndUpdateStatus("Source resolved successfully", shared_types.Building)
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	// Add organization ID to context for docker service
-	orgCtx := context.WithValue(ctx, shared_types.OrganizationIDKey, TaskPayload.Application.OrganizationID.String())
-
-	taskCtx.AddLog("Building image from Dockerfile " + repoPath + " for application " + TaskPayload.Application.Name)
-	buildImageResult, err := s.BuildImage(BuildConfig{
-		TaskPayload:       TaskPayload,
-		ContextPath:       repoPath,
-		Force:             TaskPayload.UpdateOptions.Force,
-		ForceWithoutCache: TaskPayload.UpdateOptions.ForceWithoutCache,
-		TaskContext:       taskCtx,
-		Context:           orgCtx,
-	})
-	if err != nil {
-		if ctx.Err() != nil {
-			taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-			return ctx.Err()
-		}
-		taskCtx.LogAndUpdateStatus("Failed to build image: "+err.Error(), shared_types.Failed)
-		return err
-	}
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	taskCtx.AddLog("Image built successfully: " + buildImageResult + " for application " + TaskPayload.Application.Name)
-
-	s.ExportAndRecordImage(orgCtx, TaskPayload, buildImageResult, taskCtx)
-
-	taskCtx.UpdateStatus(shared_types.Deploying)
-
-	if err := checkCancelled(ctx); err != nil {
-		taskCtx.LogAndUpdateStatus("Deployment cancelled by user", shared_types.Cancelled)
-		return err
-	}
-
-	containerResult, err := s.AtomicUpdateContainer(orgCtx, TaskPayload, taskCtx)
-	if err != nil {
-		taskCtx.LogAndUpdateStatus("Failed to update container: "+err.Error(), shared_types.Failed)
-		s.emitDeployFailed(TaskPayload, err)
-		return err
-	}
-
-	taskCtx.AddLog("Container updated successfully for application " + TaskPayload.Application.Name + " with container id " + containerResult.ContainerID)
-	taskCtx.LogAndUpdateStatus("Deployment completed successfully", shared_types.Deployed)
-
-	if len(TaskPayload.Application.Domains) > 0 {
-		port, err := strconv.Atoi(containerResult.AvailablePort)
-		if err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to convert port to int: "+err.Error(), shared_types.Failed)
-			s.emitDeployFailed(TaskPayload, err)
-			return err
-		}
-
-		upstreamHost, err := GetSSHHostForOrganization(ctx, TaskPayload.Application.OrganizationID)
-		if err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to get SSH host: "+err.Error(), shared_types.Failed)
-			s.emitDeployFailed(TaskPayload, err)
-			return err
-		}
-
-		appDomains := make([]shared_types.ApplicationDomain, len(TaskPayload.Application.Domains))
-		for i, d := range TaskPayload.Application.Domains {
-			appDomains[i] = *d
-		}
-		routes := caddy.BuildMultiUpstreamRoutes(
-			ctx, s.Storage, &s.Logger,
-			TaskPayload.Application, appDomains,
-			upstreamHost, port,
-		)
-
-		if err := caddy.AddDomainsAtomic(orgCtx, nil, &s.Logger, routes); err != nil {
-			taskCtx.LogAndUpdateStatus("Failed to configure proxy: "+err.Error(), shared_types.Failed)
-			s.emitDeployFailed(TaskPayload, err)
-			s.cleanupServiceOnFailure(orgCtx, TaskPayload.Application.Name, taskCtx)
-			return err
-		}
-		for _, r := range routes {
-			taskCtx.AddLog("Domain " + r.Domain + " added successfully with TLS")
-		}
-	}
-
-	return nil
+	return s.runDockerfilePipelineFromSource(ctx, TaskPayload, dockerfilePipelineUpdate)
 }
 
 // HandleUpdateDockerComposeDeployment handles update deployment of a Docker Compose application


### PR DESCRIPTION
## Summary
- Centralize Dockerfile create/redeploy/update in `runDockerfilePipelineFromSource` with explicit stages (resolve, build, S3 export hook, Swarm update, Caddy).
- Split Compose deploy into `compose_pipeline.go` stages; validate `deploymentType` before stack work.
- Unit tests for pipeline mode / build flags; compose redeploy clone log aligned with Dockerfile.

## Test plan
- [ ] `go test ./internal/features/deploy/tasks/...`
- [ ] `go build ./...` under `api/`
- [ ] Smoke: Dockerfile + Compose create/redeploy on a dev server (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized deployment pipeline architecture for Docker Compose and Dockerfile deployments into staged workflows.

* **Bug Fixes**
  * Added stricter deployment-type validation that immediately returns errors for unsupported types instead of proceeding with invalid configurations.
  * Improved status messaging to differentiate between redeployment and standard deployment operations.

* **Tests**
  * Added tests validating deployment pipeline mode mappings and build flag configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->