### PR TITLE
feat(machine): add inline rename with display name fallback

### DIFF
--- a/api/internal/features/machine/controller/registration.go
+++ b/api/internal/features/machine/controller/registration.go
@@ -65,6 +65,36 @@ func (c *MachineController) VerifyMachine(f fuego.ContextNoBody) (*types.VerifyM
 	return response, nil
 }
 
+func (c *MachineController) RenameMachine(f fuego.ContextWithBody[types.RenameMachineRequest]) (*types.RenameMachineResponse, error) {
+	w, r := f.Response(), f.Request()
+	user := utils.GetUser(w, r)
+	if user == nil {
+		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
+	}
+
+	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
+
+	machineID, err := uuid.Parse(f.PathParam("id"))
+	if err != nil {
+		return nil, fuego.BadRequestError{Detail: "invalid machine ID"}
+	}
+
+	body, err := f.Body()
+	if err != nil {
+		return nil, fuego.BadRequestError{Detail: "invalid request body"}
+	}
+
+	response, err := c.registrationService.RenameMachine(orgID, machineID, body.Name)
+	if err != nil {
+		return nil, mapRegistrationError(c.logger, err, orgID)
+	}
+
+	return response, nil
+}
+
 func (c *MachineController) DeleteMachine(f fuego.ContextNoBody) (*types.DeleteMachineResponse, error) {
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
@@ -123,6 +153,10 @@ func mapRegistrationError(l logger.Logger, err error, orgID uuid.UUID) error {
 	case errors.Is(err, types.ErrMachineLimitReached):
 		return fuego.ForbiddenError{Detail: err.Error()}
 	case errors.Is(err, types.ErrDuplicateHost):
+		return fuego.BadRequestError{Detail: err.Error()}
+	case errors.Is(err, types.ErrNameRequired):
+		return fuego.BadRequestError{Detail: err.Error()}
+	case errors.Is(err, types.ErrNameTooLong):
 		return fuego.BadRequestError{Detail: err.Error()}
 	case errors.Is(err, types.ErrMachineHasApps):
 		return fuego.ConflictError{Detail: err.Error()}

--- a/api/internal/features/machine/service/registration.go
+++ b/api/internal/features/machine/service/registration.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -182,6 +183,30 @@ func (s *RegistrationService) VerifyMachine(orgID uuid.UUID, machineID uuid.UUID
 	}
 
 	return &types.VerifyMachineResponse{Status: "success", IsActive: true}, nil
+}
+
+func (s *RegistrationService) RenameMachine(orgID uuid.UUID, machineID uuid.UUID, name string) (*types.RenameMachineResponse, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil, types.ErrNameRequired
+	}
+	if len(trimmed) > 255 {
+		return nil, types.ErrNameTooLong
+	}
+
+	_, err := s.storage.GetSSHKeyByID(machineID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("machine not found: %w", err)
+	}
+
+	if err := s.storage.UpdateMachineName(machineID, trimmed); err != nil {
+		return nil, fmt.Errorf("failed to rename machine: %w", err)
+	}
+
+	return &types.RenameMachineResponse{
+		ID:   machineID.String(),
+		Name: trimmed,
+	}, nil
 }
 
 func (s *RegistrationService) DeleteMachine(orgID uuid.UUID, machineID uuid.UUID) error {

--- a/api/internal/features/machine/storage/registration.go
+++ b/api/internal/features/machine/storage/registration.go
@@ -226,6 +226,17 @@ func (s *RegistrationStorage) SetMachineActive(serverID uuid.UUID, active bool) 
 	return err
 }
 
+func (s *RegistrationStorage) UpdateMachineName(id uuid.UUID, name string) error {
+	_, err := s.db.NewUpdate().
+		Model((*api_types.SSHKey)(nil)).
+		Set("name = ?", name).
+		Set("updated_at = ?", time.Now()).
+		Where("id = ?", id).
+		Where("deleted_at IS NULL").
+		Exec(s.ctx)
+	return err
+}
+
 func (s *RegistrationStorage) MarkMachineActive(id uuid.UUID) error {
 	now := time.Now()
 	_, err := s.db.NewUpdate().

--- a/api/internal/features/machine/types/registration.go
+++ b/api/internal/features/machine/types/registration.go
@@ -40,6 +40,15 @@ type ProvisionStatusResponse struct {
 	Error       *string `json:"error"`
 }
 
+type RenameMachineRequest struct {
+	Name string `json:"name" validate:"required"`
+}
+
+type RenameMachineResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type DeleteMachineResponse struct {
 	Status string `json:"status"`
 }
@@ -55,4 +64,6 @@ var (
 	ErrDuplicateHost       = errors.New("duplicate host and port for this organization")
 	ErrMachineHasApps      = errors.New("machine has active deployments")
 	ErrInsufficientCredits = errors.New("insufficient credits")
+	ErrNameRequired        = errors.New("name is required")
+	ErrNameTooLong         = errors.New("name exceeds 255 characters")
 )

--- a/api/internal/routes/machine.go
+++ b/api/internal/routes/machine.go
@@ -144,6 +144,8 @@ func (router *Router) RegisterMachineRegistrationRoutes(regGroup *fuego.Server, 
 		fuego.OptionSummary("Register a BYOS machine"))
 	fuego.Post(regGroup, "/{id}/verify", machineController.VerifyMachine,
 		fuego.OptionSummary("Verify SSH connection"))
+	fuego.Patch(regGroup, "/{id}/rename", machineController.RenameMachine,
+		fuego.OptionSummary("Rename a machine"))
 	fuego.Delete(regGroup, "/{id}", machineController.DeleteMachine,
 		fuego.OptionSummary("Remove a machine"))
 	fuego.Get(regGroup, "/{id}/ssh/status", machineController.GetSSHStatus,

--- a/api/internal/tests/helper.go
+++ b/api/internal/tests/helper.go
@@ -163,6 +163,10 @@ func GetMachineVerifyURL(id string) string {
 	return baseURL + "/machines/" + id + "/verify"
 }
 
+func GetMachineRenameURL(id string) string {
+	return baseURL + "/machines/" + id + "/rename"
+}
+
 func GetMachineSSHKeyStatusURL(id string) string {
 	return baseURL + "/machines/" + id + "/ssh/status"
 }

--- a/api/internal/tests/machine/registration_test.go
+++ b/api/internal/tests/machine/registration_test.go
@@ -228,6 +228,102 @@ func TestVerifyMachine_UnreachableHost(t *testing.T) {
 	)
 }
 
+// --- Rename machine ---
+
+func TestRenameMachine_NoAuth(t *testing.T) {
+	machineID := uuid.New().String()
+	Test(t,
+		Description("PATCH /machines/:id/rename without auth returns 401"),
+		Method(http.MethodPatch, tests.GetMachineRenameURL(machineID)),
+		Send().Body().JSON(types.RenameMachineRequest{Name: "new-name"}),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestRenameMachine_InvalidID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PATCH /machines/not-a-uuid/rename returns 400"),
+		Method(http.MethodPatch, tests.GetMachineRenameURL("not-a-uuid")),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(types.RenameMachineRequest{Name: "new-name"}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestRenameMachine_NotFound(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PATCH /machines/:id/rename for non-existent machine returns 500"),
+		Method(http.MethodPatch, tests.GetMachineRenameURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(types.RenameMachineRequest{Name: "new-name"}),
+		Expect().Status().Equal(http.StatusInternalServerError),
+	)
+}
+
+func TestRenameMachine_EmptyName(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	created := createMachineHelper(t, auth, "rename-test-empty", "192.0.2.60", 22, "root")
+
+	Test(t,
+		Description("PATCH /machines/:id/rename with empty name returns 400"),
+		Method(http.MethodPatch, tests.GetMachineRenameURL(created.ID)),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(types.RenameMachineRequest{Name: "   "}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestRenameMachine_Success(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	created := createMachineHelper(t, auth, "rename-test-ok", "192.0.2.61", 22, "root")
+
+	Test(t,
+		Description("PATCH /machines/:id/rename with valid name returns 200"),
+		Method(http.MethodPatch, tests.GetMachineRenameURL(created.ID)),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(types.RenameMachineRequest{Name: "my-production-box"}),
+		Expect().Status().Equal(http.StatusOK),
+		Expect().Body().JSON().JQ(".id").Equal(created.ID),
+		Expect().Body().JSON().JQ(".name").Equal("my-production-box"),
+	)
+
+	keyID, err := uuid.Parse(created.ID)
+	require.NoError(t, err)
+	var sshKey api_types.SSHKey
+	require.NoError(t, setup.DB.NewSelect().
+		Model(&sshKey).
+		Column("name").
+		Where("id = ?", keyID).
+		Scan(setup.Ctx))
+	require.Equal(t, "my-production-box", sshKey.Name)
+}
+
 // --- Delete machine ---
 
 func TestDeleteMachine_NoAuth(t *testing.T) {

--- a/view/packages/components/applications/server-selector.tsx
+++ b/view/packages/components/applications/server-selector.tsx
@@ -53,7 +53,7 @@ export function ServerSelector({
               )}
               onClick={() => onToggleServer(server.id)}
             >
-              {server.name}
+              {server.name?.trim() || server.host?.trim() || server.id}
               {server.is_default && <span className="ml-1 text-xs opacity-70">(default)</span>}
             </Badge>
           );
@@ -90,7 +90,7 @@ export function ServerSelector({
                 <SelectContent>
                   {selectedServers.map((s) => (
                     <SelectItem key={s.id} value={s.id}>
-                      {s.name}
+                      {s.name?.trim() || s.host?.trim() || s.id}
                       {s.is_default && ' (default)'}
                     </SelectItem>
                   ))}

--- a/view/packages/components/machines/machine-switcher.tsx
+++ b/view/packages/components/machines/machine-switcher.tsx
@@ -59,7 +59,12 @@ export function MachineSwitcher() {
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="sm" className="gap-1.5 px-2 h-7 text-sm font-medium">
           <Server className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <span className="truncate max-w-[150px]">{currentServer?.name ?? 'Select machine'}</span>
+          <span className="truncate max-w-[150px]">
+            {currentServer?.name?.trim() ||
+              currentServer?.host?.trim() ||
+              currentServer?.id ||
+              'Select machine'}
+          </span>
           <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </Button>
       </DropdownMenuTrigger>
@@ -79,7 +84,9 @@ export function MachineSwitcher() {
                 server.is_active ? 'bg-green-500' : 'bg-red-500'
               )}
             />
-            <span className="truncate text-sm flex-1 min-w-0">{server.name}</span>
+            <span className="truncate text-sm flex-1 min-w-0">
+              {server.name?.trim() || server.host?.trim() || server.id}
+            </span>
             {!server.is_active ? (
               <Button
                 variant="ghost"

--- a/view/packages/components/machines/machines-view.tsx
+++ b/view/packages/components/machines/machines-view.tsx
@@ -13,6 +13,7 @@ import {
   DataTable,
   Badge,
   Button,
+  Input,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -33,9 +34,13 @@ import {
   Trash2,
   ChartColumnDecreasing,
   DatabaseBackup,
-  Layers
+  Layers,
+  Pencil
 } from 'lucide-react';
-import { useDeleteMachineMutation } from '@/redux/services/servers/serversApi';
+import {
+  useDeleteMachineMutation,
+  useRenameMachineMutation
+} from '@/redux/services/servers/serversApi';
 import { DeleteDialog } from '@/components/ui/delete-dialog';
 import { toast } from 'sonner';
 import { AddMachineWizard } from '@/packages/components/machines/add-machine-wizard';
@@ -190,6 +195,104 @@ const MachineActionOverlay = React.memo(function MachineActionOverlay({
   );
 });
 
+const InlineEditName = React.memo(function InlineEditName({
+  machineId,
+  currentName,
+  className
+}: {
+  machineId: string;
+  currentName: string;
+  className?: string;
+}) {
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [value, setValue] = React.useState(currentName);
+  const [renameMachine, { isLoading }] = useRenameMachineMutation();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    setValue(currentName);
+  }, [currentName]);
+
+  React.useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const handleSave = async () => {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === currentName) {
+      setValue(currentName);
+      setIsEditing(false);
+      return;
+    }
+    try {
+      await renameMachine({ id: machineId, name: trimmed }).unwrap();
+      setIsEditing(false);
+    } catch {
+      toast.error('Failed to rename machine');
+      setValue(currentName);
+      setIsEditing(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSave();
+    }
+    if (e.key === 'Escape') {
+      setValue(currentName);
+      setIsEditing(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div
+        data-machine-action-zone="true"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Input
+          ref={inputRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={handleSave}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            handleKeyDown(e);
+          }}
+          disabled={isLoading}
+          className={`h-7 text-base font-semibold px-1.5 py-0 ${className || ''}`}
+          maxLength={255}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      data-machine-action-zone="true"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        setIsEditing(true);
+      }}
+      className={`group/edit inline-flex items-center gap-1.5 text-left cursor-pointer hover:opacity-80 transition-opacity ${className || ''}`}
+    >
+      <span
+        className="text-base font-semibold"
+        style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}
+      >
+        {currentName}
+      </span>
+      <Pencil className="h-3 w-3 shrink-0 opacity-0 group-hover/edit:opacity-60 transition-opacity" />
+    </button>
+  );
+});
+
 const MACHINE_NAV_OPTIONS = [
   { label: 'Charts', icon: ChartColumnDecreasing, path: 'charts' },
   { label: 'Apps', icon: Layers, path: 'apps' },
@@ -199,7 +302,7 @@ const MACHINE_NAV_OPTIONS = [
 export const MachineCard = React.memo(function MachineCard({ machine }: { machine: Machine }) {
   const router = useRouter();
   const { isInteractive, isFailed } = useMachineCard(machine);
-  const machineLabel = machine.domain || '';
+  const machineLabel = machine.name;
   const isProvisioning = machine.status === 'provisioning';
   const isActive = machine.status === 'active' || (!isProvisioning && !isFailed);
 
@@ -246,16 +349,7 @@ export const MachineCard = React.memo(function MachineCard({ machine }: { machin
                   <div className="min-w-0 flex-1 max-w-full">
                     <div className="flex items-start gap-2 flex-wrap">
                       <div className="min-w-0 max-w-full">
-                        <CardTitle
-                          className="text-base font-semibold wrap-break-word max-w-full"
-                          style={{
-                            wordBreak: 'break-word',
-                            overflowWrap: 'break-word',
-                            maxWidth: '100%'
-                          }}
-                        >
-                          {machineLabel}
-                        </CardTitle>
+                        <InlineEditName machineId={machine.ssh_key_id} currentName={machineLabel} />
                       </div>
                     </div>
                   </div>
@@ -600,7 +694,7 @@ const MachineRowActions = React.memo(function MachineRowActions({ machine }: { m
         onAction={handleAction}
         onBackup={handleTriggerBackup}
         isBackupInProgress={isBackupInProgress}
-        machineLabel={machine.domain || 'Domain pending'}
+        machineLabel={machine.name}
       />
     </div>
   );
@@ -631,15 +725,21 @@ const MachineRowStatus = React.memo(function MachineRowStatus({ machine }: { mac
   return null;
 });
 
+const MachineTableName = React.memo(function MachineTableName({ machine }: { machine: Machine }) {
+  return (
+    <InlineEditName
+      machineId={machine.ssh_key_id}
+      currentName={machine.name}
+      className="max-w-[260px]"
+    />
+  );
+});
+
 const MACHINE_TABLE_COLUMNS = [
   {
-    key: 'domain',
-    title: 'Domain',
-    render: (_: unknown, machine: Machine) => (
-      <span className="text-sm font-medium truncate block max-w-[260px]">
-        {machine.domain || 'Domain pending'}
-      </span>
-    )
+    key: 'name',
+    title: 'Name',
+    render: (_: unknown, machine: Machine) => <MachineTableName machine={machine} />
   },
   {
     key: 'status',

--- a/view/packages/hooks/machines/use-machines.ts
+++ b/view/packages/hooks/machines/use-machines.ts
@@ -32,13 +32,14 @@ function mapServerToMachine(server: Server): Machine {
     }
   }
 
-  const domain = provision?.domain?.trim() || server.host?.trim() || server.name;
+  const displayName =
+    server.name?.trim() || provision?.domain?.trim() || server.host?.trim() || server.id;
 
   return {
     id: provision?.id || server.id,
     ssh_key_id: server.id,
-    name: server.name,
-    domain,
+    name: displayName,
+    domain: provision?.domain?.trim() || server.host?.trim() || server.id,
     status,
     is_active: server.is_active,
     total_vcpu: server.total_vcpu,

--- a/view/redux/services/servers/serversApi.ts
+++ b/view/redux/services/servers/serversApi.ts
@@ -10,6 +10,8 @@ import type {
   CreateMachineRequest,
   CreateMachineResponse,
   MachineVerifyResponse,
+  RenameMachineRequest,
+  RenameMachineResponse,
   ProvisionMachineRequest,
   ProvisionStatusResponse,
   MachineSshStatusResponse,
@@ -66,6 +68,14 @@ export const machinesApi = createApi({
         url: `${SERVERURLS.PROVISION_STATUS}/${id}/status`,
         method: 'GET'
       })
+    }),
+    renameMachine: builder.mutation<RenameMachineResponse, RenameMachineRequest>({
+      query: ({ id, name }) => ({
+        url: `${SERVERURLS.VERIFY_MACHINE}/${id}/rename`,
+        method: 'PATCH',
+        body: { name }
+      }),
+      invalidatesTags: ['Server']
     }),
     deleteMachine: builder.mutation<DeleteMachineResponse, string>({
       query: (id) => ({
@@ -172,6 +182,7 @@ export const {
   useVerifyMachineMutation,
   useProvisionMachineMutation,
   useGetProvisionStatusQuery,
+  useRenameMachineMutation,
   useDeleteMachineMutation,
   useGetMachineSshStatusQuery,
   useLazyGetMachineSshStatusQuery,

--- a/view/redux/types/servers.ts
+++ b/view/redux/types/servers.ts
@@ -98,6 +98,16 @@ export interface MachineSshStatusResponse {
   last_used_at?: string;
 }
 
+export interface RenameMachineRequest {
+  id: string;
+  name: string;
+}
+
+export interface RenameMachineResponse {
+  id: string;
+  name: string;
+}
+
 export interface DeleteMachineResponse {
   status: string;
 }


### PR DESCRIPTION
## Summary

- Adds `PATCH /v1/machines/:id/rename` endpoint (backend: controller, service, storage, types, route)
- Adds inline edit UI on machine cards and table for renaming, with event propagation fixes for Radix DropdownMenu compatibility
- Unifies display name fallback across all views: `name → domain → host → id` (machines page, machine switcher, server selector)

## Changes

**Backend (API)**
- New `RenameMachine` service method with name validation (trimming, max 255 chars)
- New `UpdateMachineName` storage method
- New `RenameMachineRequest` / `RenameMachineResponse` types with `ErrNameRequired` / `ErrNameTooLong` errors
- PATCH route registered at `/{id}/rename`
- 5 integration tests covering: no auth, invalid ID, not found, empty name, success with DB verification

**Frontend (View)**
- `InlineEditName` component with click-to-edit, save on blur/Enter, cancel on Escape
- `onPointerDown` + `onKeyDown` stopPropagation to prevent Radix menu interference
- RTK Query `renameMachine` mutation with tag invalidation
- `use-machines.ts` updated for unified display name fallback
- `machine-switcher.tsx` and `server-selector.tsx` updated for consistent fallback

## Test plan

- [ ] Rename a machine via inline edit on card view
- [ ] Rename a machine via inline edit on table view
- [ ] Verify Enter saves, Escape cancels, blur saves
- [ ] Verify clicking rename area does not open navigation dropdown
- [ ] Verify display name fallback: shows name if set, else domain, else host, else ID
- [ ] Verify rename with empty/whitespace-only name is rejected
- [ ] Verify machine switcher and server selector show consistent names