### PR TITLE
fix(view): sync activeNav for extensions route

### DIFF
--- a/view/packages/hooks/shared/use-app-sidebar.ts
+++ b/view/packages/hooks/shared/use-app-sidebar.ts
@@ -389,6 +389,15 @@ Add any other context about the problem here.`;
     if (pathname) {
       const effectivePath = machineUrlPrefix ? pathname.replace(machineUrlPrefix, '') : pathname;
 
+      // Extensions live in the footer, not in navMain — still sync so main nav
+      // does not keep highlighting the previous route.
+      if (effectivePath === '/extensions' || effectivePath.startsWith('/extensions/')) {
+        if (activeNav !== '/extensions') {
+          setActiveNav('/extensions');
+        }
+        return;
+      }
+
       const matchingNavItem = data.navMain.find((item) => {
         if (effectivePath === item.url || effectivePath.startsWith(item.url + '/')) return true;
         if ('items' in item && item.items) {

--- a/view/packages/layouts/layout.tsx
+++ b/view/packages/layouts/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useTheme } from 'next-themes';
 import { Blocks, ChevronRight, LayoutGrid, MessageSquare } from 'lucide-react';
@@ -382,8 +382,11 @@ export function AppSidebar({
   ...props
 }: AppSidebarProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const { resolvedTheme } = useTheme();
   const { activeTab, setActiveTab } = useSidebarTab();
+  const isExtensionsRoute =
+    pathname === '/extensions' || (pathname != null && pathname.startsWith('/extensions/'));
 
   if (!user || !activeOrg) {
     return null;
@@ -441,7 +444,11 @@ export function AppSidebar({
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton
-              onClick={() => router.push('/extensions')}
+              isActive={isExtensionsRoute}
+              onClick={() => {
+                setActiveNav('/extensions');
+                router.push('/extensions');
+              }}
               className="cursor-pointer"
             >
               <Blocks />


### PR DESCRIPTION
## Summary
Extensions is a footer-only nav item, so pathname sync never updated `activeNav` and the previous main nav item stayed highlighted.

## Changes
- Sync `activeNav` to `/extensions` when the route is `/extensions` or under it
- Call `setActiveNav` on footer click and mark the footer button active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed sidebar navigation highlighting when browsing extension pages — the Extensions section in the sidebar now correctly displays as active when viewing extensions and related pages, providing accurate visual feedback of your current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->