### PR TITLE
refactor(scheduler): extract billing and machines subpackages

### DIFF
--- a/api/internal/scheduler/billing/billing.go
+++ b/api/internal/scheduler/billing/billing.go
@@ -1,4 +1,4 @@
-package scheduler
+package billing
 
 import (
 	"context"
@@ -18,25 +18,26 @@ const (
 	billingJobSchedule = "0 * * * *"
 )
 
-type BillingScheduler struct {
+// Billing runs periodic wallet sweep and grace-period enforcement for machine plans.
+type Billing struct {
 	cron    *cron.Cron
 	storage *billing_storage.BillingStorage
-	db      *bun.DB
 	logger  logger.Logger
 	ctx     context.Context
 }
 
-func NewBillingScheduler(db *bun.DB, ctx context.Context, l logger.Logger) *BillingScheduler {
-	return &BillingScheduler{
+// New creates a billing cron scheduler.
+func New(db *bun.DB, ctx context.Context, l logger.Logger) *Billing {
+	return &Billing{
 		cron:    cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
 		storage: billing_storage.NewBillingStorage(db, ctx),
-		db:      db,
 		logger:  l,
 		ctx:     ctx,
 	}
 }
 
-func (b *BillingScheduler) Start() {
+// Start registers and runs the billing cron.
+func (b *Billing) Start() {
 	_, err := b.cron.AddFunc(billingJobSchedule, b.run)
 	if err != nil {
 		b.logger.Log(logger.Error, fmt.Sprintf("billing scheduler: failed to register cron: %v", err), "")
@@ -46,16 +47,17 @@ func (b *BillingScheduler) Start() {
 	b.logger.Log(logger.Info, fmt.Sprintf("billing scheduler started with schedule: %s", billingJobSchedule), "")
 }
 
-func (b *BillingScheduler) Stop() {
+// Stop stops the billing cron.
+func (b *Billing) Stop() {
 	b.cron.Stop()
 }
 
-func (b *BillingScheduler) run() {
+func (b *Billing) run() {
 	b.runSweep()
 	b.runGraceCheck()
 }
 
-func (b *BillingScheduler) runSweep() {
+func (b *Billing) runSweep() {
 	rows, err := b.storage.GetDueBillings(b.ctx)
 	if err != nil {
 		b.logger.Log(logger.Error, fmt.Sprintf("billing sweep: failed to get due billings: %v", err), "")
@@ -101,7 +103,7 @@ func (b *BillingScheduler) runSweep() {
 	b.logger.Log(logger.Info, fmt.Sprintf("billing sweep: processed %d, charged %d, grace %d", len(rows), charged, grace), "")
 }
 
-func (b *BillingScheduler) runGraceCheck() {
+func (b *Billing) runGraceCheck() {
 	rows, err := b.storage.GetGraceBillings(b.ctx)
 	if err != nil {
 		b.logger.Log(logger.Error, fmt.Sprintf("grace check: failed to get grace billings: %v", err), "")
@@ -154,7 +156,7 @@ func (b *BillingScheduler) runGraceCheck() {
 	}
 }
 
-func (b *BillingScheduler) triggerServerReset(orgID uuid.UUID, sshKeyID *uuid.UUID) {
+func (b *Billing) triggerServerReset(orgID uuid.UUID, sshKeyID *uuid.UUID) {
 	info, err := b.storage.GetProvisionInfo(b.ctx, orgID, sshKeyID)
 	if err != nil || info == nil {
 		b.logger.Log(logger.Error, fmt.Sprintf("server reset: no provision found for org %s", orgID), "")

--- a/api/internal/scheduler/init.go
+++ b/api/internal/scheduler/init.go
@@ -7,19 +7,21 @@ import (
 	healthcheck_service "github.com/nixopus/nixopus/api/internal/features/healthcheck/service"
 	healthcheck_storage "github.com/nixopus/nixopus/api/internal/features/healthcheck/storage"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/scheduler/billing"
 	"github.com/nixopus/nixopus/api/internal/scheduler/cleanup"
 	"github.com/nixopus/nixopus/api/internal/scheduler/container"
+	"github.com/nixopus/nixopus/api/internal/scheduler/machines"
 	shared_storage "github.com/nixopus/nixopus/api/internal/storage"
 )
 
 type Schedulers struct {
 	Main                *Scheduler
 	HealthCheck         *HealthCheckScheduler
-	Billing             *BillingScheduler
-	Backup              *BackupScheduler
-	TrialExpiry         *TrialExpiryScheduler
-	StaleMachineCleanup *StaleMachineCleanupScheduler
-	MachineHealthCheck  *MachineHealthCheckScheduler
+	Billing             *billing.Billing
+	Backup              *machines.Backup
+	TrialExpiry         *machines.TrialExpiry
+	StaleMachineCleanup *machines.StaleCleanup
+	MachineHealthCheck  *machines.HealthCheck
 }
 
 // InitSchedulers creates and configures all schedulers
@@ -38,11 +40,11 @@ func InitSchedulers(store *shared_storage.Store, ctx context.Context) *Scheduler
 	healthCheckService := healthcheck_service.NewHealthCheckService(store, ctx, l, &healthCheckStorage)
 	healthCheckScheduler := NewHealthCheckScheduler(healthCheckService, l, ctx, nil)
 
-	billingScheduler := NewBillingScheduler(store.DB, ctx, l)
-	backupScheduler := NewBackupScheduler(store.DB, ctx, l)
-	trialExpiryScheduler := NewTrialExpiryScheduler(store.DB, ctx, l, config.AppConfig.Trail.TrialPeriodDays)
-	staleMachineCleanup := NewStaleMachineCleanupScheduler(store.DB, ctx, l)
-	machineHealthCheck := NewMachineHealthCheckScheduler(store.DB, ctx, l)
+	billingScheduler := billing.New(store.DB, ctx, l)
+	backupScheduler := machines.NewBackup(store.DB, ctx, l)
+	trialExpiryScheduler := machines.NewTrialExpiry(store.DB, ctx, l, config.AppConfig.Trail.TrialPeriodDays)
+	staleMachineCleanup := machines.NewStaleCleanup(store.DB, ctx, l)
+	machineHealthCheck := machines.NewHealthCheck(store.DB, ctx, l)
 
 	return &Schedulers{
 		Main:                sched,

--- a/api/internal/scheduler/machines/backup.go
+++ b/api/internal/scheduler/machines/backup.go
@@ -1,4 +1,4 @@
-package scheduler
+package machines
 
 import (
 	"context"
@@ -24,7 +24,8 @@ const (
 	weeklyMinGap = 6 * 24 * time.Hour
 )
 
-type BackupScheduler struct {
+// Backup enqueues scheduled machine backups per organization settings.
+type Backup struct {
 	cron         *cron.Cron
 	billingStore *machine_storage.BillingStorage
 	backupStore  *machine_storage.BackupStorage
@@ -33,8 +34,9 @@ type BackupScheduler struct {
 	ctx          context.Context
 }
 
-func NewBackupScheduler(db *bun.DB, ctx context.Context, l logger.Logger) *BackupScheduler {
-	return &BackupScheduler{
+// NewBackup creates a machine backup cron scheduler.
+func NewBackup(db *bun.DB, ctx context.Context, l logger.Logger) *Backup {
+	return &Backup{
 		cron:         cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
 		billingStore: machine_storage.NewBillingStorage(db, ctx),
 		backupStore:  machine_storage.NewBackupStorage(db, ctx),
@@ -44,7 +46,8 @@ func NewBackupScheduler(db *bun.DB, ctx context.Context, l logger.Logger) *Backu
 	}
 }
 
-func (b *BackupScheduler) Start() {
+// Start registers and runs the backup cron.
+func (b *Backup) Start() {
 	_, err := b.cron.AddFunc(backupScheduleCheck, b.run)
 	if err != nil {
 		b.logger.Log(logger.Error, fmt.Sprintf("backup scheduler: failed to register cron: %v", err), "")
@@ -54,11 +57,12 @@ func (b *BackupScheduler) Start() {
 	b.logger.Log(logger.Info, fmt.Sprintf("backup scheduler started with schedule: %s", backupScheduleCheck), "")
 }
 
-func (b *BackupScheduler) Stop() {
+// Stop stops the backup cron.
+func (b *Backup) Stop() {
 	b.cron.Stop()
 }
 
-func (b *BackupScheduler) run() {
+func (b *Backup) run() {
 	now := time.Now().UTC()
 	currentHour := now.Hour()
 	currentDay := int(now.Weekday())
@@ -115,7 +119,7 @@ func (b *BackupScheduler) run() {
 	}
 }
 
-func (b *BackupScheduler) enqueueIfDue(orgID uuid.UUID, freq string, now time.Time) error {
+func (b *Backup) enqueueIfDue(orgID uuid.UUID, freq string, now time.Time) error {
 	hasRunning, err := b.backupStore.HasInProgressBackup(b.ctx, orgID, nil)
 	if err != nil {
 		return fmt.Errorf("check in-progress: %w", err)

--- a/api/internal/scheduler/machines/health_check.go
+++ b/api/internal/scheduler/machines/health_check.go
@@ -1,4 +1,4 @@
-package scheduler
+package machines
 
 import (
 	"context"
@@ -15,7 +15,8 @@ import (
 
 const machineHealthCheckSchedule = "*/30 * * * *"
 
-type MachineHealthCheckScheduler struct {
+// HealthCheck enqueues periodic machine verification for idle user-owned machines.
+type HealthCheck struct {
 	cron    *cron.Cron
 	storage *machine_storage.RegistrationStorage
 	db      *bun.DB
@@ -23,8 +24,9 @@ type MachineHealthCheckScheduler struct {
 	ctx     context.Context
 }
 
-func NewMachineHealthCheckScheduler(db *bun.DB, ctx context.Context, l logger.Logger) *MachineHealthCheckScheduler {
-	return &MachineHealthCheckScheduler{
+// NewHealthCheck creates a machine health check cron scheduler.
+func NewHealthCheck(db *bun.DB, ctx context.Context, l logger.Logger) *HealthCheck {
+	return &HealthCheck{
 		cron:    cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
 		storage: machine_storage.NewRegistrationStorage(db, ctx),
 		db:      db,
@@ -33,7 +35,8 @@ func NewMachineHealthCheckScheduler(db *bun.DB, ctx context.Context, l logger.Lo
 	}
 }
 
-func (s *MachineHealthCheckScheduler) Start() {
+// Start registers and runs the health check cron.
+func (s *HealthCheck) Start() {
 	_, err := s.cron.AddFunc(machineHealthCheckSchedule, s.run)
 	if err != nil {
 		s.logger.Log(logger.Error, fmt.Sprintf("machine health check: failed to register cron: %v", err), "")
@@ -43,11 +46,12 @@ func (s *MachineHealthCheckScheduler) Start() {
 	s.logger.Log(logger.Info, fmt.Sprintf("machine health check scheduler started with schedule: %s", machineHealthCheckSchedule), "")
 }
 
-func (s *MachineHealthCheckScheduler) Stop() {
+// Stop stops the health check cron.
+func (s *HealthCheck) Stop() {
 	s.cron.Stop()
 }
 
-func (s *MachineHealthCheckScheduler) run() {
+func (s *HealthCheck) run() {
 	var orgSettings []*types.OrganizationSettings
 	err := s.db.NewSelect().
 		Model(&orgSettings).

--- a/api/internal/scheduler/machines/stale_cleanup.go
+++ b/api/internal/scheduler/machines/stale_cleanup.go
@@ -1,4 +1,4 @@
-package scheduler
+package machines
 
 import (
 	"context"
@@ -14,7 +14,8 @@ import (
 
 const staleMachineCleanupSchedule = "0 * * * *"
 
-type StaleMachineCleanupScheduler struct {
+// StaleCleanup removes stale BYOS machine registrations per org.
+type StaleCleanup struct {
 	cron    *cron.Cron
 	storage *machine_storage.RegistrationStorage
 	db      *bun.DB
@@ -22,8 +23,9 @@ type StaleMachineCleanupScheduler struct {
 	ctx     context.Context
 }
 
-func NewStaleMachineCleanupScheduler(db *bun.DB, ctx context.Context, l logger.Logger) *StaleMachineCleanupScheduler {
-	return &StaleMachineCleanupScheduler{
+// NewStaleCleanup creates a stale machine cleanup cron scheduler.
+func NewStaleCleanup(db *bun.DB, ctx context.Context, l logger.Logger) *StaleCleanup {
+	return &StaleCleanup{
 		cron:    cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
 		storage: machine_storage.NewRegistrationStorage(db, ctx),
 		db:      db,
@@ -32,7 +34,8 @@ func NewStaleMachineCleanupScheduler(db *bun.DB, ctx context.Context, l logger.L
 	}
 }
 
-func (s *StaleMachineCleanupScheduler) Start() {
+// Start registers and runs the stale cleanup cron.
+func (s *StaleCleanup) Start() {
 	_, err := s.cron.AddFunc(staleMachineCleanupSchedule, s.run)
 	if err != nil {
 		s.logger.Log(logger.Error, fmt.Sprintf("stale machine cleanup: failed to register cron: %v", err), "")
@@ -42,11 +45,12 @@ func (s *StaleMachineCleanupScheduler) Start() {
 	s.logger.Log(logger.Info, fmt.Sprintf("stale machine cleanup scheduler started with schedule: %s", staleMachineCleanupSchedule), "")
 }
 
-func (s *StaleMachineCleanupScheduler) Stop() {
+// Stop stops the stale cleanup cron.
+func (s *StaleCleanup) Stop() {
 	s.cron.Stop()
 }
 
-func (s *StaleMachineCleanupScheduler) run() {
+func (s *StaleCleanup) run() {
 	var orgSettings []*types.OrganizationSettings
 	err := s.db.NewSelect().
 		Model(&orgSettings).

--- a/api/internal/scheduler/machines/trial_expiry.go
+++ b/api/internal/scheduler/machines/trial_expiry.go
@@ -1,4 +1,4 @@
-package scheduler
+package machines
 
 import (
 	"context"
@@ -16,7 +16,8 @@ import (
 
 const trialExpirySchedule = "0 * * * *"
 
-type TrialExpiryScheduler struct {
+// TrialExpiry deletes expired trail trial VMs and emits notifications.
+type TrialExpiry struct {
 	cron       *cron.Cron
 	storage    *trail_storage.TrailStorage
 	logger     logger.Logger
@@ -26,11 +27,12 @@ type TrialExpiryScheduler struct {
 	notifier   shared_types.Notifier
 }
 
-func NewTrialExpiryScheduler(db *bun.DB, ctx context.Context, l logger.Logger, trialDays int) *TrialExpiryScheduler {
+// NewTrialExpiry creates a trail trial expiry cron scheduler.
+func NewTrialExpiry(db *bun.DB, ctx context.Context, l logger.Logger, trialDays int) *TrialExpiry {
 	if trialDays <= 0 {
 		trialDays = 7
 	}
-	return &TrialExpiryScheduler{
+	return &TrialExpiry{
 		cron:      cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
 		storage:   trail_storage.NewTrailStorage(db, ctx),
 		logger:    l,
@@ -39,19 +41,21 @@ func NewTrialExpiryScheduler(db *bun.DB, ctx context.Context, l logger.Logger, t
 	}
 }
 
-func (t *TrialExpiryScheduler) SetNotifier(n shared_types.Notifier) {
+// SetNotifier sets the notification dispatcher (optional).
+func (t *TrialExpiry) SetNotifier(n shared_types.Notifier) {
 	t.notifierMu.Lock()
 	defer t.notifierMu.Unlock()
 	t.notifier = n
 }
 
-func (t *TrialExpiryScheduler) getNotifier() shared_types.Notifier {
+func (t *TrialExpiry) getNotifier() shared_types.Notifier {
 	t.notifierMu.RLock()
 	defer t.notifierMu.RUnlock()
 	return t.notifier
 }
 
-func (t *TrialExpiryScheduler) Start() {
+// Start registers and runs the trial expiry cron.
+func (t *TrialExpiry) Start() {
 	_, err := t.cron.AddFunc(trialExpirySchedule, t.run)
 	if err != nil {
 		t.logger.Log(logger.Error, fmt.Sprintf("trial expiry scheduler: failed to register cron: %v", err), "")
@@ -61,11 +65,12 @@ func (t *TrialExpiryScheduler) Start() {
 	t.logger.Log(logger.Info, fmt.Sprintf("trial expiry scheduler started with schedule: %s (trial_period_days=%d)", trialExpirySchedule, t.trialDays), "")
 }
 
-func (t *TrialExpiryScheduler) Stop() {
+// Stop stops the trial expiry cron.
+func (t *TrialExpiry) Stop() {
 	t.cron.Stop()
 }
 
-func (t *TrialExpiryScheduler) run() {
+func (t *TrialExpiry) run() {
 	users, err := t.storage.GetExpiredTrialUsers(t.ctx, t.trialDays)
 	if err != nil {
 		t.logger.Log(logger.Error, fmt.Sprintf("trial expiry: query failed: %v", err), "")


### PR DESCRIPTION
## Summary
- Move **billing** cron into `api/internal/scheduler/billing`.
- Move **trail trial expiry**, **stale BYOS cleanup**, **machine health verify**, and **scheduled backups** into `api/internal/scheduler/machines`.
- Wire everything from `scheduler.InitSchedulers` (`init.go`); `main` / `routes` field names unchanged.

## Base branch
Opened against **`test/api-coverage-integration`** because `test/cache-100-coverage` is not on `origin`. This PR includes the commits that were stacked on that branch (config/redisclient/queue/realtime/secrets/logger/cache tests) plus the scheduler refactor at the tip.

To get a **scheduler-only** diff, either push `test/cache-100-coverage` and retarget the PR, or rebase `refactor/scheduler-packages` onto your preferred base and force-push.

## Test plan
- [ ] `go build ./...` from `api/`
- [ ] CI / API tests as configured for the target branch