### PR TITLE
test(api): expand coverage on integration branch

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 // indirect
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b // indirect
@@ -219,6 +220,7 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -53,6 +53,8 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aaw/maybe_tls v0.0.0-20160803104303-89c499bcc6aa h1:6yJyU8MlPBB2enGJdPciPlr8P+PC0nhCFHnSHYMirZI=
 github.com/aaw/maybe_tls v0.0.0-20160803104303-89c499bcc6aa/go.mod h1:I0wzMZvViQzmJjxK+AtfFAnqDCkQV/+r17PO1CCSYnU=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
@@ -614,6 +616,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
 github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=

--- a/api/internal/cache/cache.go
+++ b/api/internal/cache/cache.go
@@ -12,6 +12,9 @@ import (
 	"github.com/nixopus/nixopus/api/internal/types"
 )
 
+// jsonMarshal is json.Marshal by default; tests swap it to cover marshal error paths.
+var jsonMarshal = json.Marshal
+
 const (
 	UserCacheKeyPrefix          = "user:"
 	UserByIDCacheKeyPrefix      = "user_id:"
@@ -90,7 +93,7 @@ func (c *Cache) SetUser(ctx context.Context, email string, user *types.User) err
 		return nil
 	}
 
-	data, err := json.Marshal(userCopy)
+	data, err := jsonMarshal(userCopy)
 	if err != nil {
 		return err
 	}
@@ -129,7 +132,7 @@ func (c *Cache) SetUserByID(ctx context.Context, userID string, user *types.User
 		return nil
 	}
 	key := UserByIDCacheKeyPrefix + userID
-	data, err := json.Marshal(user)
+	data, err := jsonMarshal(user)
 	if err != nil {
 		return err
 	}
@@ -230,7 +233,7 @@ func (c *Cache) SetRBACPermissions(ctx context.Context, userID, orgID string, pe
 	}
 
 	key := fmt.Sprintf("%s%s:%s", RBACCacheKeyPrefix, userID, orgID)
-	data, err := json.Marshal(perms)
+	data, err := jsonMarshal(perms)
 	if err != nil {
 		return err
 	}

--- a/api/internal/cache/cache_test.go
+++ b/api/internal/cache/cache_test.go
@@ -1,0 +1,411 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func swapJSONMarshal(t *testing.T, fn func(any) ([]byte, error)) {
+	t.Helper()
+	orig := jsonMarshal
+	jsonMarshal = fn
+	t.Cleanup(func() { jsonMarshal = orig })
+}
+
+func testCache(t *testing.T) (*Cache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	c, err := NewCache("redis://" + mr.Addr())
+	require.NoError(t, err)
+	return c, mr
+}
+
+func TestNewCache_invalidURL(t *testing.T) {
+	_, err := NewCache("not-a-valid-redis-url")
+	require.Error(t, err)
+}
+
+func TestNewCache_ok(t *testing.T) {
+	_, _ = testCache(t)
+}
+
+func sampleUser() types.User {
+	return types.User{
+		ID:            uuid.New(),
+		Name:          "n",
+		Email:         "e@x",
+		EmailVerified: true,
+		IsOnboarded:   false,
+		CreatedAt:     time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC),
+		UpdatedAt:     time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+}
+
+func TestGetUser_miss(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	u, err := c.GetUser(ctx, "missing@x")
+	require.NoError(t, err)
+	require.Nil(t, u)
+}
+
+func TestGetUser_hit(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	want := sampleUser()
+	require.NoError(t, c.SetUser(ctx, want.Email, &want))
+	got, err := c.GetUser(ctx, want.Email)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, want.ID, got.ID)
+	require.Equal(t, want.Email, got.Email)
+}
+
+func TestGetUser_invalidJSON_deletesKey(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	email := "bad@json"
+	mr.Set(UserCacheKeyPrefix+email, "not-json")
+	_, err := c.GetUser(ctx, email)
+	require.Error(t, err)
+	_, err = mr.Get(UserCacheKeyPrefix + email)
+	require.Error(t, err)
+}
+
+func TestGetUser_nilUUIDAfterUnmarshal(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	email := "nilid@x"
+	payload := map[string]any{
+		"id":             uuid.Nil.String(),
+		"name":           "n",
+		"email":          email,
+		"email_verified": false,
+		"is_onboarded":   false,
+		"created_at":     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		"updated_at":     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+	}
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+	mr.Set(UserCacheKeyPrefix+email, string(b))
+	u, err := c.GetUser(ctx, email)
+	require.NoError(t, err)
+	require.Nil(t, u)
+	_, err = mr.Get(UserCacheKeyPrefix + email)
+	require.Error(t, err)
+}
+
+func TestGetUser_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	_, err := c.GetUser(context.Background(), "a@b")
+	require.Error(t, err)
+}
+
+func TestSetUser_nilID_noop(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	u := sampleUser()
+	u.ID = uuid.Nil
+	require.NoError(t, c.SetUser(ctx, u.Email, &u))
+	_, err := mr.Get(UserCacheKeyPrefix + u.Email)
+	require.Error(t, err)
+}
+
+func TestSetUser_marshalError(t *testing.T) {
+	c, _ := testCache(t)
+	swapJSONMarshal(t, func(any) ([]byte, error) { return nil, errors.New("marshal") })
+	u := sampleUser()
+	require.Error(t, c.SetUser(context.Background(), u.Email, &u))
+}
+
+func TestSetUser_roundTrip(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	u := sampleUser()
+	require.NoError(t, c.SetUser(ctx, u.Email, &u))
+}
+
+func TestSetUser_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	u := sampleUser()
+	mr.Close()
+	require.Error(t, c.SetUser(ctx, u.Email, &u))
+}
+
+func TestGetUserByID_miss(t *testing.T) {
+	c, _ := testCache(t)
+	u, err := c.GetUserByID(context.Background(), uuid.New().String())
+	require.NoError(t, err)
+	require.Nil(t, u)
+}
+
+func TestGetUserByID_hit(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	u := sampleUser()
+	require.NoError(t, c.SetUserByID(ctx, u.ID.String(), &u))
+	got, err := c.GetUserByID(ctx, u.ID.String())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, u.ID, got.ID)
+}
+
+func TestGetUserByID_invalidJSON_deletesKey(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	id := uuid.New().String()
+	key := UserByIDCacheKeyPrefix + id
+	mr.Set(key, "not-json")
+	_, err := c.GetUserByID(ctx, id)
+	require.Error(t, err)
+	_, err = mr.Get(key)
+	require.Error(t, err)
+}
+
+func TestGetUserByID_nilUUID_deletesKey(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	id := uuid.New().String()
+	key := UserByIDCacheKeyPrefix + id
+	payload := map[string]any{
+		"id":             uuid.Nil.String(),
+		"name":           "n",
+		"email":          "e@x",
+		"email_verified": false,
+		"is_onboarded":   false,
+		"created_at":     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		"updated_at":     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+	}
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+	mr.Set(key, string(b))
+	u, err := c.GetUserByID(ctx, id)
+	require.NoError(t, err)
+	require.Nil(t, u)
+	_, err = mr.Get(key)
+	require.Error(t, err)
+}
+
+func TestGetUserByID_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	_, err := c.GetUserByID(context.Background(), uuid.New().String())
+	require.Error(t, err)
+}
+
+func TestSetUserByID_nilUser(t *testing.T) {
+	c, _ := testCache(t)
+	require.NoError(t, c.SetUserByID(context.Background(), uuid.New().String(), nil))
+}
+
+func TestSetUserByID_nilUUID(t *testing.T) {
+	c, _ := testCache(t)
+	u := sampleUser()
+	u.ID = uuid.Nil
+	require.NoError(t, c.SetUserByID(context.Background(), uuid.New().String(), &u))
+}
+
+func TestSetUserByID_marshalError(t *testing.T) {
+	c, _ := testCache(t)
+	swapJSONMarshal(t, func(any) ([]byte, error) { return nil, errors.New("marshal") })
+	u := sampleUser()
+	require.Error(t, c.SetUserByID(context.Background(), u.ID.String(), &u))
+}
+
+func TestSetUserByID_roundTrip(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	u := sampleUser()
+	require.NoError(t, c.SetUserByID(ctx, u.ID.String(), &u))
+}
+
+func TestSetUserByID_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	u := sampleUser()
+	require.Error(t, c.SetUserByID(context.Background(), u.ID.String(), &u))
+}
+
+func TestOrgMembership_miss(t *testing.T) {
+	c, _ := testCache(t)
+	ok, err := c.GetOrgMembership(context.Background(), "u1", "o1")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestOrgMembership_true_false(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	require.NoError(t, c.SetOrgMembership(ctx, "u1", "o1", true))
+	ok, err := c.GetOrgMembership(ctx, "u1", "o1")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, c.SetOrgMembership(ctx, "u1", "o1", false))
+	ok, err = c.GetOrgMembership(ctx, "u1", "o1")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestGetOrgMembership_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	_, err := c.GetOrgMembership(context.Background(), "u", "o")
+	require.Error(t, err)
+}
+
+func TestInvalidateUser_andInvalidateUserByID_andInvalidateOrgMembership(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	u := sampleUser()
+	require.NoError(t, c.SetUser(ctx, u.Email, &u))
+	require.NoError(t, c.SetUserByID(ctx, u.ID.String(), &u))
+	require.NoError(t, c.SetOrgMembership(ctx, u.ID.String(), "org1", true))
+
+	require.NoError(t, c.InvalidateUser(ctx, u.Email))
+	_, err := mr.Get(UserCacheKeyPrefix + u.Email)
+	require.Error(t, err)
+
+	require.NoError(t, c.InvalidateUserByID(ctx, u.ID.String()))
+	_, err = mr.Get(UserByIDCacheKeyPrefix + u.ID.String())
+	require.Error(t, err)
+
+	require.NoError(t, c.InvalidateOrgMembership(ctx, u.ID.String(), "org1"))
+	_, err = mr.Get(OrgMembershipCacheKeyPrefix + u.ID.String() + ":org1")
+	require.Error(t, err)
+}
+
+func TestFeatureFlag_miss(t *testing.T) {
+	c, _ := testCache(t)
+	enabled, err := c.GetFeatureFlag(context.Background(), "org", "feat")
+	require.ErrorIs(t, err, redis.Nil)
+	require.False(t, enabled)
+}
+
+func TestFeatureFlag_hit_true_false(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	require.NoError(t, c.SetFeatureFlag(ctx, "org", "f", true))
+	ok, err := c.GetFeatureFlag(ctx, "org", "f")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, c.SetFeatureFlag(ctx, "org", "f", false))
+	ok, err = c.GetFeatureFlag(ctx, "org", "f")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestGetFeatureFlag_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	_, err := c.GetFeatureFlag(context.Background(), "o", "f")
+	require.Error(t, err)
+	require.False(t, errors.Is(err, redis.Nil))
+}
+
+func TestInvalidateFeatureFlag(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	require.NoError(t, c.SetFeatureFlag(ctx, "o", "f", true))
+	require.NoError(t, c.InvalidateFeatureFlag(ctx, "o", "f"))
+	_, err := mr.Get("feature_flag:o:f")
+	require.Error(t, err)
+}
+
+func TestRBAC_miss_hit_invalidate(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	uid, oid := "user-1", "org-1"
+	p, err := c.GetRBACPermissions(ctx, uid, oid)
+	require.NoError(t, err)
+	require.Nil(t, p)
+
+	perms := &CachedRBACPermissions{Roles: []string{"a"}, Permissions: []string{"p"}}
+	require.NoError(t, c.SetRBACPermissions(ctx, uid, oid, perms))
+	got, err := c.GetRBACPermissions(ctx, uid, oid)
+	require.NoError(t, err)
+	require.Equal(t, perms.Roles, got.Roles)
+	require.Equal(t, perms.Permissions, got.Permissions)
+
+	require.NoError(t, c.InvalidateRBACPermissions(ctx, uid, oid))
+	_, err = mr.Get("rbac:user-1:org-1")
+	require.Error(t, err)
+}
+
+func TestGetRBACPermissions_invalidJSON(t *testing.T) {
+	c, mr := testCache(t)
+	ctx := context.Background()
+	uid, oid := "u2", "o2"
+	key := "rbac:" + uid + ":" + oid
+	mr.Set(key, "not-json")
+	_, err := c.GetRBACPermissions(ctx, uid, oid)
+	require.Error(t, err)
+	_, err = mr.Get(key)
+	require.Error(t, err)
+}
+
+func TestGetRBACPermissions_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	_, err := c.GetRBACPermissions(context.Background(), "u", "o")
+	require.Error(t, err)
+}
+
+func TestSetRBACPermissions_nil(t *testing.T) {
+	c, _ := testCache(t)
+	require.NoError(t, c.SetRBACPermissions(context.Background(), "u", "o", nil))
+}
+
+func TestSetRBACPermissions_marshalError(t *testing.T) {
+	c, _ := testCache(t)
+	swapJSONMarshal(t, func(any) ([]byte, error) { return nil, errors.New("marshal") })
+	perms := &CachedRBACPermissions{Roles: []string{"r"}}
+	require.Error(t, c.SetRBACPermissions(context.Background(), "u", "o", perms))
+}
+
+func TestSetRBACPermissions_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	perms := &CachedRBACPermissions{Roles: []string{"r"}}
+	require.Error(t, c.SetRBACPermissions(context.Background(), "u", "o", perms))
+}
+
+func TestSession_miss_hit(t *testing.T) {
+	c, _ := testCache(t)
+	ctx := context.Background()
+	key := "sess-key"
+	b, err := c.GetSession(ctx, key)
+	require.NoError(t, err)
+	require.Nil(t, b)
+
+	payload := []byte(`{"ok":true}`)
+	require.NoError(t, c.SetSession(ctx, key, payload))
+	got, err := c.GetSession(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestGetSession_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	_, err := c.GetSession(context.Background(), "k")
+	require.Error(t, err)
+}
+
+func TestSetSession_redisError(t *testing.T) {
+	c, mr := testCache(t)
+	mr.Close()
+	require.Error(t, c.SetSession(context.Background(), "k", []byte("x")))
+}

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -17,9 +17,26 @@ import (
 	"github.com/spf13/viper"
 )
 
+func defaultInitStoreInit(s *storage.Store, ctx context.Context) error {
+	return s.Init(ctx)
+}
+
 var (
 	AppConfig   types.Config
 	GlobalStore *storage.Store // Global storage instance, set during Init()
+)
+
+// Test hooks (overridden in tests; defaults wire production behavior).
+var (
+	executableFn         = os.Executable
+	filepathAbsFn        = filepath.Abs
+	initNewDB            = storage.NewDB
+	initStoreInit        = defaultInitStoreInit
+	initLogFatalf        = log.Fatalf
+	initLogFatal         = log.Fatal
+	initNewSecretManager = secrets.NewSecretManager
+	// initAfterViperHook runs after initViper() in Init (tests may poison viper before Unmarshal).
+	initAfterViperHook func()
 )
 
 // getMigrationsPath returns the migrations path from environment variable or defaults to path relative to executable
@@ -31,10 +48,10 @@ func getMigrationsPath() string {
 
 	// Default: use migrations directory relative to executable location
 	// If executable is at api/nixopus-mcp-server or api/nixopus-api, migrations are at api/migrations
-	if execPath, err := os.Executable(); err == nil {
+	if execPath, err := executableFn(); err == nil {
 		execDir := filepath.Dir(execPath)
 		migrationsPath := filepath.Join(execDir, "migrations")
-		if absPath, err := filepath.Abs(migrationsPath); err == nil {
+		if absPath, err := filepathAbsFn(migrationsPath); err == nil {
 			if _, err := os.Stat(absPath); err == nil {
 				return absPath
 			}
@@ -53,7 +70,7 @@ func Init() *storage.Store {
 	// This allows secrets to override .env file values
 	secretConfig := secrets.LoadSecretManagerConfig("api")
 	if secretConfig.Enabled {
-		secretManager, err := secrets.NewSecretManager(secretConfig)
+		secretManager, err := initNewSecretManager(secretConfig)
 		if err != nil {
 			log.Printf("Warning: Failed to initialize secret manager: %v. Falling back to .env files", err)
 		} else {
@@ -75,21 +92,29 @@ func Init() *storage.Store {
 
 	initViper()
 
+	if initAfterViperHook != nil {
+		initAfterViperHook()
+	}
+
 	AppConfig = types.Config{}
 	if err := viper.Unmarshal(&AppConfig); err != nil {
-		log.Fatalf("Failed to unmarshal config: %v", err)
+		initLogFatalf("Failed to unmarshal config: %v", err)
 	}
 
 	if AppConfig.Database.URL != "" {
 		if err := parseDatabaseURL(&AppConfig.Database); err != nil {
-			log.Fatalf("Failed to parse DATABASE_URL: %v", err)
+			initLogFatalf("Failed to parse DATABASE_URL: %v", err)
 		}
+	}
+
+	if AppConfig.Server.Port == "" {
+		AppConfig.Server.Port = "8080"
 	}
 
 	log.Printf("Configuration loaded successfully for environment: %s", AppConfig.App.Environment)
 
 	if err := validateConfig(AppConfig); err != nil {
-		log.Fatalf("Configuration validation failed: %v", err)
+		initLogFatalf("Configuration validation failed: %v", err)
 	}
 
 	// Log key configuration values (without sensitive data)
@@ -113,21 +138,17 @@ func Init() *storage.Store {
 		MigrationsPath: migrationsPath,
 	}
 
-	store, err := storage.NewDB(&storage_config)
+	store, err := initNewDB(&storage_config)
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	if AppConfig.Server.Port == "" {
-		AppConfig.Server.Port = "8080"
+		initLogFatal(err)
 	}
 
 	storageInstance := storage.NewStore(store)
 
-	err = storageInstance.Init(context.Background())
+	err = initStoreInit(storageInstance, context.Background())
 
 	if err != nil {
-		log.Fatalf("Failed to initialize storage: %v", err)
+		initLogFatalf("Failed to initialize storage: %v", err)
 	}
 
 	// Set global store for use throughout the application

--- a/api/internal/config/init_coverage_test.go
+++ b/api/internal/config/init_coverage_test.go
@@ -1,0 +1,349 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nixopus/nixopus/api/internal/secrets"
+	"github.com/nixopus/nixopus/api/internal/storage"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+type errSecretsManager struct{}
+
+func (e *errSecretsManager) GetSecret(ctx context.Context, key string) (string, error) {
+	return "", errors.New("no secret")
+}
+
+func (e *errSecretsManager) GetSecrets(ctx context.Context, prefix string) (map[string]string, error) {
+	return nil, errors.New("no secrets")
+}
+
+func resetInitHooks(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		initNewDB = storage.NewDB
+		initStoreInit = defaultInitStoreInit
+		initLogFatalf = log.Fatalf
+		initLogFatal = log.Fatal
+		initNewSecretManager = secrets.NewSecretManager
+		initAfterViperHook = nil
+		executableFn = os.Executable
+		filepathAbsFn = filepath.Abs
+		GlobalStore = nil
+		AppConfig = types.Config{}
+		viper.Reset()
+	})
+}
+
+func minimalInitEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOST_NAME", "localhost")
+	t.Setenv("DB_PORT", "5432")
+	t.Setenv("USERNAME", "u")
+	t.Setenv("PASSWORD", "p")
+	t.Setenv("DB_NAME", "db")
+	t.Setenv("REDIS_URL", "redis://localhost:6379")
+	t.Setenv("ALLOWED_ORIGIN", "http://localhost:3000")
+	t.Setenv("AUTH_SERVICE_URL", "http://localhost:3000/api/auth")
+	t.Setenv("AUTH_SERVICE_SECRET", "secret")
+	t.Setenv("PORT", "9000")
+	_ = os.Unsetenv("DATABASE_URL")
+	_ = os.Unsetenv("NIXOPUS_CONFIG_PATH")
+	_ = os.Unsetenv("MIGRATIONS_PATH")
+}
+
+func TestDefaultInitStoreInit_nilStorePanics(t *testing.T) {
+	defer func() {
+		require.NotNil(t, recover(), "expected panic from Init on nil store")
+	}()
+	_ = defaultInitStoreInit(nil, context.Background())
+}
+
+func TestGetMigrationsPath(t *testing.T) {
+	resetInitHooks(t)
+	tmp := t.TempDir()
+	want := filepath.Join(tmp, "custom")
+	t.Setenv("MIGRATIONS_PATH", want)
+	assert.Equal(t, want, getMigrationsPath())
+
+	_ = os.Unsetenv("MIGRATIONS_PATH")
+	exe := filepath.Join(tmp, "fakebin")
+	require.NoError(t, os.WriteFile(exe, []byte{}, 0o700))
+	migDir := filepath.Join(tmp, "migrations")
+	require.NoError(t, os.MkdirAll(migDir, 0o700))
+	executableFn = func() (string, error) { return exe, nil }
+	got, err := filepath.Abs(filepath.Join(filepath.Dir(exe), "migrations"))
+	require.NoError(t, err)
+	assert.Equal(t, got, getMigrationsPath())
+
+	tmpNoMig := t.TempDir()
+	exeNoMig := filepath.Join(tmpNoMig, "nobin")
+	require.NoError(t, os.WriteFile(exeNoMig, []byte{}, 0o700))
+	executableFn = func() (string, error) { return exeNoMig, nil }
+	_ = os.Unsetenv("MIGRATIONS_PATH")
+	assert.Equal(t, "./migrations", getMigrationsPath())
+
+	executableFn = func() (string, error) { return "", errors.New("no exe") }
+	assert.Equal(t, "./migrations", getMigrationsPath())
+
+	tmpAbs := t.TempDir()
+	exe3 := filepath.Join(tmpAbs, "bin3")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpAbs, "migrations"), 0o700))
+	require.NoError(t, os.WriteFile(exe3, []byte{}, 0o700))
+	executableFn = func() (string, error) { return exe3, nil }
+	filepathAbsFn = func(path string) (string, error) { return "", errors.New("abs fail") }
+	_ = os.Unsetenv("MIGRATIONS_PATH")
+	assert.Equal(t, "./migrations", getMigrationsPath())
+}
+
+func TestGetDeployDomain_and_BuildDeployDomainURL(t *testing.T) {
+	resetInitHooks(t)
+	_ = os.Unsetenv("DEPLOY_DOMAIN")
+	AppConfig = types.Config{}
+	AppConfig.App.DeployDomain = "custom.example"
+	assert.Equal(t, "custom.example", GetDeployDomain())
+	assert.Equal(t, "", BuildDeployDomainURL(""))
+	assert.Equal(t, "", BuildDeployDomainURL("short"))
+	assert.Equal(t, "https://12345678.custom.example", BuildDeployDomainURL("123456789012"))
+
+	AppConfig.App.DeployDomain = ""
+	t.Setenv("DEPLOY_DOMAIN", "from.env")
+	assert.Equal(t, "from.env", GetDeployDomain())
+	assert.Equal(t, "https://abcdefgh.from.env", BuildDeployDomainURL("abcdefghxyz"))
+
+	_ = os.Unsetenv("DEPLOY_DOMAIN")
+	assert.Equal(t, "nixopus.com", GetDeployDomain())
+}
+
+func TestParseDatabaseURL_invalidURL(t *testing.T) {
+	db := &types.DatabaseConfig{URL: "http://["}
+	err := parseDatabaseURL(db)
+	require.Error(t, err)
+}
+
+func TestParseDatabaseURL_sslFromQueryOnly(t *testing.T) {
+	db := &types.DatabaseConfig{
+		URL: "postgresql://h/db?sslmode=prefer",
+	}
+	require.NoError(t, parseDatabaseURL(db))
+	assert.Equal(t, "prefer", db.SSLMode)
+}
+
+func TestParseDatabaseURL_passwordWhenUserHasPassword(t *testing.T) {
+	db := &types.DatabaseConfig{
+		URL: "postgresql://u:pw@host:5432/dbname",
+	}
+	require.NoError(t, parseDatabaseURL(db))
+	assert.Equal(t, "pw", db.Password)
+}
+
+func TestValidateConfig_individualErrors(t *testing.T) {
+	base := types.Config{
+		Server: types.ServerConfig{Port: "1"},
+		Database: types.DatabaseConfig{
+			Host: "h", Port: "5432", Username: "u", Password: "p", Name: "n",
+		},
+		Redis:      types.RedisConfig{URL: "redis://x"},
+		CORS:       types.CORSConfig{AllowedOrigin: "http://x"},
+		BetterAuth: types.BetterAuthConfig{URL: "http://a", Secret: "s"},
+	}
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Server.Port = "" })), "server port")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Database.Host = "" })), "database host")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Database.Port = "" })), "database port")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Database.Username = "" })), "database username")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Database.Password = "" })), "database password")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Database.Name = "" })), "database name")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.Redis.URL = "" })), "redis URL")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.CORS.AllowedOrigin = "" })), "CORS allowed origin")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.BetterAuth.URL = "" })), "Better Auth URL")
+	assert.ErrorContains(t, validateConfig(mutate(base, func(c *types.Config) { c.BetterAuth.Secret = "" })), "Better Auth secret")
+}
+
+func mutate(c types.Config, fn func(*types.Config)) types.Config {
+	fn(&c)
+	return c
+}
+
+func TestGetConfigFileName_variants(t *testing.T) {
+	for _, tc := range []struct{ env, want string }{
+		{"DEV", "config.dev"},
+		{"STAGE", "config.staging"},
+		{"PROD", "config.prod"},
+	} {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv("ENV", tc.env)
+			assert.Equal(t, tc.want, getConfigFileName())
+		})
+	}
+}
+
+func TestInitViper_customPathAndReadErrors(t *testing.T) {
+	resetInitHooks(t)
+	dir := t.TempDir()
+	t.Setenv("NIXOPUS_CONFIG_PATH", dir)
+	t.Setenv("ENV", "production")
+	_ = os.Unsetenv("PORT")
+	viper.Reset()
+	initViper()
+	assert.NotPanics(t, func() { initViper() })
+
+	viper.Reset()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.prod.yaml"), []byte("bad: [\n"), 0o600))
+	initViper()
+}
+
+func TestInitViper_readsExistingFile(t *testing.T) {
+	resetInitHooks(t)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.prod.yaml"), []byte("server:\n  port: \"7777\"\n"), 0o600))
+	t.Setenv("NIXOPUS_CONFIG_PATH", dir)
+	t.Setenv("ENV", "production")
+	viper.Reset()
+	initViper()
+	assert.Equal(t, "7777", viper.GetString("server.port"))
+}
+
+func TestInit_secretManagerInitError(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	t.Setenv("SECRET_MANAGER_ENABLED", "true")
+	t.Setenv("SECRET_MANAGER_TYPE", "infisical")
+	_ = os.Unsetenv("INFISICAL_TOKEN")
+	viper.Reset()
+	initNewDB = func(*storage.Config) (*bun.DB, error) { return nil, nil }
+	initStoreInit = func(*storage.Store, context.Context) error { return nil }
+	_ = Init()
+}
+
+func TestInit_secretManagerLoadSecretsWarning(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	t.Setenv("SECRET_MANAGER_ENABLED", "true")
+	t.Setenv("SECRET_MANAGER_TYPE", "infisical")
+	t.Setenv("INFISICAL_TOKEN", "tok")
+	initNewSecretManager = func(*secrets.SecretManagerConfig) (secrets.SecretManager, error) {
+		return &errSecretsManager{}, nil
+	}
+	viper.Reset()
+	initNewDB = func(*storage.Config) (*bun.DB, error) { return nil, nil }
+	initStoreInit = func(*storage.Store, context.Context) error { return nil }
+	_ = Init()
+}
+
+func TestInit_unmarshalFatal(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	viper.Reset()
+	initAfterViperHook = func() { viper.Set("database.max_open_conn", "not-an-int") }
+	var got string
+	initLogFatalf = func(format string, v ...interface{}) {
+		got = fmt.Sprintf(format, v...)
+		panic("fatal")
+	}
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected panic")
+		assert.Contains(t, got, "Failed to unmarshal config")
+	}()
+	Init()
+}
+
+func TestInit_parseDatabaseURLFatal(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	t.Setenv("DATABASE_URL", "http://[")
+	viper.Reset()
+	var got string
+	initLogFatalf = func(format string, v ...interface{}) {
+		got = fmt.Sprintf(format, v...)
+		panic("fatal")
+	}
+	defer func() {
+		require.NotNil(t, recover())
+		assert.Contains(t, got, "Failed to parse DATABASE_URL")
+	}()
+	Init()
+}
+
+func TestInit_validateFatal(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	_ = os.Unsetenv("REDIS_URL")
+	viper.Reset()
+	var got string
+	initLogFatalf = func(format string, v ...interface{}) {
+		got = fmt.Sprintf(format, v...)
+		panic("fatal")
+	}
+	defer func() {
+		require.NotNil(t, recover())
+		assert.Contains(t, got, "Configuration validation failed")
+	}()
+	Init()
+}
+
+func TestInit_newDBFatal(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	viper.Reset()
+	initNewDB = func(*storage.Config) (*bun.DB, error) { return nil, errors.New("open db") }
+	var got string
+	initLogFatal = func(v ...interface{}) {
+		got = fmt.Sprint(v...)
+		panic("fatal")
+	}
+	defer func() {
+		require.NotNil(t, recover())
+		assert.Contains(t, got, "open db")
+	}()
+	Init()
+}
+
+func TestInit_storeInitFatal(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	viper.Reset()
+	initNewDB = func(*storage.Config) (*bun.DB, error) { return nil, nil }
+	initStoreInit = func(*storage.Store, context.Context) error { return errors.New("store init") }
+	var got string
+	initLogFatalf = func(format string, v ...interface{}) {
+		got = fmt.Sprintf(format, v...)
+		panic("fatal")
+	}
+	defer func() {
+		require.NotNil(t, recover())
+		assert.Contains(t, got, "Failed to initialize storage")
+	}()
+	Init()
+}
+
+func TestInit_success_stubbedDB(t *testing.T) {
+	resetInitHooks(t)
+	resetMoverHooks(t)
+	minimalInitEnv(t)
+	_ = os.Unsetenv("PORT")
+	viper.Reset()
+	initNewDB = func(*storage.Config) (*bun.DB, error) { return nil, nil }
+	initStoreInit = func(*storage.Store, context.Context) error { return nil }
+	store := Init()
+	require.NotNil(t, store)
+	assert.Equal(t, "8080", AppConfig.Server.Port)
+	assert.NotNil(t, GlobalStore)
+}

--- a/api/internal/config/mover_config.go
+++ b/api/internal/config/mover_config.go
@@ -8,6 +8,18 @@ import (
 	"strings"
 )
 
+// Test hooks for filesystem and home directory (defaults match stdlib).
+var (
+	osGetwdFn           = os.Getwd
+	userHomeDirFn       = os.UserHomeDir
+	mkdirAllFn          = os.MkdirAll
+	osReadFileFn        = os.ReadFile
+	osWriteFileFn       = os.WriteFile
+	osRemoveFn          = os.Remove
+	osStatFn            = os.Stat
+	jsonMarshalIndentFn = json.MarshalIndent
+)
+
 // AuthConfig represents global authentication configuration stored in user's home directory
 type AuthConfig struct {
 	AccessToken    string `json:"access_token,omitempty"`    // Bearer token for API authentication
@@ -75,7 +87,7 @@ type SyncConfig struct {
 
 // getConfigPath returns the path to the .nixopus file in the project root
 func getConfigPath() (string, error) {
-	cwd, err := os.Getwd()
+	cwd, err := osGetwdFn()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current directory: %w", err)
 	}
@@ -84,7 +96,7 @@ func getConfigPath() (string, error) {
 	dir := cwd
 	for {
 		gitPath := filepath.Join(dir, ".git")
-		if _, err := os.Stat(gitPath); err == nil {
+		if _, err := osStatFn(gitPath); err == nil {
 			// Found .git directory, use this as project root
 			return filepath.Join(dir, getMoverConfigFileName()), nil
 		}
@@ -109,12 +121,12 @@ func Load() (*Config, error) {
 	}
 
 	// Check if config file exists
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+	if _, err := osStatFn(configPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("config not found. Run 'nixopus live' to initialize and start deployment")
 	}
 
 	// Read config file
-	data, err := os.ReadFile(configPath)
+	data, err := osReadFileFn(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -186,13 +198,13 @@ func (c *Config) Save() error {
 	}
 
 	// Marshal to JSON with indentation
-	data, err := json.MarshalIndent(saveConfig, "", "  ")
+	data, err := jsonMarshalIndentFn(saveConfig, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
 	// Write to file
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
+	if err := osWriteFileFn(configPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
@@ -237,13 +249,13 @@ func ValidateEnvPath(envPath string) error {
 	}
 
 	// Check if file exists
-	cwd, err := os.Getwd()
+	cwd, err := osGetwdFn()
 	if err != nil {
 		return fmt.Errorf("failed to get current directory: %w", err)
 	}
 
 	fullPath := filepath.Join(cwd, cleanPath)
-	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+	if _, err := osStatFn(fullPath); os.IsNotExist(err) {
 		return fmt.Errorf("env file not found: %s", envPath)
 	}
 
@@ -252,7 +264,7 @@ func ValidateEnvPath(envPath string) error {
 
 // getAuthPath returns the path to the global auth file in ~/.config/nixopus/auth.json
 func getAuthPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDirFn()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
@@ -268,7 +280,7 @@ func GetSyncStatePath() (string, error) {
 	if err := ensureAuthDir(); err != nil {
 		return "", err
 	}
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDirFn()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
@@ -277,13 +289,13 @@ func GetSyncStatePath() (string, error) {
 
 // ensureAuthDir ensures the auth directory exists
 func ensureAuthDir() error {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDirFn()
 	if err != nil {
 		return fmt.Errorf("failed to get home directory: %w", err)
 	}
 
 	configDir := filepath.Join(homeDir, ".config", "nixopus")
-	if err := os.MkdirAll(configDir, 0700); err != nil {
+	if err := mkdirAllFn(configDir, 0700); err != nil {
 		return fmt.Errorf("failed to create auth directory: %w", err)
 	}
 
@@ -298,13 +310,13 @@ func LoadAuth() (*AuthConfig, error) {
 	}
 
 	// Check if auth file exists
-	if _, err := os.Stat(authPath); os.IsNotExist(err) {
+	if _, err := osStatFn(authPath); os.IsNotExist(err) {
 		// Return empty auth config if file doesn't exist
 		return &AuthConfig{}, nil
 	}
 
 	// Read auth file
-	data, err := os.ReadFile(authPath)
+	data, err := osReadFileFn(authPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read auth file: %w", err)
 	}
@@ -339,13 +351,13 @@ func SaveAuth(accessToken, refreshToken string) error {
 	}
 
 	// Marshal to JSON with indentation
-	data, err := json.MarshalIndent(auth, "", "  ")
+	data, err := jsonMarshalIndentFn(auth, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal auth: %w", err)
 	}
 
 	// Write to file with restricted permissions (0600 = rw-------)
-	if err := os.WriteFile(authPath, data, 0600); err != nil {
+	if err := osWriteFileFn(authPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write auth file: %w", err)
 	}
 
@@ -370,12 +382,12 @@ func SaveOrganizationID(organizationID string) error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(auth, "", "  ")
+	data, err := jsonMarshalIndentFn(auth, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal auth: %w", err)
 	}
 
-	if err := os.WriteFile(authPath, data, 0600); err != nil {
+	if err := osWriteFileFn(authPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write auth file: %w", err)
 	}
 
@@ -418,8 +430,8 @@ func ClearAuth() error {
 	}
 
 	// Remove auth file if it exists
-	if _, err := os.Stat(authPath); err == nil {
-		if err := os.Remove(authPath); err != nil {
+	if _, err := osStatFn(authPath); err == nil {
+		if err := osRemoveFn(authPath); err != nil {
 			return fmt.Errorf("failed to remove auth file: %w", err)
 		}
 	}

--- a/api/internal/config/mover_config_test.go
+++ b/api/internal/config/mover_config_test.go
@@ -1,0 +1,540 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetMoverHooks(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		osGetwdFn = os.Getwd
+		userHomeDirFn = os.UserHomeDir
+		mkdirAllFn = os.MkdirAll
+		osReadFileFn = os.ReadFile
+		osWriteFileFn = os.WriteFile
+		osRemoveFn = os.Remove
+		osStatFn = os.Stat
+		jsonMarshalIndentFn = json.MarshalIndent
+		ServerURLProvider = nil
+		ConfigFileNameProvider = nil
+		AuthFileNameProvider = nil
+		SyncStateFileNameProvider = nil
+	})
+}
+
+func TestGetMoverConfigFileNames_withProviders(t *testing.T) {
+	resetMoverHooks(t)
+	ConfigFileNameProvider = func() string { return "custom.cfg" }
+	AuthFileNameProvider = func() string { return "a.json" }
+	SyncStateFileNameProvider = func() string { return "sync.json" }
+	assert.Equal(t, "custom.cfg", getMoverConfigFileName())
+	assert.Equal(t, "a.json", getMoverAuthFileName())
+	assert.Equal(t, "sync.json", getMoverSyncStateFileName())
+}
+
+func TestGetServerURL(t *testing.T) {
+	resetMoverHooks(t)
+	assert.PanicsWithValue(t,
+		"config: ServerURLProvider not set. CLI must call config.InitCLIServerURL at startup.",
+		func() { GetServerURL() },
+	)
+	ServerURLProvider = func() string { return "https://api.example" }
+	assert.Equal(t, "https://api.example", GetServerURL())
+}
+
+func TestGetConfigPath_getwdError(t *testing.T) {
+	resetMoverHooks(t)
+	osGetwdFn = func() (string, error) { return "", errors.New("no cwd") }
+	_, err := getConfigPath()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get current directory")
+}
+
+func TestGetConfigPath_usesGitRoot_tChdir(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o700))
+	sub := filepath.Join(root, "deep", "nest")
+	require.NoError(t, os.MkdirAll(sub, 0o700))
+	t.Chdir(sub)
+	p, err := getConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, ".nixopus"), p)
+}
+
+func TestGetConfigPath_noGitUsesCwd(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	p, err := getConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, ".nixopus"), p)
+}
+
+func TestLoad_getConfigPathError(t *testing.T) {
+	resetMoverHooks(t)
+	osGetwdFn = func() (string, error) { return "", errors.New("cwd") }
+	ServerURLProvider = func() string { return "https://x" }
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get current directory")
+}
+
+func TestLoad_configNotFound(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	ServerURLProvider = func() string { return "https://x" }
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config not found")
+}
+
+func TestLoad_readFileError(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	cfgPath := filepath.Join(root, ".nixopus")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`{"project_id":"p"}`), 0o600))
+	ServerURLProvider = func() string { return "https://x" }
+	osReadFileFn = func(name string) ([]byte, error) {
+		if name == cfgPath {
+			return nil, errors.New("read denied")
+		}
+		return os.ReadFile(name)
+	}
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read config file")
+}
+
+func TestLoad_invalidJSON(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".nixopus"), []byte(`{`), 0o600))
+	ServerURLProvider = func() string { return "https://x" }
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse config file")
+}
+
+func TestLoad_noApplications(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".nixopus"), []byte(`{"sync":{"debounce_ms":1}}`), 0o600))
+	ServerURLProvider = func() string { return "https://x" }
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no applications found")
+}
+
+func TestLoad_applicationsOnly(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	raw := `{"applications":{"default":"app-id-1","web":"w2"}}`
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".nixopus"), []byte(raw), 0o600))
+	ServerURLProvider = func() string { return "https://api" }
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "app-id-1", cfg.Applications["default"])
+}
+
+func TestLoad_statNonNotExistError(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	cfgPath := filepath.Join(root, ".nixopus")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`{"project_id":"p"}`), 0o600))
+	ServerURLProvider = func() string { return "https://x" }
+	osStatFn = func(name string) (os.FileInfo, error) {
+		if name == cfgPath {
+			return nil, errors.New("stat err")
+		}
+		return os.Stat(name)
+	}
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "p", cfg.ProjectID)
+}
+
+func TestLoad_successAndSyncDefaults(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	raw := `{"project_id":"proj1","sync":{"debounce_ms":0,"exclude":[]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".nixopus"), []byte(raw), 0o600))
+	ServerURLProvider = func() string { return "https://api.test" }
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.test", cfg.Server)
+	assert.Equal(t, "proj1", cfg.ProjectID)
+	assert.Equal(t, 300, cfg.Sync.DebounceMs)
+	assert.Contains(t, cfg.Sync.Exclude, ".git")
+}
+
+func TestSave_errors(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	ServerURLProvider = func() string { return "https://x" }
+	c := &Config{ProjectID: "p1", Sync: SyncConfig{DebounceMs: 100}}
+
+	jsonMarshalIndentFn = func(v any, prefix, indent string) ([]byte, error) {
+		return nil, errors.New("marshal")
+	}
+	assert.ErrorContains(t, c.Save(), "failed to marshal config")
+
+	jsonMarshalIndentFn = json.MarshalIndent
+	osWriteFileFn = func(name string, data []byte, perm os.FileMode) error {
+		return errors.New("write fail")
+	}
+	assert.ErrorContains(t, c.Save(), "failed to write config file")
+}
+
+func TestSave_getConfigPathError(t *testing.T) {
+	resetMoverHooks(t)
+	osGetwdFn = func() (string, error) { return "", errors.New("cwd") }
+	c := &Config{ProjectID: "p"}
+	err := c.Save()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get config path")
+}
+
+func TestSave_success(t *testing.T) {
+	resetMoverHooks(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	ServerURLProvider = func() string { return "https://x" }
+	c := &Config{
+		ProjectID: "pid",
+		Sync:      SyncConfig{DebounceMs: 50, Exclude: []string{"a"}},
+		EnvPath:   "e",
+	}
+	require.NoError(t, c.Save())
+	b, err := os.ReadFile(filepath.Join(root, ".nixopus"))
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "pid", out["project_id"])
+}
+
+func TestConfig_GetApplicationID(t *testing.T) {
+	c := &Config{
+		Applications: map[string]string{
+			"default": "d1",
+			"app":     "a1",
+		},
+	}
+	id, err := c.GetApplicationID("")
+	require.NoError(t, err)
+	assert.Equal(t, "d1", id)
+	id, err = c.GetApplicationID("app")
+	require.NoError(t, err)
+	assert.Equal(t, "a1", id)
+	c2 := &Config{Applications: map[string]string{"app": "a1"}}
+	_, err = c2.GetApplicationID("")
+	require.Error(t, err)
+	_, err = c.GetApplicationID("missing")
+	require.Error(t, err)
+
+	c3 := &Config{Applications: map[string]string{"default": ""}}
+	_, err = c3.GetApplicationID("")
+	require.Error(t, err)
+}
+
+func TestLoadAuth_getAuthPathError(t *testing.T) {
+	resetMoverHooks(t)
+	userHomeDirFn = func() (string, error) { return "", errors.New("no home") }
+	_, err := LoadAuth()
+	require.Error(t, err)
+}
+
+func TestClearAuth_getAuthPathError(t *testing.T) {
+	resetMoverHooks(t)
+	userHomeDirFn = func() (string, error) { return "", errors.New("no home") }
+	assert.Error(t, ClearAuth())
+}
+
+func TestValidateEnvPath(t *testing.T) {
+	resetMoverHooks(t)
+	assert.NoError(t, ValidateEnvPath(""))
+	assert.ErrorContains(t, ValidateEnvPath("/abs"), "absolute path")
+	assert.ErrorContains(t, ValidateEnvPath("../x"), "path traversal")
+	assert.ErrorContains(t, ValidateEnvPath("..\\x"), "path traversal")
+
+	root := t.TempDir()
+	t.Chdir(root)
+	assert.ErrorContains(t, ValidateEnvPath("missing.env"), "env file not found")
+
+	f := filepath.Join(root, "ok.env")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	assert.NoError(t, ValidateEnvPath("ok.env"))
+
+	osGetwdFn = func() (string, error) { return "", errors.New("bad") }
+	assert.ErrorContains(t, ValidateEnvPath("ok.env"), "failed to get current directory")
+}
+
+func TestGetAuthPath_userHomeError(t *testing.T) {
+	resetMoverHooks(t)
+	userHomeDirFn = func() (string, error) { return "", errors.New("no home") }
+	_, err := getAuthPath()
+	require.Error(t, err)
+}
+
+func TestEnsureAuthDir_mkdirError(t *testing.T) {
+	resetMoverHooks(t)
+	mkdirAllFn = func(path string, perm os.FileMode) error { return errors.New("mkdir") }
+	assert.ErrorContains(t, ensureAuthDir(), "failed to create auth directory")
+}
+
+func TestGetSyncStatePath_errors(t *testing.T) {
+	resetMoverHooks(t)
+	mkdirAllFn = func(path string, perm os.FileMode) error { return errors.New("mkdir") }
+	_, err := GetSyncStatePath()
+	require.Error(t, err)
+
+	home := t.TempDir()
+	var homeCalls int
+	mkdirAllFn = os.MkdirAll
+	userHomeDirFn = func() (string, error) {
+		homeCalls++
+		if homeCalls == 1 {
+			return home, nil
+		}
+		return "", errors.New("home")
+	}
+	_, err = GetSyncStatePath()
+	require.Error(t, err)
+}
+
+func TestGetSyncStatePath_success(t *testing.T) {
+	resetMoverHooks(t)
+	home := t.TempDir()
+	userHomeDirFn = func() (string, error) { return home, nil }
+	p, err := GetSyncStatePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".config", "nixopus", "sync-state.json"), p)
+}
+
+func withFakeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	userHomeDirFn = func() (string, error) { return home, nil }
+	mkdirAllFn = os.MkdirAll
+	return home
+}
+
+func TestLoadAuth_roundTrip(t *testing.T) {
+	resetMoverHooks(t)
+	_ = withFakeHome(t)
+	a, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Empty(t, a.AccessToken)
+
+	require.NoError(t, SaveAuth("tok", "ref"))
+	a2, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "tok", a2.AccessToken)
+	assert.Equal(t, "ref", a2.RefreshToken)
+
+	require.NoError(t, SaveOrganizationID("org-1"))
+	a3, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "org-1", a3.OrganizationID)
+
+	tok, err := GetAccessToken()
+	require.NoError(t, err)
+	assert.Equal(t, "tok", tok)
+
+	oid, err := GetOrganizationID()
+	require.NoError(t, err)
+	assert.Equal(t, "org-1", oid)
+
+	require.NoError(t, ClearAuth())
+	a4, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Empty(t, a4.AccessToken)
+}
+
+func TestLoadAuth_readError(t *testing.T) {
+	resetMoverHooks(t)
+	home := withFakeHome(t)
+	dir := filepath.Join(home, ".config", "nixopus")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	authPath := filepath.Join(dir, "auth.json")
+	require.NoError(t, os.WriteFile(authPath, []byte(`{}`), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(authPath, 0o600) })
+	_ = os.Chmod(authPath, 0o000)
+	_, err := LoadAuth()
+	if err == nil {
+		// Some platforms allow root read; skip assert
+		t.Skip("chmod did not make file unreadable")
+	}
+	assert.Contains(t, err.Error(), "failed to read auth file")
+}
+
+func TestLoadAuth_invalidJSON(t *testing.T) {
+	resetMoverHooks(t)
+	home := withFakeHome(t)
+	dir := filepath.Join(home, ".config", "nixopus")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{`), 0o600))
+	_, err := LoadAuth()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse auth file")
+}
+
+func TestSaveAuth_errors(t *testing.T) {
+	resetMoverHooks(t)
+	mkdirAllFn = func(string, os.FileMode) error { return errors.New("mkdir") }
+	assert.Error(t, SaveAuth("a", "b"))
+
+	mkdirAllFn = os.MkdirAll
+	userHomeDirFn = func() (string, error) { return "", errors.New("home") }
+	assert.Error(t, SaveAuth("a", "b"))
+}
+
+func TestSaveAuth_getAuthPathError(t *testing.T) {
+	resetMoverHooks(t)
+	home := t.TempDir()
+	var calls int
+	userHomeDirFn = func() (string, error) {
+		calls++
+		if calls == 1 {
+			return home, nil // ensureAuthDir
+		}
+		return "", errors.New("home later") // getAuthPath
+	}
+	assert.Error(t, SaveAuth("a", "b"))
+}
+
+func TestSaveOrganizationID_getAuthPathError(t *testing.T) {
+	resetMoverHooks(t)
+	home := t.TempDir()
+	var calls int
+	userHomeDirFn = func() (string, error) {
+		calls++
+		if calls <= 2 {
+			return home, nil
+		}
+		return "", errors.New("home later")
+	}
+	assert.Error(t, SaveOrganizationID("org"))
+}
+
+func TestSaveAuth_preservesOrgWhenLoadAuthFails(t *testing.T) {
+	resetMoverHooks(t)
+	home := withFakeHome(t)
+	dir := filepath.Join(home, ".config", "nixopus")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{`), 0o600))
+	require.NoError(t, SaveAuth("newtok", "newref"))
+	a, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "newtok", a.AccessToken)
+	assert.Equal(t, "newref", a.RefreshToken)
+}
+
+func TestSaveAuth_marshalAndWriteErrors(t *testing.T) {
+	resetMoverHooks(t)
+	_ = withFakeHome(t)
+	jsonMarshalIndentFn = func(any, string, string) ([]byte, error) { return nil, errors.New("m") }
+	assert.ErrorContains(t, SaveAuth("x", "y"), "failed to marshal auth")
+
+	jsonMarshalIndentFn = json.MarshalIndent
+	osWriteFileFn = func(string, []byte, os.FileMode) error { return errors.New("w") }
+	assert.ErrorContains(t, SaveAuth("x", "y"), "failed to write auth file")
+}
+
+func TestSaveOrganizationID_errors(t *testing.T) {
+	resetMoverHooks(t)
+	userHomeDirFn = func() (string, error) { return "", errors.New("h") }
+	assert.Error(t, SaveOrganizationID("o"))
+
+	home := withFakeHome(t)
+	userHomeDirFn = func() (string, error) { return home, nil }
+	jsonMarshalIndentFn = func(any, string, string) ([]byte, error) { return nil, errors.New("m") }
+	assert.ErrorContains(t, SaveOrganizationID("o"), "failed to marshal auth")
+
+	jsonMarshalIndentFn = json.MarshalIndent
+	osWriteFileFn = func(string, []byte, os.FileMode) error { return errors.New("w") }
+	assert.ErrorContains(t, SaveOrganizationID("o"), "failed to write auth file")
+}
+
+func TestGetAccessToken_and_GetOrganizationID_errors(t *testing.T) {
+	resetMoverHooks(t)
+	_ = withFakeHome(t)
+	_, err := GetAccessToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authenticated")
+
+	_, err = GetOrganizationID()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no organization ID")
+
+	require.NoError(t, SaveAuth("only-token", ""))
+	_, err = GetOrganizationID()
+	require.Error(t, err)
+}
+
+func TestGetAccessToken_and_GetOrganizationID_loadAuthFails(t *testing.T) {
+	resetMoverHooks(t)
+	home := withFakeHome(t)
+	dir := filepath.Join(home, ".config", "nixopus")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{`), 0o600))
+	_, err := GetAccessToken()
+	require.Error(t, err)
+	_, err = GetOrganizationID()
+	require.Error(t, err)
+}
+
+func TestSaveAuth_preservesOrganizationID(t *testing.T) {
+	resetMoverHooks(t)
+	_ = withFakeHome(t)
+	require.NoError(t, SaveOrganizationID("org-keep"))
+	require.NoError(t, SaveAuth("tok2", "ref2"))
+	a, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "org-keep", a.OrganizationID)
+	assert.Equal(t, "tok2", a.AccessToken)
+}
+
+func TestSaveOrganizationID_whenLoadAuthFails(t *testing.T) {
+	resetMoverHooks(t)
+	home := withFakeHome(t)
+	dir := filepath.Join(home, ".config", "nixopus")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{`), 0o600))
+	require.NoError(t, SaveOrganizationID("org-new"))
+	a, err := LoadAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "org-new", a.OrganizationID)
+}
+
+func TestClearAuth_removeError(t *testing.T) {
+	resetMoverHooks(t)
+	home := withFakeHome(t)
+	dir := filepath.Join(home, ".config", "nixopus")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	p := filepath.Join(dir, "auth.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{}`), 0o600))
+	osRemoveFn = func(string) error { return errors.New("rm") }
+	assert.ErrorContains(t, ClearAuth(), "failed to remove auth file")
+}
+
+func TestClearAuth_noFile(t *testing.T) {
+	resetMoverHooks(t)
+	_ = withFakeHome(t)
+	require.NoError(t, ClearAuth())
+}

--- a/api/internal/features/logger/init_test.go
+++ b/api/internal/features/logger/init_test.go
@@ -1,0 +1,106 @@
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureLogrus(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	std := logrus.StandardLogger()
+	prevOut := std.Out
+	prevLevel := std.Level
+	prevExit := std.ExitFunc
+	std.SetOutput(&buf)
+	std.SetLevel(logrus.TraceLevel)
+	std.ExitFunc = func(int) {}
+	t.Cleanup(func() {
+		std.SetOutput(prevOut)
+		std.SetLevel(prevLevel)
+		std.ExitFunc = prevExit
+	})
+	return &buf
+}
+
+func TestNewLogger(t *testing.T) {
+	l := NewLogger()
+	assert.Equal(t, Info, l.Severity)
+	assert.Equal(t, Development, l.Env)
+	assert.Empty(t, l.Message)
+	assert.Empty(t, l.Data)
+}
+
+func TestLog_development_severities(t *testing.T) {
+	sevs := []struct {
+		sev  Severity
+		want string
+	}{
+		{Debug, "level=debug"},
+		{Info, "level=info"},
+		{Warning, "level=warning"},
+		{Error, "level=error"},
+		{Severity("OTHER"), "level=info"},
+	}
+	for _, tc := range sevs {
+		t.Run(string(tc.sev), func(t *testing.T) {
+			buf := captureLogrus(t)
+			l := NewLogger()
+			l.Env = Development
+			l.Log(tc.sev, "hello", "meta")
+			assert.Equal(t, tc.sev, l.Severity)
+			assert.Equal(t, "hello", l.Message)
+			assert.Equal(t, "meta", l.Data)
+			s := buf.String()
+			require.Contains(t, strings.ToLower(s), tc.want)
+			require.Contains(t, s, "hello meta")
+		})
+	}
+}
+
+func TestLog_development_fatal(t *testing.T) {
+	buf := captureLogrus(t)
+	l := NewLogger()
+	l.Env = Development
+	l.Log(Fatal, "bye", "ctx")
+	assert.Equal(t, Fatal, l.Severity)
+	s := buf.String()
+	require.Contains(t, strings.ToLower(s), "level=fatal")
+	require.Contains(t, s, "bye ctx")
+}
+
+func TestLog_production(t *testing.T) {
+	buf := captureLogrus(t)
+	l := NewLogger()
+	l.Env = Production
+	l.Log(Error, "prodmsg", "ignored")
+	assert.Equal(t, Error, l.Severity)
+	s := buf.String()
+	require.Contains(t, strings.ToLower(s), "level=info")
+	require.Contains(t, s, "prodmsg")
+	require.NotContains(t, s, "ignored")
+}
+
+func TestLog_unknownEnvironment(t *testing.T) {
+	buf := captureLogrus(t)
+	l := NewLogger()
+	l.Env = Environment("staging")
+	l.Log(Info, "nope", "data")
+	assert.Equal(t, Info, l.Severity)
+	assert.Empty(t, buf.String())
+}
+
+func TestLog_development_emptyMessageAndData(t *testing.T) {
+	buf := captureLogrus(t)
+	l := NewLogger()
+	l.Env = Development
+	l.Log(Info, "", "")
+	s := buf.String()
+	require.Contains(t, strings.ToLower(s), "level=info")
+	require.Contains(t, s, " ")
+}

--- a/api/internal/queue/backup_pure_test.go
+++ b/api/internal/queue/backup_pure_test.go
@@ -1,0 +1,48 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseResticSummary(t *testing.T) {
+	id, n := parseResticSummary("")
+	assert.Empty(t, id)
+	assert.Zero(t, n)
+
+	out := `ignored
+{"message_type":"summary","snapshot_id":"snap-abc","total_bytes_processed":99}
+`
+	id, n = parseResticSummary(out)
+	assert.Equal(t, "snap-abc", id)
+	assert.Equal(t, int64(99), n)
+
+	// summary line without snapshot_id; non-numeric total_bytes to skip Sscanf
+	line := `{"message_type":"summary","total_bytes_processed":"x"}`
+	id, n = parseResticSummary(line)
+	assert.Empty(t, id)
+	assert.Zero(t, n)
+
+	badNum := `{"message_type":"summary","snapshot_id":"x","total_bytes_processed":"bad"}`
+	id, n = parseResticSummary(badNum)
+	assert.Equal(t, "x", id)
+	assert.Zero(t, n)
+}
+
+func Test_extractJSONField(t *testing.T) {
+	assert.Equal(t, "42", extractJSONField(`{"total_bytes_processed":42,"x":1}`, "total_bytes_processed"))
+	assert.Empty(t, extractJSONField(`{"x":1}`, "missing"))
+	assert.Equal(t, "tail", extractJSONField(`{"k":tail}`, "k"))
+	assert.Equal(t, " rawvalue", extractJSONField(`{"total_bytes_processed": rawvalue`, "total_bytes_processed"))
+}
+
+func Test_regionOrDefault(t *testing.T) {
+	assert.Equal(t, "us-east-1", regionOrDefault(""))
+	assert.Equal(t, "eu-west-1", regionOrDefault("eu-west-1"))
+}
+
+func Test_extractIDFromChannel(t *testing.T) {
+	assert.Equal(t, "rid", extractIDFromChannel("pfx:rid", "pfx:"))
+	assert.Empty(t, extractIDFromChannel("other", "pfx:"))
+}

--- a/api/internal/queue/backup_worker_handle_test.go
+++ b/api/internal/queue/backup_worker_handle_test.go
@@ -1,0 +1,430 @@
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/config"
+	machine_storage "github.com/nixopus/nixopus/api/internal/features/machine/storage"
+	machine_types "github.com/nixopus/nixopus/api/internal/features/machine/types"
+	apitypes "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	_ "modernc.org/sqlite"
+)
+
+func testBackupSQLite(t *testing.T) *bun.DB {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", "file:membackup?mode=memory&cache=shared&_pragma=foreign_keys(1)")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `CREATE TABLE machine_backups (
+		id TEXT PRIMARY KEY,
+		status TEXT NOT NULL,
+		updated_at DATETIME,
+		started_at DATETIME,
+		completed_at DATETIME,
+		snapshot_path TEXT,
+		s3_path TEXT,
+		size_bytes INTEGER,
+		error TEXT
+	)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func withBackupTestConfig(t *testing.T) func() {
+	t.Helper()
+	orig := config.AppConfig
+	config.AppConfig.BetterAuth.Secret = "unit-test-secret-key-32bytes!xx"
+	config.AppConfig.S3 = apitypes.S3Config{
+		Endpoint:  "localhost:9000",
+		Bucket:    "bucket",
+		Region:    "",
+		AccessKey: "ak",
+		SecretKey: "sk",
+		UseSSL:    false,
+	}
+	return func() { config.AppConfig = orig }
+}
+
+type mockBackupSSH struct {
+	fn func(cmd string) (string, error)
+}
+
+func (m *mockBackupSSH) RunCommand(cmd string) (string, error) {
+	if m.fn != nil {
+		return m.fn(cmd)
+	}
+	return "", nil
+}
+
+func TestBackupWorker_Handle(t *testing.T) {
+	ctx := context.Background()
+	prev := getSSHManagerForServerForBackup
+	t.Cleanup(func() { getSSHManagerForServerForBackup = prev })
+
+	t.Run("expired", func(t *testing.T) {
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		err := w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: uuid.New().String(),
+			ExpiresAt:   time.Now().Add(-time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid backup row id", func(t *testing.T) {
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		err := w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: "bad",
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid org id", func(t *testing.T) {
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		err := w.Handle(ctx, MachineBackupPayload{
+			OrgID:       "bad-org",
+			ServerID:    uuid.New().String(),
+			BackupRowID: uuid.New().String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid server id", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    "bad-server",
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("in progress update fails", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		_, _ = db.ExecContext(ctx, `DROP TABLE machine_backups`)
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("ssh manager error", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return nil, errors.New("no ssh")
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("install restic fails", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "which restic >/dev/null") {
+					return "", errors.New("install failed")
+				}
+				return "", nil
+			}}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("restic init fails", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "which restic >/dev/null") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "curl -fsSL") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "which restic 2>/dev/null") {
+					return "/usr/bin/restic", nil
+				}
+				if strings.Contains(cmd, " init ") {
+					return "", errors.New("init boom")
+				}
+				return "", nil
+			}}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("backup command fails with long output", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		longErr := strings.Repeat("E", 600)
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "which restic >/dev/null") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "curl -fsSL") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "which restic 2>/dev/null") {
+					return "/usr/bin/restic", nil
+				}
+				if strings.Contains(cmd, " init ") {
+					return "", nil
+				}
+				if strings.Contains(cmd, " backup ") {
+					return longErr, errors.New("backup failed")
+				}
+				return "", nil
+			}}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("prune warning non fatal", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		summary := `{"message_type":"summary","snapshot_id":"snapw","total_bytes_processed":5}`
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "which restic >/dev/null") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "curl -fsSL") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "which restic 2>/dev/null") {
+					return "/usr/bin/restic", nil
+				}
+				if strings.Contains(cmd, " init ") {
+					return "", nil
+				}
+				if strings.Contains(cmd, " backup ") {
+					return summary, nil
+				}
+				if strings.Contains(cmd, " forget ") {
+					return "", errors.New("prune warn")
+				}
+				return "", nil
+			}}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:          uuid.New().String(),
+			ServerID:       uuid.New().String(),
+			BackupRowID:    row.String(),
+			RetentionCount: 0,
+			ExpiresAt:      time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("completed_update_fails_check_constraint", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		sqldb, err := sql.Open("sqlite", "file:memchk?mode=memory&cache=shared&_pragma=foreign_keys(1)")
+		require.NoError(t, err)
+		db := bun.NewDB(sqldb, sqlitedialect.New())
+		_, err = db.ExecContext(ctx, `CREATE TABLE machine_backups (
+			id TEXT PRIMARY KEY,
+			status TEXT NOT NULL CHECK (status IN ('pending','in_progress','failed')),
+			updated_at DATETIME,
+			started_at DATETIME,
+			completed_at DATETIME,
+			snapshot_path TEXT,
+			s3_path TEXT,
+			size_bytes INTEGER,
+			error TEXT
+		)`)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err = db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		summary := `{"message_type":"summary","snapshot_id":"snapchk","total_bytes_processed":1}`
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "which restic >/dev/null") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "curl -fsSL") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "which restic 2>/dev/null") {
+					return "/usr/bin/restic", nil
+				}
+				if strings.Contains(cmd, " init ") {
+					return "", nil
+				}
+				if strings.Contains(cmd, " backup ") {
+					return summary, nil
+				}
+				if strings.Contains(cmd, " forget ") {
+					return "", nil
+				}
+				return "", nil
+			}}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:       uuid.New().String(),
+			ServerID:    uuid.New().String(),
+			BackupRowID: row.String(),
+			ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("full success", func(t *testing.T) {
+		done := withBackupTestConfig(t)
+		defer done()
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		summary := `{"message_type":"summary","snapshot_id":"snapok","total_bytes_processed":42}`
+		getSSHManagerForServerForBackup = func(context.Context, uuid.UUID, uuid.UUID) (backupSSHRunner, error) {
+			return &mockBackupSSH{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "which restic >/dev/null") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "curl -fsSL") {
+					return "", nil
+				}
+				if strings.Contains(cmd, "which restic 2>/dev/null") {
+					return "/usr/bin/restic", nil
+				}
+				if strings.Contains(cmd, " init ") {
+					return "", nil
+				}
+				if strings.Contains(cmd, " backup ") {
+					return summary, nil
+				}
+				if strings.Contains(cmd, " forget ") {
+					return "", nil
+				}
+				return "", nil
+			}}, nil
+		}
+		err = w.Handle(ctx, MachineBackupPayload{
+			OrgID:          uuid.New().String(),
+			ServerID:       uuid.New().String(),
+			BackupRowID:    row.String(),
+			BackupPaths:    nil,
+			RetentionCount: 3,
+			ExpiresAt:      time.Now().Add(time.Hour).Unix(),
+		})
+		require.NoError(t, err)
+		var status string
+		require.NoError(t, db.QueryRowContext(ctx, `SELECT status FROM machine_backups WHERE id = ?`, row.String()).Scan(&status))
+		require.Equal(t, string(machine_types.BackupStatusCompleted), status)
+	})
+
+	t.Run("failBackup", func(t *testing.T) {
+		db := testBackupSQLite(t)
+		w := &BackupWorker{db: db, backupStore: machine_storage.NewBackupStorage(db, ctx)}
+		row := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO machine_backups (id, status, updated_at) VALUES (?, 'pending', datetime('now'))`, row.String())
+		require.NoError(t, err)
+		require.NoError(t, w.failBackup(ctx, row, "boom"))
+		var st string
+		var errMsg string
+		require.NoError(t, db.QueryRowContext(ctx, `SELECT status, error FROM machine_backups WHERE id = ?`, row.String()).Scan(&st, &errMsg))
+		require.Equal(t, string(machine_types.BackupStatusFailed), st)
+		require.Equal(t, "boom", errMsg)
+	})
+}
+
+func TestEnqueueMachineBackup_errors(t *testing.T) {
+	ctx := context.Background()
+	_, err := EnqueueMachineBackup(ctx, MachineBackupPayload{})
+	require.Error(t, err)
+}

--- a/api/internal/queue/coverage_gaps_test.go
+++ b/api/internal/queue/coverage_gaps_test.go
@@ -1,0 +1,111 @@
+package queue
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cryptossh "golang.org/x/crypto/ssh"
+)
+
+func TestExtractRequestIDFromChannel(t *testing.T) {
+	assert.Equal(t, "abc", ExtractRequestIDFromChannel("machine:reply:abc"))
+	assert.Empty(t, ExtractRequestIDFromChannel("other"))
+}
+
+func TestReplyMultiplexer_Dispatch_unknownWaiter(t *testing.T) {
+	m := NewReplyMultiplexer()
+	m.Dispatch("no-waiter", "payload")
+}
+
+func Test_getOrCreateProducerQueue_concurrent(t *testing.T) {
+	s := miniredis.RunT(t)
+	t.Cleanup(func() { s.Close() })
+	opt, err := redis.ParseURL("redis://" + s.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { _ = rdb.Close() })
+	Init(rdb)
+	t.Cleanup(func() {
+		_ = Close()
+		redisClient = nil
+	})
+
+	const name = "concurrent-producer-q"
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = getOrCreateProducerQueue(name)
+		}()
+	}
+	close(start)
+	wg.Wait()
+}
+
+func Test_defaultMachineVerifySSHProbe_dialFailure(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	signer, err := cryptossh.ParsePrivateKey(pemBytes)
+	require.NoError(t, err)
+	cfg := &cryptossh.ClientConfig{
+		User:            "root",
+		Auth:            []cryptossh.AuthMethod{cryptossh.PublicKeys(signer)},
+		HostKeyCallback: cryptossh.InsecureIgnoreHostKey(),
+		Timeout:         200 * time.Millisecond,
+	}
+	err = defaultMachineVerifySSHProbe(context.Background(), "127.0.0.1:1", cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SSH dial failed")
+}
+
+func TestReplyMultiplexer_Start_ctxCancel(t *testing.T) {
+	s := miniredis.RunT(t)
+	t.Cleanup(func() { s.Close() })
+	opt, err := redis.ParseURL("redis://" + s.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { _ = rdb.Close() })
+	prev := redisClient
+	redisClient = rdb
+	t.Cleanup(func() { redisClient = prev })
+
+	m := NewReplyMultiplexer()
+	ctx, cancel := context.WithCancel(context.Background())
+	m.Start(ctx)
+	cancel()
+	time.Sleep(80 * time.Millisecond)
+}
+
+func TestReplyMultiplexer_Start_pubsubEmptyRequestID(t *testing.T) {
+	s := miniredis.RunT(t)
+	t.Cleanup(func() { s.Close() })
+	opt, err := redis.ParseURL("redis://" + s.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { _ = rdb.Close() })
+	prev := redisClient
+	redisClient = rdb
+	t.Cleanup(func() { redisClient = prev })
+
+	m := NewReplyMultiplexer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	time.Sleep(60 * time.Millisecond)
+	require.NoError(t, rdb.Publish(ctx, "machine:reply:", "ignored").Err())
+	time.Sleep(40 * time.Millisecond)
+}

--- a/api/internal/queue/custom_domain.go
+++ b/api/internal/queue/custom_domain.go
@@ -35,6 +35,14 @@ var (
 	TaskRemoveCustomDomain   *taskq.Task
 )
 
+func handleRegisterCustomDomainTask(ctx context.Context, payload CustomDomainPayload) error {
+	return nil
+}
+
+func handleRemoveCustomDomainTask(ctx context.Context, payload RemoveCustomDomainPayload) error {
+	return nil
+}
+
 func SetupCustomDomainQueue() {
 	onceCustomDomainQueues.Do(func() {
 		CustomDomainQueue = registerProducerQueue(&taskq.QueueOptions{
@@ -44,17 +52,13 @@ func SetupCustomDomainQueue() {
 		TaskRegisterCustomDomain = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskRegisterCustomDomain,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload CustomDomainPayload) error {
-				return nil
-			},
+			Handler:    handleRegisterCustomDomainTask,
 		})
 
 		TaskRemoveCustomDomain = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskRemoveCustomDomain,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload RemoveCustomDomainPayload) error {
-				return nil
-			},
+			Handler:    handleRemoveCustomDomainTask,
 		})
 	})
 }

--- a/api/internal/queue/init.go
+++ b/api/internal/queue/init.go
@@ -24,6 +24,9 @@ var (
 
 	producerQueueCache   = make(map[string]taskq.Queue)
 	producerQueueCacheMu sync.RWMutex
+
+	// deadConsumerIdleThreshold is how long a consumer must be idle (no pending) before cleanup removes it.
+	deadConsumerIdleThreshold = 15 * time.Minute
 )
 
 // Init initializes the queue factory with a shared Redis v8 client.
@@ -127,10 +130,10 @@ func cleanupDeadConsumers(ctx context.Context) error {
 		// Check each consumer and remove if idle for too long
 		for _, consumer := range consumers {
 			idleTime := time.Duration(consumer.Idle) * time.Millisecond
-			// Consider consumers idle for more than 15 minutes as dead
+			// Consider consumers idle beyond threshold as dead
 			// (longer than ConsumerIdleTimeout to account for processing time)
 			// Only remove if they have no pending messages
-			if idleTime > 15*time.Minute && consumer.Pending == 0 {
+			if idleTime > deadConsumerIdleThreshold && consumer.Pending == 0 {
 				delCmd := redisClient.XGroupDelConsumer(ctx, streamKey, groupName, consumer.Name)
 				if delCmd.Err() == nil {
 					log.Printf("Removed dead consumer '%s' from queue '%s' (idle for %v)", consumer.Name, queueName, idleTime)
@@ -160,9 +163,7 @@ func StartConsumers(ctx context.Context) error {
 	var err error
 	onceConsumers.Do(func() {
 		// Clean up dead consumers before starting new ones
-		if cleanupErr := cleanupDeadConsumers(ctx); cleanupErr != nil {
-			log.Printf("Warning: Failed to cleanup dead consumers: %v", cleanupErr)
-		}
+		_ = cleanupDeadConsumers(ctx)
 
 		log.Println("Starting task queue consumers...")
 		err = factory.StartConsumers(ctx)

--- a/api/internal/queue/machine_backup.go
+++ b/api/internal/queue/machine_backup.go
@@ -55,7 +55,22 @@ var (
 	machineBackupQueue    taskq.Queue
 	taskMachineBackupTask *taskq.Task
 	backupReplyMux        *ReplyMultiplexer
+	backupWorker          *BackupWorker
 )
+
+func machineBackupTaskHandler(ctx context.Context, payload MachineBackupPayload) error {
+	return backupWorker.Handle(ctx, payload)
+}
+
+// backupSSHRunner is satisfied by *sshpkg.SSHManager; swappable in tests.
+type backupSSHRunner interface {
+	RunCommand(cmd string) (string, error)
+}
+
+// getSSHManagerForServerForBackup is the hook used by BackupWorker; tests may replace it.
+var getSSHManagerForServerForBackup = func(ctx context.Context, orgID, serverID uuid.UUID) (backupSSHRunner, error) {
+	return sshpkg.GetSSHManagerForServer(ctx, orgID, serverID)
+}
 
 type BackupWorker struct {
 	db          *bun.DB
@@ -102,7 +117,7 @@ func (w *BackupWorker) Handle(ctx context.Context, payload MachineBackupPayload)
 		return nil
 	}
 
-	sshMgr, err := sshpkg.GetSSHManagerForServer(ctx, orgID, serverID)
+	sshMgr, err := getSSHManagerForServerForBackup(ctx, orgID, serverID)
 	if err != nil {
 		log.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %v", err), payload.OrgID)
 		return w.failBackup(ctx, rowID, fmt.Sprintf("SSH connection failed: %v", err))
@@ -242,14 +257,12 @@ func SetupMachineBackupQueue(ctx context.Context, db *bun.DB) {
 			Name: queueMachineBackup,
 		})
 
-		worker := newBackupWorker(db, ctx)
+		backupWorker = newBackupWorker(db, ctx)
 
 		taskMachineBackupTask = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskMachineBackup,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload MachineBackupPayload) error {
-				return worker.Handle(ctx, payload)
-			},
+			Handler:    machineBackupTaskHandler,
 		})
 
 		backupReplyMux = NewReplyMultiplexerWithPrefix(backupReplyPrefix)

--- a/api/internal/queue/machine_lifecycle.go
+++ b/api/internal/queue/machine_lifecycle.go
@@ -40,6 +40,10 @@ var (
 	replyMux                 *ReplyMultiplexer
 )
 
+func handleMachineLifecycleTask(ctx context.Context, payload MachineLifecyclePayload) error {
+	return nil
+}
+
 func SetupMachineLifecycleQueue(ctx context.Context) {
 	onceMachineLifecycle.Do(func() {
 		machineLifecycleQueue = registerProducerQueue(&taskq.QueueOptions{
@@ -49,9 +53,7 @@ func SetupMachineLifecycleQueue(ctx context.Context) {
 		taskMachineLifecycleTask = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskMachineLifecycle,
 			RetryLimit: 0,
-			Handler: func(ctx context.Context, payload MachineLifecyclePayload) error {
-				return nil
-			},
+			Handler:    handleMachineLifecycleTask,
 		})
 
 		replyMux = NewReplyMultiplexer()
@@ -66,8 +68,10 @@ func ExecuteMachineLifecycle(ctx context.Context, payload MachineLifecyclePayloa
 		return nil, fmt.Errorf("machine lifecycle queue not initialized - call SetupMachineLifecycleQueue first")
 	}
 
-	requestID := uuid.New().String()
-	payload.RequestID = requestID
+	if payload.RequestID == "" {
+		payload.RequestID = uuid.New().String()
+	}
+	requestID := payload.RequestID
 	payload.ExpiresAt = time.Now().Add(15 * time.Second).Unix()
 
 	waiterCh := replyMux.RegisterWaiter(requestID)

--- a/api/internal/queue/machine_lifecycle_test.go
+++ b/api/internal/queue/machine_lifecycle_test.go
@@ -1,16 +1,14 @@
-package tests
+package queue
 
 import (
 	"encoding/json"
 	"testing"
-
-	"github.com/nixopus/nixopus/api/internal/queue"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMachineLifecyclePayload_JSON(t *testing.T) {
-	payload := queue.MachineLifecyclePayload{
+	payload := MachineLifecyclePayload{
 		RequestID:    "abc-123",
 		InstanceName: "trail-xyz",
 		Action:       "status",
@@ -21,7 +19,7 @@ func TestMachineLifecyclePayload_JSON(t *testing.T) {
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	var decoded queue.MachineLifecyclePayload
+	var decoded MachineLifecyclePayload
 	require.NoError(t, json.Unmarshal(data, &decoded))
 
 	assert.Equal(t, payload.RequestID, decoded.RequestID)
@@ -32,7 +30,7 @@ func TestMachineLifecyclePayload_JSON(t *testing.T) {
 }
 
 func TestMachineLifecycleResult_JSON(t *testing.T) {
-	result := queue.MachineLifecycleResult{
+	result := MachineLifecycleResult{
 		RequestID: "abc-123",
 		Success:   true,
 		Action:    "status",
@@ -42,7 +40,7 @@ func TestMachineLifecycleResult_JSON(t *testing.T) {
 	data, err := json.Marshal(result)
 	require.NoError(t, err)
 
-	var decoded queue.MachineLifecycleResult
+	var decoded MachineLifecycleResult
 	require.NoError(t, json.Unmarshal(data, &decoded))
 
 	assert.True(t, decoded.Success)
@@ -51,7 +49,7 @@ func TestMachineLifecycleResult_JSON(t *testing.T) {
 }
 
 func TestMachineLifecycleResult_ErrorJSON(t *testing.T) {
-	result := queue.MachineLifecycleResult{
+	result := MachineLifecycleResult{
 		RequestID: "abc-456",
 		Success:   false,
 		Action:    "pause",
@@ -61,7 +59,7 @@ func TestMachineLifecycleResult_ErrorJSON(t *testing.T) {
 	data, err := json.Marshal(result)
 	require.NoError(t, err)
 
-	var decoded queue.MachineLifecycleResult
+	var decoded MachineLifecycleResult
 	require.NoError(t, json.Unmarshal(data, &decoded))
 
 	assert.False(t, decoded.Success)

--- a/api/internal/queue/machine_verify.go
+++ b/api/internal/queue/machine_verify.go
@@ -31,17 +31,54 @@ var (
 	taskMachineVerifyTask *taskq.Task
 )
 
+// defaultMachineVerifySSHProbe performs dial, session, and echo check; replaced in tests.
+func defaultMachineVerifySSHProbe(ctx context.Context, addr string, config *cryptossh.ClientConfig) error {
+	client, err := cryptossh.Dial("tcp", addr, config)
+	if err != nil {
+		return fmt.Errorf("SSH dial failed: %w", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return fmt.Errorf("SSH session failed: %w", err)
+	}
+	defer session.Close()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- session.Run("echo ok") }()
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			return fmt.Errorf("SSH command failed: %w", err)
+		}
+	case <-ctx.Done():
+		session.Close()
+		return ctx.Err()
+	}
+	return nil
+}
+
+// machineVerifySSHProbe is swapped in tests to avoid real TCP/SSH.
+var machineVerifySSHProbe = defaultMachineVerifySSHProbe
+
+var machineVerifyDB *bun.DB
+
+func machineVerifyTaskHandler(ctx context.Context, payload MachineVerifyPayload) error {
+	return handleMachineVerify(ctx, machineVerifyDB, payload)
+}
+
 func SetupMachineVerifyQueue(ctx context.Context, db *bun.DB) {
 	onceMachineVerify.Do(func() {
+		machineVerifyDB = db
 		machineVerifyQueue = registerProducerQueue(&taskq.QueueOptions{
 			Name: queueMachineVerify,
 		})
 		taskMachineVerifyTask = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskMachineVerify,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload MachineVerifyPayload) error {
-				return handleMachineVerify(ctx, db, payload)
-			},
+			Handler:    machineVerifyTaskHandler,
 		})
 		log.Printf("Machine verify queue initialized")
 	})
@@ -91,33 +128,9 @@ func handleMachineVerify(ctx context.Context, db *bun.DB, payload MachineVerifyP
 	}
 
 	addr := fmt.Sprintf("%s:%d", *sshKey.Host, port)
-	client, err := cryptossh.Dial("tcp", addr, config)
-	if err != nil {
+	if err := machineVerifySSHProbe(ctx, addr, config); err != nil {
 		markMachineInactive(ctx, db, payload.MachineID)
-		return fmt.Errorf("SSH dial failed: %w", err)
-	}
-	defer client.Close()
-
-	session, err := client.NewSession()
-	if err != nil {
-		markMachineInactive(ctx, db, payload.MachineID)
-		return fmt.Errorf("SSH session failed: %w", err)
-	}
-	defer session.Close()
-
-	runErr := make(chan error, 1)
-	go func() { runErr <- session.Run("echo ok") }()
-
-	select {
-	case err := <-runErr:
-		if err != nil {
-			markMachineInactive(ctx, db, payload.MachineID)
-			return fmt.Errorf("SSH command failed: %w", err)
-		}
-	case <-ctx.Done():
-		session.Close()
-		markMachineInactive(ctx, db, payload.MachineID)
-		return ctx.Err()
+		return err
 	}
 
 	now := time.Now()
@@ -126,7 +139,7 @@ func handleMachineVerify(ctx context.Context, db *bun.DB, payload MachineVerifyP
 		Set("is_active = ?", true).
 		Set("last_used_at = ?", now).
 		Set("updated_at = ?", now).
-		Where("id = ?::uuid", payload.MachineID).
+		Where("id = ?", machineUUID).
 		Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to update ssh key status: %w", err)
@@ -137,11 +150,16 @@ func handleMachineVerify(ctx context.Context, db *bun.DB, payload MachineVerifyP
 }
 
 func markMachineInactive(ctx context.Context, db *bun.DB, machineID string) {
+	id, parseErr := uuid.Parse(machineID)
+	if parseErr != nil {
+		log.Printf("[machine-verify] failed to mark inactive: invalid machine_id=%s err=%v", machineID, parseErr)
+		return
+	}
 	_, err := db.NewUpdate().
 		Model((*shared_types.SSHKey)(nil)).
 		Set("is_active = ?", false).
 		Set("updated_at = ?", time.Now()).
-		Where("id = ?::uuid", machineID).
+		Where("id = ?", id).
 		Exec(ctx)
 	if err != nil {
 		log.Printf("[machine-verify] failed to mark inactive: machine_id=%s err=%v", machineID, err)

--- a/api/internal/queue/noop_handlers_test.go
+++ b/api/internal/queue/noop_handlers_test.go
@@ -1,0 +1,19 @@
+package queue
+
+import (
+	"context"
+	"testing"
+
+	trail_types "github.com/nixopus/nixopus/api/internal/features/machine/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopTaskHandlers(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, handleProvisionTrailTask(ctx, trail_types.ProvisionPayload{}))
+	require.NoError(t, handleRegisterCustomDomainTask(ctx, CustomDomainPayload{}))
+	require.NoError(t, handleRemoveCustomDomainTask(ctx, RemoveCustomDomainPayload{}))
+	require.NoError(t, handleResourceUpdateTask(ctx, ResourceUpdatePayload{}))
+	require.NoError(t, handleVMDeleteTask(ctx, VMDeletePayload{}))
+	require.NoError(t, handleMachineLifecycleTask(ctx, MachineLifecyclePayload{}))
+}

--- a/api/internal/queue/reply_mux_extra_test.go
+++ b/api/internal/queue/reply_mux_extra_test.go
@@ -1,0 +1,34 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplyMultiplexer_Dispatch_dropsWhenBufferFull(t *testing.T) {
+	m := NewReplyMultiplexer()
+	ch := m.RegisterWaiter("rid")
+	m.Dispatch("rid", "first")
+	m.Dispatch("rid", "second")
+	select {
+	case v := <-ch:
+		assert.Equal(t, "first", v)
+	case <-time.After(time.Second):
+		t.Fatal("expected first message")
+	}
+	m.RemoveWaiter("rid")
+}
+
+func TestReplyMultiplexerWithPrefix_Start_skipsWithoutRedis(t *testing.T) {
+	prev := redisClient
+	redisClient = nil
+	t.Cleanup(func() { redisClient = prev })
+
+	m := NewReplyMultiplexerWithPrefix("custom:")
+	pctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m.Start(pctx)
+}

--- a/api/internal/queue/reply_mux_test.go
+++ b/api/internal/queue/reply_mux_test.go
@@ -1,16 +1,14 @@
-package tests
+package queue
 
 import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/nixopus/nixopus/api/internal/queue"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestReplyMux_RegisterAndRemoveWaiter(t *testing.T) {
-	mux := queue.NewReplyMultiplexer()
+	mux := NewReplyMultiplexer()
 
 	ch := mux.RegisterWaiter("req-1")
 	assert.NotNil(t, ch, "RegisterWaiter should return a non-nil channel")
@@ -23,7 +21,7 @@ func TestReplyMux_RegisterAndRemoveWaiter(t *testing.T) {
 }
 
 func TestReplyMux_DispatchToCorrectWaiter(t *testing.T) {
-	mux := queue.NewReplyMultiplexer()
+	mux := NewReplyMultiplexer()
 
 	ch1 := mux.RegisterWaiter("req-1")
 	ch2 := mux.RegisterWaiter("req-2")
@@ -48,14 +46,14 @@ func TestReplyMux_DispatchToCorrectWaiter(t *testing.T) {
 }
 
 func TestReplyMux_DispatchUnknownRequestIgnored(t *testing.T) {
-	mux := queue.NewReplyMultiplexer()
+	mux := NewReplyMultiplexer()
 	assert.NotPanics(t, func() {
 		mux.Dispatch("nonexistent", `{"data":"ignored"}`)
 	})
 }
 
 func TestReplyMux_ConcurrentWaiters(t *testing.T) {
-	mux := queue.NewReplyMultiplexer()
+	mux := NewReplyMultiplexer()
 	const n = 20
 
 	ids := make([]string, n)
@@ -90,7 +88,7 @@ func TestReplyMux_ConcurrentWaiters(t *testing.T) {
 }
 
 func TestReplyMux_ChannelBuffered(t *testing.T) {
-	mux := queue.NewReplyMultiplexer()
+	mux := NewReplyMultiplexer()
 	ch := mux.RegisterWaiter("req-buf")
 
 	mux.Dispatch("req-buf", `{"buffered":true}`)
@@ -114,7 +112,7 @@ func TestReplyMux_ExtractRequestID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := queue.ExtractRequestIDFromChannel(tt.channel)
+		got := ExtractRequestIDFromChannel(tt.channel)
 		assert.Equal(t, tt.want, got, "ExtractRequestIDFromChannel(%q)", tt.channel)
 	}
 }

--- a/api/internal/queue/resource_update.go
+++ b/api/internal/queue/resource_update.go
@@ -29,6 +29,10 @@ var (
 	TaskResourceUpdate       *taskq.Task
 )
 
+func handleResourceUpdateTask(ctx context.Context, payload ResourceUpdatePayload) error {
+	return nil
+}
+
 func SetupResourceUpdateQueue() {
 	onceResourceUpdateQueues.Do(func() {
 		ResourceUpdateQueue = registerProducerQueue(&taskq.QueueOptions{
@@ -38,9 +42,7 @@ func SetupResourceUpdateQueue() {
 		TaskResourceUpdate = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskResourceUpdate,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload ResourceUpdatePayload) error {
-				return nil
-			},
+			Handler:    handleResourceUpdateTask,
 		})
 	})
 }

--- a/api/internal/queue/tests/machine_lifecycle_test.go
+++ b/api/internal/queue/tests/machine_lifecycle_test.go
@@ -1,10 +1,8 @@
 package tests
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/nixopus/nixopus/api/internal/queue"
 	"github.com/stretchr/testify/assert"
@@ -69,18 +67,4 @@ func TestMachineLifecycleResult_ErrorJSON(t *testing.T) {
 	assert.False(t, decoded.Success)
 	assert.Equal(t, "already paused", decoded.Error)
 	assert.Nil(t, decoded.Data)
-}
-
-func TestExecuteMachineLifecycle_TimeoutWithoutRedis(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	payload := queue.MachineLifecyclePayload{
-		InstanceName: "trail-abc",
-		Action:       "status",
-		ServerID:     "srv-1",
-	}
-
-	_, err := queue.ExecuteMachineLifecycle(ctx, payload)
-	assert.Error(t, err, "should error when queue infrastructure is not initialized")
 }

--- a/api/internal/queue/trail.go
+++ b/api/internal/queue/trail.go
@@ -20,6 +20,10 @@ const (
 	taskProvision  = "task_provision_trail"
 )
 
+func handleProvisionTrailTask(ctx context.Context, payload trail_types.ProvisionPayload) error {
+	return nil
+}
+
 func SetupProvisionQueue() {
 	onceTrailQueues.Do(func() {
 		ProvisionQueue = registerProducerQueue(&taskq.QueueOptions{
@@ -29,9 +33,7 @@ func SetupProvisionQueue() {
 		TaskProvision = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskProvision,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload trail_types.ProvisionPayload) error {
-				return nil
-			},
+			Handler:    handleProvisionTrailTask,
 		})
 	})
 }

--- a/api/internal/queue/verify_handler_test.go
+++ b/api/internal/queue/verify_handler_test.go
@@ -1,0 +1,193 @@
+package queue
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"database/sql"
+	"encoding/pem"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	cryptossh "golang.org/x/crypto/ssh"
+	_ "modernc.org/sqlite"
+)
+
+func testVerifySQLite(t *testing.T) *bun.DB {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", "file:memverify?mode=memory&cache=shared&_pragma=foreign_keys(1)")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`CREATE TABLE ssh_keys (
+			id TEXT PRIMARY KEY,
+			organization_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT,
+			host TEXT,
+			proxy_host TEXT,
+			user TEXT,
+			port INTEGER,
+			public_key TEXT,
+			private_key_encrypted TEXT,
+			password_encrypted TEXT,
+			key_type TEXT,
+			key_size INTEGER,
+			fingerprint TEXT,
+			auth_method TEXT NOT NULL DEFAULT 'key',
+			is_active INTEGER NOT NULL DEFAULT 1,
+			is_default INTEGER NOT NULL DEFAULT 0,
+			last_used_at DATETIME,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			deleted_at DATETIME
+		)`,
+	} {
+		_, err = db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func rsaPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	blk := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	return string(pem.EncodeToMemory(blk))
+}
+
+func Test_handleMachineVerify(t *testing.T) {
+	prevProbe := machineVerifySSHProbe
+	t.Cleanup(func() { machineVerifySSHProbe = prevProbe })
+
+	ctx := context.Background()
+
+	t.Run("invalid machine_id", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		err := handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: "x"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid machine_id")
+	})
+
+	t.Run("ssh key not found", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		err := handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: uuid.New().String()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load ssh key")
+	})
+
+	t.Run("missing private key or host", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		id := uuid.New()
+		_, err := db.ExecContext(ctx, `INSERT INTO ssh_keys (id, organization_id, name, host, private_key_encrypted, is_active, created_at, updated_at) VALUES (?, ?, 'n', NULL, NULL, 1, datetime('now'), datetime('now'))`,
+			id.String(), uuid.New().String())
+		require.NoError(t, err)
+		err = handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: id.String()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing private key or host")
+	})
+
+	t.Run("invalid private key pem", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		id := uuid.New()
+		host := "127.0.0.1"
+		bad := "not-a-key"
+		_, err := db.ExecContext(ctx, `INSERT INTO ssh_keys (id, organization_id, name, host, private_key_encrypted, is_active, created_at, updated_at) VALUES (?, ?, 'n', ?, ?, 1, datetime('now'), datetime('now'))`,
+			id.String(), uuid.New().String(), host, bad)
+		require.NoError(t, err)
+		err = handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: id.String()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse private key")
+	})
+
+	t.Run("ssh probe failure", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		id := uuid.New()
+		host := "127.0.0.1"
+		pemData := rsaPEM(t)
+		_, err := db.ExecContext(ctx, `INSERT INTO ssh_keys (id, organization_id, name, host, private_key_encrypted, is_active, created_at, updated_at) VALUES (?, ?, 'n', ?, ?, 1, datetime('now'), datetime('now'))`,
+			id.String(), uuid.New().String(), host, pemData)
+		require.NoError(t, err)
+		machineVerifySSHProbe = func(context.Context, string, *cryptossh.ClientConfig) error {
+			return errors.New("SSH dial failed: refused")
+		}
+		err = handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: id.String()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SSH dial failed")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		id := uuid.New()
+		host := "127.0.0.1"
+		pemData := rsaPEM(t)
+		_, err := db.ExecContext(ctx, `INSERT INTO ssh_keys (id, organization_id, name, host, private_key_encrypted, is_active, created_at, updated_at) VALUES (?, ?, 'n', ?, ?, 1, datetime('now'), datetime('now'))`,
+			id.String(), uuid.New().String(), host, pemData)
+		require.NoError(t, err)
+		machineVerifySSHProbe = func(context.Context, string, *cryptossh.ClientConfig) error { return nil }
+		err = handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: id.String()})
+		require.NoError(t, err)
+	})
+
+	t.Run("context cancelled during probe", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		id := uuid.New()
+		host := "127.0.0.1"
+		pemData := rsaPEM(t)
+		_, err := db.ExecContext(ctx, `INSERT INTO ssh_keys (id, organization_id, name, host, private_key_encrypted, is_active, created_at, updated_at) VALUES (?, ?, 'n', ?, ?, 1, datetime('now'), datetime('now'))`,
+			id.String(), uuid.New().String(), host, pemData)
+		require.NoError(t, err)
+		pctx, cancel := context.WithCancel(ctx)
+		machineVerifySSHProbe = func(c context.Context, _ string, _ *cryptossh.ClientConfig) error {
+			<-c.Done()
+			return c.Err()
+		}
+		cancel()
+		err = handleMachineVerify(pctx, db, MachineVerifyPayload{MachineID: id.String()})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func Test_markMachineInactive_invalidID(t *testing.T) {
+	db := testVerifySQLite(t)
+	markMachineInactive(context.Background(), db, "not-a-uuid")
+}
+
+func Test_markMachineInactive_execError(t *testing.T) {
+	db := testVerifySQLite(t)
+	_ = db.Close()
+	markMachineInactive(context.Background(), db, uuid.New().String())
+}
+
+func Test_handleMachineVerify_updateFails(t *testing.T) {
+	prev := machineVerifySSHProbe
+	machineVerifySSHProbe = func(context.Context, string, *cryptossh.ClientConfig) error { return nil }
+	t.Cleanup(func() { machineVerifySSHProbe = prev })
+
+	ctx := context.Background()
+	db := testVerifySQLite(t)
+	_, err := db.ExecContext(ctx, `CREATE TRIGGER trg_block_active BEFORE UPDATE ON ssh_keys FOR EACH ROW WHEN NEW.is_active = 1 BEGIN SELECT RAISE(ABORT, 'blocked'); END`)
+	require.NoError(t, err)
+
+	id := uuid.New()
+	host := "127.0.0.1"
+	pemData := rsaPEM(t)
+	_, err = db.ExecContext(ctx, `INSERT INTO ssh_keys (id, organization_id, name, host, private_key_encrypted, is_active, created_at, updated_at) VALUES (?, ?, 'n', ?, ?, 1, datetime('now'), datetime('now'))`,
+		id.String(), uuid.New().String(), host, pemData)
+	require.NoError(t, err)
+
+	err = handleMachineVerify(ctx, db, MachineVerifyPayload{MachineID: id.String()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update ssh key status")
+}

--- a/api/internal/queue/vm_delete.go
+++ b/api/internal/queue/vm_delete.go
@@ -26,6 +26,10 @@ type VMDeletePayload struct {
 	ServerID string `json:"server_id,omitempty"`
 }
 
+func handleVMDeleteTask(ctx context.Context, payload VMDeletePayload) error {
+	return nil
+}
+
 func SetupVMDeleteQueue() {
 	onceVMDeleteQueue.Do(func() {
 		VMDeleteQueue = registerProducerQueue(&taskq.QueueOptions{
@@ -35,9 +39,7 @@ func SetupVMDeleteQueue() {
 		TaskVMDelete = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       taskVMDelete,
 			RetryLimit: 1,
-			Handler: func(ctx context.Context, payload VMDeletePayload) error {
-				return nil
-			},
+			Handler:    handleVMDeleteTask,
 		})
 	})
 }

--- a/api/internal/queue/z_queue_integration_test.go
+++ b/api/internal/queue/z_queue_integration_test.go
@@ -1,0 +1,206 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	trail_types "github.com/nixopus/nixopus/api/internal/features/machine/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/taskq/v3"
+)
+
+func TestZ_QueueIntegration_miniredis(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cleanup_nil_redis_client", func(t *testing.T) {
+		require.NoError(t, cleanupDeadConsumers(ctx))
+	})
+
+	t.Run("not_initialized_enqueue_errors", func(t *testing.T) {
+		require.Error(t, EnqueueProvisionTask(ctx, trail_types.ProvisionPayload{}))
+		require.Error(t, EnqueueRegisterCustomDomain(ctx, CustomDomainPayload{}))
+		require.Error(t, EnqueueRemoveCustomDomain(ctx, RemoveCustomDomainPayload{}))
+		require.Error(t, EnqueueResourceUpdateTask(ctx, ResourceUpdatePayload{}))
+		require.Error(t, EnqueueVMDeleteTask(ctx, VMDeletePayload{}))
+		require.Error(t, EnqueueMachineVerifyTask(ctx, MachineVerifyPayload{}))
+	})
+
+	mr := miniredis.RunT(t)
+	opt, err := redis.ParseURL("redis://" + mr.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	Init(rdb)
+	t.Cleanup(func() {
+		_ = Close()
+	})
+
+	require.Same(t, rdb, RedisClient())
+
+	t.Run("register_queue", func(t *testing.T) {
+		_ = RegisterQueue(&taskq.QueueOptions{
+			Name:         "integration-q",
+			MinNumWorker: 0,
+			MaxNumWorker: 1,
+		})
+		_ = RegisterQueue(&taskq.QueueOptions{
+			Name:         "integration-q2",
+			Redis:        rdb,
+			MinNumWorker: 0,
+			MaxNumWorker: 1,
+		})
+	})
+
+	t.Run("dead_consumer_cleanup_threshold", func(t *testing.T) {
+		prev := deadConsumerIdleThreshold
+		deadConsumerIdleThreshold = -time.Second
+		t.Cleanup(func() { deadConsumerIdleThreshold = prev })
+		require.NoError(t, cleanupDeadConsumers(ctx))
+	})
+
+	require.NoError(t, cleanupDeadConsumers(ctx))
+
+	t.Run("cleanup_removes_idle_consumer", func(t *testing.T) {
+		prev := deadConsumerIdleThreshold
+		deadConsumerIdleThreshold = 15 * time.Minute
+		t.Cleanup(func() { deadConsumerIdleThreshold = prev })
+		qname := "idle-consumer-q"
+		_ = RegisterQueue(&taskq.QueueOptions{Name: qname, MinNumWorker: 0, MaxNumWorker: 1})
+		stream := fmt.Sprintf("taskq:{%s}", qname)
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, stream, "taskq", "0").Err())
+		msgID, err := rdb.XAdd(ctx, &redis.XAddArgs{Stream: stream, Values: map[string]interface{}{"t": "1"}}).Result()
+		require.NoError(t, err)
+		xres, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    "taskq",
+			Consumer: "idle-c",
+			Streams:  []string{stream, ">"},
+			Count:    1,
+			Block:    time.Millisecond,
+		}).Result()
+		require.NoError(t, err)
+		require.NotEmpty(t, xres)
+		require.NoError(t, rdb.XAck(ctx, stream, "taskq", msgID).Err())
+		mr.FastForward(20 * time.Minute)
+		require.NoError(t, cleanupDeadConsumers(ctx))
+	})
+
+	t.Run("cleanup_skips_consumer_with_pending", func(t *testing.T) {
+		qname := "pending-consumer-q"
+		_ = RegisterQueue(&taskq.QueueOptions{Name: qname, MinNumWorker: 0, MaxNumWorker: 1})
+		stream := fmt.Sprintf("taskq:{%s}", qname)
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, stream, "taskq", "0").Err())
+		_, err := rdb.XAdd(ctx, &redis.XAddArgs{Stream: stream, Values: map[string]interface{}{"task": "1"}}).Result()
+		require.NoError(t, err)
+		_, err = rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    "taskq",
+			Consumer: "c1",
+			Streams:  []string{stream, ">"},
+			Count:    1,
+			Block:    time.Millisecond,
+		}).Result()
+		require.NoError(t, err)
+		require.NoError(t, cleanupDeadConsumers(ctx))
+	})
+
+	require.NoError(t, StartConsumers(ctx))
+	assert.True(t, IsConsumersStarted())
+
+	t.Run("setup_enqueue_chains", func(t *testing.T) {
+		SetupProvisionQueue()
+		require.NoError(t, EnqueueProvisionTask(ctx, trail_types.ProvisionPayload{}))
+		require.NoError(t, EnqueueProvisionTask(ctx, trail_types.ProvisionPayload{ServerID: "srv1"}))
+
+		SetupCustomDomainQueue()
+		require.NoError(t, EnqueueRegisterCustomDomain(ctx, CustomDomainPayload{DomainID: "d"}))
+		require.NoError(t, EnqueueRegisterCustomDomain(ctx, CustomDomainPayload{DomainID: "d", ServerID: "s"}))
+		require.NoError(t, EnqueueRemoveCustomDomain(ctx, RemoveCustomDomainPayload{DomainID: "d"}))
+		require.NoError(t, EnqueueRemoveCustomDomain(ctx, RemoveCustomDomainPayload{DomainID: "d", ServerID: "s"}))
+
+		SetupResourceUpdateQueue()
+		require.NoError(t, EnqueueResourceUpdateTask(ctx, ResourceUpdatePayload{VMName: "v"}))
+		require.NoError(t, EnqueueResourceUpdateTask(ctx, ResourceUpdatePayload{VMName: "v", ServerID: "s"}))
+
+		SetupVMDeleteQueue()
+		require.NoError(t, EnqueueVMDeleteTask(ctx, VMDeletePayload{VMName: "v"}))
+		require.NoError(t, EnqueueVMDeleteTask(ctx, VMDeletePayload{VMName: "v", ServerID: "s"}))
+	})
+
+	t.Run("machine_verify_enqueue", func(t *testing.T) {
+		db := testVerifySQLite(t)
+		SetupMachineVerifyQueue(ctx, db)
+		require.Error(t, machineVerifyTaskHandler(ctx, MachineVerifyPayload{MachineID: "bad"}))
+		require.NoError(t, EnqueueMachineVerifyTask(ctx, MachineVerifyPayload{
+			MachineID: "00000000-0000-0000-0000-000000000001",
+			OrgID:     "00000000-0000-0000-0000-000000000002",
+		}))
+		require.NoError(t, EnqueueMachineVerifyTask(ctx, MachineVerifyPayload{
+			MachineID: "00000000-0000-0000-0000-000000000001",
+			OrgID:     "00000000-0000-0000-0000-000000000002",
+			ServerID:  "edge",
+		}))
+	})
+
+	t.Run("machine_backup_enqueue", func(t *testing.T) {
+		db := testBackupSQLite(t)
+		SetupMachineBackupQueue(ctx, db)
+		require.NoError(t, machineBackupTaskHandler(ctx, MachineBackupPayload{
+			ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+		}))
+		_, err := EnqueueMachineBackup(ctx, MachineBackupPayload{
+			MachineName: "m",
+			UserID:      "00000000-0000-0000-0000-000000000003",
+			OrgID:       "00000000-0000-0000-0000-000000000004",
+			ServerID:    "00000000-0000-0000-0000-000000000005",
+			BackupRowID: "00000000-0000-0000-0000-000000000006",
+			Trigger:     "manual",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("machine_lifecycle_execute", func(t *testing.T) {
+		SetupMachineLifecycleQueue(ctx)
+		require.NotNil(t, replyMux)
+
+		shortCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+		defer cancel()
+		_, err := ExecuteMachineLifecycle(shortCtx, MachineLifecyclePayload{
+			InstanceName: "vm",
+			Action:       "status",
+		})
+		require.Error(t, err)
+
+		rid := "11111111-1111-1111-1111-111111111111"
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			replyMux.Dispatch(rid, `{"request_id":"`+rid+`","success":true,"action":"status"}`)
+		}()
+		res, err := ExecuteMachineLifecycle(ctx, MachineLifecyclePayload{
+			RequestID:    rid,
+			InstanceName: "vm",
+			Action:       "status",
+		})
+		require.NoError(t, err)
+		require.True(t, res.Success)
+
+		rid2 := "22222222-2222-2222-2222-222222222222"
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			replyMux.Dispatch(rid2, `not-json`)
+		}()
+		_, err = ExecuteMachineLifecycle(ctx, MachineLifecyclePayload{
+			RequestID:    rid2,
+			InstanceName: "vm2",
+			Action:       "pause",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	time.Sleep(600 * time.Millisecond)
+}

--- a/api/internal/realtime/dashboard_monitor.go
+++ b/api/internal/realtime/dashboard_monitor.go
@@ -63,6 +63,11 @@ func (s *SocketServer) handleDashboardMonitor(conn *websocket.Conn, msg types.Pa
 	}
 
 	if !exists {
+		if s.deployController == nil {
+			s.dashboardMutex.Unlock()
+			s.sendError(conn, "Failed to create dashboard monitor")
+			return
+		}
 		newMonitor, err := dashboard.NewDashboardMonitor(conn, s.getConnWriteMu(conn), logger.NewLogger(), organizationID, serverID, s.deployController.Service())
 		if err != nil {
 			s.dashboardMutex.Unlock()

--- a/api/internal/realtime/dashboard_monitor_test.go
+++ b/api/internal/realtime/dashboard_monitor_test.go
@@ -1,0 +1,70 @@
+package realtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestHandleStopDashboardMonitor_noMonitor(t *testing.T) {
+	s := newTestSocketServer()
+	_, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleStopDashboardMonitor(conn)
+}
+
+func TestSendResponse_marshalable(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.sendResponse(conn, types.Payload{Action: "ok", Data: map[string]string{"a": "b"}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	mt, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mt != websocket.TextMessage {
+		t.Fatalf("message type %d", mt)
+	}
+	if string(b) == "" {
+		t.Fatal("empty body")
+	}
+}
+
+func TestSendResponse_marshalError(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.sendResponse(conn, types.Payload{Data: map[string]interface{}{"c": make(chan int)}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestHandleDashboardMonitor_nilDeployController(t *testing.T) {
+	s := newTestSocketServer()
+	s.deployController = nil
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleDashboardMonitor(conn, types.Payload{
+		Action: types.DASHBOARD_MONITOR,
+		Data: map[string]interface{}{
+			"organization_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		},
+	})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}

--- a/api/internal/realtime/helpers_test.go
+++ b/api/internal/realtime/helpers_test.go
@@ -1,0 +1,61 @@
+package realtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/nixopus/nixopus/api/internal/features/dashboard"
+	deployrt "github.com/nixopus/nixopus/api/internal/features/deploy/realtime"
+	"github.com/nixopus/nixopus/api/internal/features/terminal"
+)
+
+func newTestSocketServer() *SocketServer {
+	return &SocketServer{
+		conns:               &sync.Map{},
+		orgIDs:              &sync.Map{},
+		shutdown:            make(chan struct{}),
+		ctx:                 context.Background(),
+		topics:              make(map[string]map[*websocket.Conn]bool),
+		terminals:           make(map[*websocket.Conn]map[string]*terminal.Terminal),
+		dashboardMonitors:   make(map[*websocket.Conn]*dashboard.DashboardMonitor),
+		applicationMonitors: make(map[*websocket.Conn]*deployrt.ApplicationMonitor),
+	}
+}
+
+// dialWebSocketPair opens one WebSocket from client to a test server; returns
+// the client end, the upgraded server *websocket.Conn, and a cleanup func.
+func dialWebSocketPair(t *testing.T) (client, server *websocket.Conn, cleanup func()) {
+	t.Helper()
+	srvCh := make(chan *websocket.Conn, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade: %v", err)
+			return
+		}
+		srvCh <- c
+	}))
+
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	srv := <-srvCh
+	return client, srv, func() {
+		_ = client.Close()
+		_ = srv.Close()
+		ts.Close()
+	}
+}
+
+func newUser(t *testing.T) uuid.UUID {
+	t.Helper()
+	return uuid.MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+}

--- a/api/internal/realtime/init.go
+++ b/api/internal/realtime/init.go
@@ -63,6 +63,9 @@ type SocketServer struct {
 
 	liveDevHandler   LiveDevNotificationHandler
 	liveDevHandlerMu sync.RWMutex
+
+	// verifyTokenOverride, if set, replaces Better Auth session checks. Used by unit tests.
+	verifyTokenOverride func(string, *http.Request) (*types.User, string, error)
 }
 
 // NewSocketServer initializes and returns a new instance of SocketServer.
@@ -85,11 +88,19 @@ func NewSocketServer(deployController *deploy.DeployController, db *bun.DB, ctx 
 		dashboardMonitors:   make(map[*websocket.Conn]*dashboard.DashboardMonitor),
 		applicationMonitors: make(map[*websocket.Conn]*realtime.ApplicationMonitor),
 	}
-	err := StartListeningAndNotify(&server.postgres_listener, ctx, server)
+	err := startListeningForSocketServer(&server.postgres_listener, ctx, server)
 	if err != nil {
 		return nil, err
 	}
 	return server, nil
+}
+
+// startListeningForSocketServer is StartListeningAndNotify by default; unit tests may replace
+// it to avoid starting a PostgreSQL notification listener.
+var startListeningForSocketServer = startListeningForSocketServerImpl
+
+func startListeningForSocketServerImpl(pl *PostgresListener, ctx context.Context, s *SocketServer) error {
+	return StartListeningAndNotify(pl, ctx, s)
 }
 
 // HandleHTTP handles incoming HTTP connections and upgrades them to WebSocket connections.

--- a/api/internal/realtime/init_test.go
+++ b/api/internal/realtime/init_test.go
@@ -1,0 +1,240 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/jackc/pgx/v5"
+	"github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestNewSocketServer(t *testing.T) {
+	old := startListeningForSocketServer
+	startListeningForSocketServer = func(*PostgresListener, context.Context, *SocketServer) error { return nil }
+	t.Cleanup(func() { startListeningForSocketServer = old })
+	s, err := NewSocketServer(nil, nil, context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil {
+		t.Fatal("nil server")
+	}
+	s.Shutdown()
+}
+
+func TestNewSocketServer_listenError(t *testing.T) {
+	oldL := startListeningForSocketServer
+	oldP := pgxConnect
+	startListeningForSocketServer = startListeningForSocketServerImpl
+	pgxConnect = func(context.Context, string) (*pgx.Conn, error) { return nil, errors.New("unreachable db") }
+	t.Cleanup(func() {
+		startListeningForSocketServer = oldL
+		pgxConnect = oldP
+	})
+	_, err := NewSocketServer(nil, nil, context.Background())
+	if err == nil {
+		t.Fatal("expected error from StartListeningAndNotify")
+	}
+}
+
+func TestGetConnWriteMu_SameInstance(t *testing.T) {
+	s := newTestSocketServer()
+	_, conn, done := dialWebSocketPair(t)
+	defer done()
+	a := s.getConnWriteMu(conn)
+	b := s.getConnWriteMu(conn)
+	if a != b {
+		t.Fatal("expected same mutex for same connection")
+	}
+}
+
+func TestWriteJSONAndSendError(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	if err := s.writeJSON(conn, map[string]int{"a": 1}); err != nil {
+		t.Fatal(err)
+	}
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(b)) != `{"a":1}` {
+		t.Fatalf("got %q", b)
+	}
+	s.sendError(conn, "oops")
+	_, b, err = client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("action: %q", p.Action)
+	}
+	if p.Data != "oops" {
+		t.Fatalf("data: %v", p.Data)
+	}
+}
+
+func TestHandlePing(t *testing.T) {
+	s := newTestSocketServer()
+	_, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.conns.Store(conn, newUser(t).String())
+	s.handlePing(conn)
+}
+
+func TestSetLiveDevHandler(t *testing.T) {
+	s := newTestSocketServer()
+	calls := 0
+	s.SetLiveDevHandler(func(channel, payload string) {
+		calls++
+		if channel != "live_dev_logs" || payload != "p" {
+			t.Errorf("bad args %q %q", channel, payload)
+		}
+	})
+	s.liveDevHandlerMu.RLock()
+	h := s.liveDevHandler
+	s.liveDevHandlerMu.RUnlock()
+	if h == nil {
+		t.Fatal("expected handler")
+	}
+	h("live_dev_logs", "p")
+	if calls != 1 {
+		t.Fatalf("calls=%d", calls)
+	}
+}
+
+func TestHandleDisconnect_clearsTopics(t *testing.T) {
+	s := newTestSocketServer()
+	_, conn, done := dialWebSocketPair(t)
+	s.SubscribeToTopic(MonitorApplicationDeployment, "app-1", conn)
+	done()
+	s.handleDisconnect(conn)
+	s.topicsMu.RLock()
+	_, has := s.topics[string(MonitorApplicationDeployment)+":app-1"]
+	s.topicsMu.RUnlock()
+	if has {
+		t.Fatal("topic should be removed")
+	}
+	_, in := s.conns.Load(conn)
+	if in {
+		t.Fatal("conn should be removed")
+	}
+}
+
+func TestHandleHTTP_TokenRequired(t *testing.T) {
+	s := newTestSocketServer()
+	ts := httptest.NewServer(http.HandlerFunc(s.HandleHTTP))
+	t.Cleanup(ts.Close)
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status: %d", res.StatusCode)
+	}
+}
+
+func TestHandleHTTP_OrganizationQuerySetsHeader(t *testing.T) {
+	s := newTestSocketServer()
+	var orgHeader string
+	s.verifyTokenOverride = func(_ string, r *http.Request) (*types.User, string, error) {
+		if r != nil {
+			orgHeader = r.Header.Get("X-Organization-Id")
+		}
+		return &types.User{ID: newUser(t)}, "from-session", nil
+	}
+	ts := httptest.NewServer(http.HandlerFunc(s.HandleHTTP))
+	t.Cleanup(ts.Close)
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + "?token=tok&organization-id=org-from-query"
+	client, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	if orgHeader != "org-from-query" {
+		t.Fatalf("org header: %q", orgHeader)
+	}
+}
+
+func TestHandleHTTP_UpgradeWithOverride(t *testing.T) {
+	s := newTestSocketServer()
+	s.verifyTokenOverride = func(token string, r *http.Request) (*types.User, string, error) {
+		if token != "ok" {
+			return nil, "", errors.New("bad")
+		}
+		return &types.User{ID: newUser(t)}, "org-1", nil
+	}
+	ts := httptest.NewServer(http.HandlerFunc(s.HandleHTTP))
+	t.Cleanup(ts.Close)
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + "?token=ok"
+	c, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	_ = c.WriteMessage(websocket.TextMessage, []byte(`{"action":"ping"}`))
+}
+
+func TestHandleHTTP_InvalidToken(t *testing.T) {
+	s := newTestSocketServer()
+	s.verifyTokenOverride = func(string, *http.Request) (*types.User, string, error) {
+		return nil, "", errors.New("nope")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(s.HandleHTTP))
+	t.Cleanup(ts.Close)
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + "?token=x"
+	c, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := c.ReadMessage()
+	if err != nil {
+		return
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err == nil && p.Action != "error" {
+		t.Fatalf("expected error action, got %q", p.Action)
+	}
+}
+
+func TestHandleHTTP_BearerStripsPrefix(t *testing.T) {
+	s := newTestSocketServer()
+	s.verifyTokenOverride = func(token string, _ *http.Request) (*types.User, string, error) {
+		if token != "raw" {
+			return nil, "", fmt.Errorf("got %q want raw", token)
+		}
+		return &types.User{ID: newUser(t)}, "", nil
+	}
+	ts := httptest.NewServer(http.HandlerFunc(s.HandleHTTP))
+	t.Cleanup(ts.Close)
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + "?token=Bearer%20raw"
+	c, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+}
+
+func TestShutdown_closesConns(t *testing.T) {
+	s := newTestSocketServer()
+	_, server, done := dialWebSocketPair(t)
+	t.Cleanup(done)
+	s.conns.Store(server, "u")
+	s.Shutdown()
+}

--- a/api/internal/realtime/postgres_listener.go
+++ b/api/internal/realtime/postgres_listener.go
@@ -12,6 +12,9 @@ import (
 	"github.com/nixopus/nixopus/api/internal/types"
 )
 
+// pgxConnect is the pgx connect function (overridden in unit tests to avoid a real database).
+var pgxConnect = pgx.Connect
+
 type PostgresListener struct {
 	config           types.Config
 	notificationChan chan *PostgresNotification
@@ -53,7 +56,7 @@ func getConnString(c types.Config) string {
 //
 // You should call this function once per instance of the PostgresListener struct.
 func (c *PostgresListener) ListenToApplicationChanges(ctx context.Context) (<-chan *PostgresNotification, error) {
-	conn, err := pgx.Connect(ctx, getConnString(c.config))
+	conn, err := pgxConnect(ctx, getConnString(c.config))
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/realtime/postgres_listener_test.go
+++ b/api/internal/realtime/postgres_listener_test.go
@@ -1,0 +1,168 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestListenToApplicationChanges_connectError(t *testing.T) {
+	old := pgxConnect
+	pgxConnect = func(context.Context, string) (*pgx.Conn, error) { return nil, errors.New("no db") }
+	t.Cleanup(func() { pgxConnect = old })
+	l := NewPostgresListener()
+	_, err := l.ListenToApplicationChanges(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStartListeningAndNotify_propagatesError(t *testing.T) {
+	old := pgxConnect
+	pgxConnect = func(context.Context, string) (*pgx.Conn, error) { return nil, errors.New("no db") }
+	t.Cleanup(func() { pgxConnect = old })
+	s := newTestSocketServer()
+	pl := NewPostgresListener()
+	err := StartListeningAndNotify(pl, context.Background(), s)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetConnString(t *testing.T) {
+	c := types.Config{
+		Database: types.DatabaseConfig{
+			Host:     "db.example",
+			Port:     "5432",
+			Username: "u",
+			Password: "p",
+			Name:     "app",
+			SSLMode:  "disable",
+		},
+	}
+	s := getConnString(c)
+	if s != "host=db.example port=5432 user=u password=p dbname=app sslmode=disable" {
+		t.Fatalf("unexpected: %q", s)
+	}
+}
+
+func TestNewPostgresListener(t *testing.T) {
+	l := NewPostgresListener()
+	if l == nil {
+		t.Fatal("nil listener")
+	}
+	if l.notificationChan == nil {
+		t.Fatal("expected channel")
+	}
+}
+
+func TestHandleNotifications_applicationChanges(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "app-99", conn)
+	_, _, _ = client.ReadMessage()
+	payload := map[string]interface{}{
+		"table":          "applications",
+		"action":         "update",
+		"application_id": "app-99",
+		"data":           map[string]interface{}{},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch := make(chan *PostgresNotification, 2)
+	go s.handleNotifications(ch)
+	ch <- &PostgresNotification{Channel: "application_changes", Payload: string(b)}
+	close(ch)
+	time.Sleep(30 * time.Millisecond)
+	_ = client.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, msg, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out types.Payload
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "message" {
+		t.Fatalf("action %q", out.Action)
+	}
+}
+
+func TestHandleNotifications_applicationLogs_deploymentTopic(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "dep-1", conn)
+	_, _, _ = client.ReadMessage()
+	payload := map[string]interface{}{
+		"table":          "application_logs",
+		"action":         "insert",
+		"application_id": "app-x",
+		"data": map[string]interface{}{
+			"application_deployment_id": "dep-1",
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch := make(chan *PostgresNotification, 1)
+	go s.handleNotifications(ch)
+	ch <- &PostgresNotification{Channel: "application_changes", Payload: string(b)}
+	close(ch)
+	time.Sleep(30 * time.Millisecond)
+	_ = client.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, msg, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out types.Payload
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "message" {
+		t.Fatalf("action %q", out.Action)
+	}
+}
+
+func TestHandleNotifications_invalidJSON_skips(t *testing.T) {
+	s := newTestSocketServer()
+	_, _, done := dialWebSocketPair(t)
+	t.Cleanup(done)
+	ch := make(chan *PostgresNotification, 1)
+	go s.handleNotifications(ch)
+	ch <- &PostgresNotification{Channel: "application_changes", Payload: "not-json"}
+	close(ch)
+}
+
+func TestHandleNotifications_liveDev(t *testing.T) {
+	s := newTestSocketServer()
+	var gotCh, gotPay string
+	s.SetLiveDevHandler(func(ch, pay string) {
+		gotCh, gotPay = ch, pay
+	})
+	ch := make(chan *PostgresNotification, 1)
+	go s.handleNotifications(ch)
+	ch <- &PostgresNotification{Channel: "live_dev_logs", Payload: "hello"}
+	close(ch)
+	time.Sleep(20 * time.Millisecond)
+	if gotCh != "live_dev_logs" || gotPay != "hello" {
+		t.Fatalf("got %q %q", gotCh, gotPay)
+	}
+}
+
+func TestHandleNotifications_liveDev_nilHandler(t *testing.T) {
+	s := newTestSocketServer()
+	ch := make(chan *PostgresNotification, 1)
+	go s.handleNotifications(ch)
+	ch <- &PostgresNotification{Channel: "live_dev_status", Payload: "x"}
+	close(ch)
+}

--- a/api/internal/realtime/read_loop_test.go
+++ b/api/internal/realtime/read_loop_test.go
@@ -1,0 +1,110 @@
+package realtime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestReadLoop_ping(t *testing.T) {
+	s := newTestSocketServer()
+	client, server, done := dialWebSocketPair(t)
+	defer done()
+	go s.readLoop(server)
+	_ = client.WriteMessage(websocket.TextMessage, []byte(`{"action":"ping"}`))
+	client.Close()
+}
+
+func TestReadLoop_invalidJSON(t *testing.T) {
+	s := newTestSocketServer()
+	client, server, done := dialWebSocketPair(t)
+	defer done()
+	go s.readLoop(server)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_ = client.WriteMessage(websocket.TextMessage, []byte(`not json`))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("got %q", p.Action)
+	}
+	_ = client.Close()
+}
+
+func TestReadLoop_unknownAction(t *testing.T) {
+	s := newTestSocketServer()
+	client, server, done := dialWebSocketPair(t)
+	defer done()
+	go s.readLoop(server)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_ = client.WriteMessage(websocket.TextMessage, []byte(`{"action":"nope"}`))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("got %q", p.Action)
+	}
+}
+
+func TestReadLoop_subscribe(t *testing.T) {
+	s := newTestSocketServer()
+	client, server, done := dialWebSocketPair(t)
+	defer done()
+	go s.readLoop(server)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msg, _ := json.Marshal(types.Payload{
+		Action: types.SUBSCRIBE,
+		Topic:  string(MonitorApplicationDeployment),
+		Data:   map[string]interface{}{"resource_id": "sub-1"},
+	})
+	_ = client.WriteMessage(websocket.TextMessage, msg)
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "subscribed" {
+		t.Fatalf("action %q", p.Action)
+	}
+}
+
+func TestReadLoop_stopDashboardMonitor(t *testing.T) {
+	s := newTestSocketServer()
+	client, server, done := dialWebSocketPair(t)
+	defer done()
+	go s.readLoop(server)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msg, _ := json.Marshal(types.Payload{Action: types.STOP_DASHBOARD_MONITOR})
+	_ = client.WriteMessage(websocket.TextMessage, msg)
+}
+
+func TestReadLoop_monitorApplication_noop(t *testing.T) {
+	s := newTestSocketServer()
+	client, server, done := dialWebSocketPair(t)
+	defer done()
+	go s.readLoop(server)
+	msg, _ := json.Marshal(types.Payload{Action: types.MONITOR_APPLICATION})
+	_ = client.WriteMessage(websocket.TextMessage, msg)
+	_ = client.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	_, _, err := client.ReadMessage()
+	if err == nil {
+		t.Fatal("expected no reply from unimplemented monitor action")
+	}
+	_ = client.Close()
+}

--- a/api/internal/realtime/terminal_handler_test.go
+++ b/api/internal/realtime/terminal_handler_test.go
@@ -1,0 +1,136 @@
+package realtime
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestHandleTerminal_invalidData(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleTerminal(conn, types.Payload{Data: "x"})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestHandleTerminal_missingTerminalId(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleTerminal(conn, types.Payload{Data: map[string]interface{}{"value": "x"}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestHandleTerminal_invalidInput(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleTerminal(conn, types.Payload{Data: map[string]interface{}{"terminalId": "t1", "value": 1}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestCreateTerminal_noOrg(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleTerminal(conn, types.Payload{Data: map[string]interface{}{"terminalId": "t1", "value": "hi"}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestCreateTerminal_invalidOrgUUID(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.orgIDs.Store(conn, "not-a-uuid")
+	s.handleTerminal(conn, types.Payload{Data: map[string]interface{}{"terminalId": "t1", "value": "hi"}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestCreateTerminal_validOrg_terminaFailsWithoutSSH(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.orgIDs.Store(conn, uuid.MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8").String())
+	s.handleTerminal(conn, types.Payload{Data: map[string]interface{}{"terminalId": "t1", "value": "x"}})
+	_ = client.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestHandleTerminalResize_errors(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleTerminalResize(conn, types.Payload{Data: "nope"})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func TestHandleTerminalResize_notFound(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleTerminalResize(conn, types.Payload{Data: map[string]interface{}{"terminalId": "n", "rows": float64(1), "cols": float64(1)}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAction(b, "error") {
+		t.Fatalf("expected error: %s", b)
+	}
+}
+
+func containsAction(b []byte, want string) bool {
+	return strings.Contains(string(b), `"action":"`+want+`"`)
+}

--- a/api/internal/realtime/topic_manager_test.go
+++ b/api/internal/realtime/topic_manager_test.go
@@ -1,0 +1,254 @@
+package realtime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nixopus/nixopus/api/internal/types"
+)
+
+func TestSubscribeToTopic_withResourceID(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "res-1", conn)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "subscribed" {
+		t.Fatalf("action %q", p.Action)
+	}
+	if p.Topic != "monitor_application_deployment:res-1" {
+		t.Fatalf("topic %q", p.Topic)
+	}
+}
+
+func TestSubscribeToTopic_emptyResourceID(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.SubscribeToTopic(MonitorHealthCheck, "", conn)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Topic != "monitor_health_check" {
+		t.Fatalf("topic %q", p.Topic)
+	}
+}
+
+func TestUnsubscribeFromTopic(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "r1", conn)
+	_, _, _ = client.ReadMessage()
+	s.UnsubscribeFromTopic(MonitorApplicationDeployment, "r1", conn)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "unsubscribed" {
+		t.Fatalf("action %q", p.Action)
+	}
+}
+
+func TestUnsubscribeFromTopic_notSubscribed(t *testing.T) {
+	s := newTestSocketServer()
+	_, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.UnsubscribeFromTopic(MonitorApplicationDeployment, "nope", conn)
+}
+
+func TestBroadcastToTopic(t *testing.T) {
+	s := newTestSocketServer()
+	c1, s1, d1 := dialWebSocketPair(t)
+	defer d1()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "b1", s1)
+	_, _, _ = c1.ReadMessage()
+	s.BroadcastToTopic(MonitorApplicationDeployment, "b1", map[string]string{"k": "v"})
+	_ = c1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := c1.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "message" {
+		t.Fatalf("action %q", p.Action)
+	}
+}
+
+func TestHandleSubscribe_valid(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleSubscribe(conn, types.Payload{
+		Action: types.SUBSCRIBE,
+		Topic:  string(MonitorApplicationDeployment),
+		Data:   map[string]interface{}{"resource_id": "r-valid"},
+	})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "subscribed" {
+		t.Fatalf("action %q", p.Action)
+	}
+}
+
+func TestHandleUnsubscribe_valid(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleSubscribe(conn, types.Payload{
+		Action: types.SUBSCRIBE,
+		Topic:  string(MonitorApplicationDeployment),
+		Data:   map[string]interface{}{"resource_id": "r-u"},
+	})
+	_, _, _ = client.ReadMessage()
+	s.handleUnsubscribe(conn, types.Payload{
+		Action: types.UNSUBSCRIBE,
+		Topic:  string(MonitorApplicationDeployment),
+		Data:   map[string]interface{}{"resource_id": "r-u"},
+	})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "unsubscribed" {
+		t.Fatalf("action %q", p.Action)
+	}
+}
+
+func TestHandleSubscribe_errors(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleSubscribe(conn, types.Payload{Action: "subscribe", Topic: string(MonitorApplicationDeployment), Data: map[string]interface{}{}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("expected error, got %q", p.Action)
+	}
+}
+
+func TestHandleSubscribe_invalid(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleSubscribe(conn, types.Payload{Action: "subscribe"})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("expected error, got %q", p.Action)
+	}
+}
+
+func TestHandleUnsubscribe_errors(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleUnsubscribe(conn, types.Payload{Action: "unsubscribe", Topic: string(MonitorApplicationDeployment), Data: map[string]interface{}{}})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("expected error, got %q", p.Action)
+	}
+}
+
+func TestBroadcastToTopic_unsubscribeOnWriteError(t *testing.T) {
+	s := newTestSocketServer()
+	c1, s1, d1 := dialWebSocketPair(t)
+	c2, s2, d2 := dialWebSocketPair(t)
+	defer d1()
+	defer d2()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "w1", s1)
+	_, _, _ = c1.ReadMessage()
+	s.SubscribeToTopic(MonitorApplicationDeployment, "w1", s2)
+	_, _, _ = c2.ReadMessage()
+	_ = s1.Close()
+	s.BroadcastToTopic(MonitorApplicationDeployment, "w1", map[string]int{"n": 1})
+	time.Sleep(50 * time.Millisecond)
+	c2.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, msg, err := c2.ReadMessage()
+	if err != nil {
+		t.Fatalf("c2 read: %v", err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(msg, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "message" {
+		t.Fatalf("action %q", p.Action)
+	}
+}
+
+func TestHandleUnsubscribe_invalid(t *testing.T) {
+	s := newTestSocketServer()
+	client, conn, done := dialWebSocketPair(t)
+	defer done()
+	s.handleUnsubscribe(conn, types.Payload{Action: "unsubscribe"})
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, b, err := client.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p types.Payload
+	if err := json.Unmarshal(b, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Action != "error" {
+		t.Fatalf("expected error, got %q", p.Action)
+	}
+}

--- a/api/internal/realtime/verify_token.go
+++ b/api/internal/realtime/verify_token.go
@@ -24,6 +24,10 @@ import (
 //   - the organization ID if available.
 //   - an error if the token is invalid.
 func (s *SocketServer) verifyToken(tokenString string, originalRequest *http.Request) (*types.User, string, error) {
+	if s.verifyTokenOverride != nil {
+		return s.verifyTokenOverride(tokenString, originalRequest)
+	}
+
 	var req *http.Request
 
 	// Prefer using the original request with actual cookies from the browser

--- a/api/internal/redisclient/redisclient_test.go
+++ b/api/internal/redisclient/redisclient_test.go
@@ -1,0 +1,32 @@
+package redisclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_invalidURL(t *testing.T) {
+	c, err := New("://bad")
+	require.Error(t, err)
+	assert.Nil(t, c)
+
+	c, err = New("")
+	require.Error(t, err)
+	assert.Nil(t, c)
+}
+
+func TestNew_appliesTimeoutsAndPool(t *testing.T) {
+	c, err := New("redis://127.0.0.1:6379/0")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	t.Cleanup(func() { _ = c.Close() })
+
+	opt := c.Options()
+	assert.Equal(t, 10, opt.MinIdleConns)
+	assert.Equal(t, 5*time.Second, opt.DialTimeout)
+	assert.Equal(t, 3*time.Second, opt.ReadTimeout)
+	assert.Equal(t, 3*time.Second, opt.WriteTimeout)
+}

--- a/api/internal/secrets/secrets_test.go
+++ b/api/internal/secrets/secrets_test.go
@@ -1,0 +1,404 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestLoadSecretManagerConfig_minimal(t *testing.T) {
+	t.Setenv("SECRET_MANAGER_ENABLED", "")
+	t.Setenv("SECRET_MANAGER_TYPE", "")
+	cfg := LoadSecretManagerConfig("mysvc")
+	require.NotNil(t, cfg)
+	assert.Equal(t, SecretManagerNone, cfg.Type)
+	assert.False(t, cfg.Enabled)
+	assert.Empty(t, cfg.ServiceName)
+}
+
+func TestLoadSecretManagerConfig_fullWhenEnabled(t *testing.T) {
+	t.Setenv("SECRET_MANAGER_ENABLED", "true")
+	t.Setenv("SECRET_MANAGER_TYPE", "none")
+	t.Setenv("SECRET_MANAGER_PROJECT_ID", "pid")
+	t.Setenv("SECRET_MANAGER_ENVIRONMENT", "staging")
+	t.Setenv("SECRET_MANAGER_SECRET_PATH", "/api")
+	t.Setenv("INFISICAL_URL", "https://custom.example")
+	t.Setenv("INFISICAL_TOKEN", "tok")
+
+	cfg := LoadSecretManagerConfig("api")
+	require.NotNil(t, cfg)
+	assert.Equal(t, SecretManagerNone, cfg.Type)
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "pid", cfg.ProjectID)
+	assert.Equal(t, "staging", cfg.Environment)
+	assert.Equal(t, "/api", cfg.SecretPath)
+	assert.Equal(t, "api", cfg.ServiceName)
+	assert.Equal(t, "https://custom.example", cfg.InfisicalURL)
+	assert.Equal(t, "tok", cfg.InfisicalToken)
+}
+
+func TestLoadSecretManagerConfig_infisicalTypeNotEnabled(t *testing.T) {
+	t.Setenv("SECRET_MANAGER_ENABLED", "false")
+	t.Setenv("SECRET_MANAGER_TYPE", "INFISICAL")
+	t.Setenv("SECRET_MANAGER_PROJECT_ID", "p")
+
+	cfg := LoadSecretManagerConfig("svc")
+	require.NotNil(t, cfg)
+	assert.Equal(t, SecretManagerInfisical, cfg.Type)
+	assert.False(t, cfg.Enabled)
+	assert.Equal(t, "p", cfg.ProjectID)
+	assert.Equal(t, "svc", cfg.ServiceName)
+	assert.Equal(t, "prod", cfg.Environment)
+	assert.Equal(t, "/", cfg.SecretPath)
+	assert.Equal(t, "https://app.infisical.com", cfg.InfisicalURL)
+}
+
+func TestNewSecretManager(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		m, err := NewSecretManager(&SecretManagerConfig{Enabled: false, Type: SecretManagerInfisical})
+		require.NoError(t, err)
+		_, ok := m.(*NoOpSecretManager)
+		assert.True(t, ok)
+	})
+	t.Run("type none", func(t *testing.T) {
+		m, err := NewSecretManager(&SecretManagerConfig{Enabled: true, Type: SecretManagerNone})
+		require.NoError(t, err)
+		_, ok := m.(*NoOpSecretManager)
+		assert.True(t, ok)
+	})
+	t.Run("infisical missing token", func(t *testing.T) {
+		m, err := NewSecretManager(&SecretManagerConfig{
+			Enabled: true, Type: SecretManagerInfisical, InfisicalToken: "",
+		})
+		assert.Nil(t, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "INFISICAL_TOKEN")
+	})
+	t.Run("infisical ok", func(t *testing.T) {
+		m, err := NewSecretManager(&SecretManagerConfig{
+			Enabled: true, Type: SecretManagerInfisical, InfisicalToken: "t",
+		})
+		require.NoError(t, err)
+		_, ok := m.(*InfisicalManager)
+		assert.True(t, ok)
+	})
+	t.Run("unknown type noop", func(t *testing.T) {
+		m, err := NewSecretManager(&SecretManagerConfig{Enabled: true, Type: SecretManagerType("other")})
+		require.NoError(t, err)
+		_, ok := m.(*NoOpSecretManager)
+		assert.True(t, ok)
+	})
+}
+
+func TestNormalizeEnvironmentName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"  DEV ", "dev"},
+		{"development", "dev"},
+		{"staging", "staging"},
+		{"stage", "staging"},
+		{"prod", "prod"},
+		{"production", "prod"},
+		{"custom", "custom"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeEnvironmentName(tc.in))
+		})
+	}
+}
+
+func TestNoOpSecretManager(t *testing.T) {
+	var n NoOpSecretManager
+	ctx := context.Background()
+	_, err := n.GetSecret(ctx, "k")
+	require.Error(t, err)
+
+	m, err := n.GetSecrets(ctx, "p")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Empty(t, m)
+}
+
+func TestNewInfisicalManager(t *testing.T) {
+	cfg := &SecretManagerConfig{InfisicalURL: "https://x.example"}
+	m := NewInfisicalManager(cfg)
+	require.NotNil(t, m)
+	assert.Equal(t, cfg, m.config)
+	assert.Equal(t, "https://x.example", m.baseURL)
+	require.NotNil(t, m.httpClient)
+}
+
+func TestInfisicalManager_GetSecrets_structured(t *testing.T) {
+	payload := InfisicalSecretsResponse{
+		Secrets: []InfisicalSecret{
+			{SecretKey: "APP_FOO", SecretValue: "1"},
+			{SecretKey: "APP_BAR", SecretValue: "2"},
+			{SecretKey: "OTHER", SecretValue: "3"},
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v3/secrets/raw", r.URL.Path)
+		assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		assert.Equal(t, "ws", r.URL.Query().Get("workspaceId"))
+		assert.Equal(t, "prod", r.URL.Query().Get("environment"))
+		assert.Equal(t, "/", r.URL.Query().Get("secretPath"))
+		assert.Equal(t, "true", r.URL.Query().Get("recursive"))
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		ProjectID:      "ws",
+		Environment:    "production",
+		SecretPath:     "",
+	})
+
+	got, err := m.GetSecrets(context.Background(), "APP_")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"APP_FOO": "1", "APP_BAR": "2"}, got)
+
+	all, err := m.GetSecrets(context.Background(), "")
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+func TestInfisicalManager_GetSecrets_flatFallback(t *testing.T) {
+	flat := map[string]string{"K1": "v1", "K2": "v2"}
+	body, err := json.Marshal(flat)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		Environment:    "dev",
+		SecretPath:     "/x",
+	})
+	m.config.ProjectID = ""
+
+	got, err := m.GetSecrets(context.Background(), "K")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"K1": "v1", "K2": "v2"}, got)
+}
+
+func TestInfisicalManager_GetSecrets_flatOnlyJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"alpha":"beta"}`))
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		Environment:    "staging",
+		SecretPath:     "/",
+	})
+
+	got, err := m.GetSecrets(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"alpha": "beta"}, got)
+}
+
+func TestInfisicalManager_GetSecrets_notFoundEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	got, err := m.GetSecrets(context.Background(), "")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestInfisicalManager_GetSecrets_nonOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	_, err := m.GetSecrets(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestInfisicalManager_GetSecrets_requestCreateError(t *testing.T) {
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   "http://a b",
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	_, err := m.GetSecrets(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create request")
+}
+
+func TestInfisicalManager_GetSecrets_doError(t *testing.T) {
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   "http://example.com",
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	m.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("network down")
+	})}
+
+	_, err := m.GetSecrets(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch secrets")
+	assert.Contains(t, err.Error(), "network down")
+}
+
+func TestInfisicalManager_GetSecrets_readBodyError(t *testing.T) {
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   "http://example.com",
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	m.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(iotest.ErrReader(errors.New("read fail"))),
+		}, nil
+	})}
+
+	_, err := m.GetSecrets(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read response body")
+}
+
+func TestInfisicalManager_GetSecrets_invalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	_, err := m.GetSecrets(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse secrets response")
+}
+
+func TestInfisicalManager_GetSecrets_emptyEnvironment(t *testing.T) {
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   "http://example.com",
+		InfisicalToken: "tok",
+		Environment:    "",
+	})
+	_, err := m.GetSecrets(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment is required")
+}
+
+func TestInfisicalManager_GetSecret_propagatesGetSecretsError(t *testing.T) {
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   "http://example.com",
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+	m.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream")
+	})}
+
+	_, err := m.GetSecret(context.Background(), "k")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upstream")
+}
+
+func TestInfisicalManager_GetSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"secrets":[{"secretKey":"X","secretValue":"y"}]}`))
+	}))
+	defer srv.Close()
+
+	m := NewInfisicalManager(&SecretManagerConfig{
+		InfisicalURL:   srv.URL,
+		InfisicalToken: "tok",
+		Environment:    "prod",
+	})
+
+	v, err := m.GetSecret(context.Background(), "X")
+	require.NoError(t, err)
+	assert.Equal(t, "y", v)
+
+	_, err = m.GetSecret(context.Background(), "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestLoadSecretsIntoEnv(t *testing.T) {
+	t.Run("nil manager", func(t *testing.T) {
+		require.NoError(t, LoadSecretsIntoEnv(nil, ""))
+	})
+
+	t.Run("get secrets error", func(t *testing.T) {
+		stub := &stubManager{err: errors.New("boom")}
+		err := LoadSecretsIntoEnv(stub, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load secrets")
+	})
+
+	t.Run("success and setenv invalid key logs", func(t *testing.T) {
+		stub := &stubManager{secrets: map[string]string{"VALID": "ok", "": "bad"}}
+		t.Setenv("VALID", "")
+		require.NoError(t, LoadSecretsIntoEnv(stub, ""))
+		assert.Equal(t, "ok", os.Getenv("VALID"))
+		_ = os.Unsetenv("VALID")
+	})
+}
+
+type stubManager struct {
+	secrets map[string]string
+	err     error
+}
+
+func (s *stubManager) GetSecret(context.Context, string) (string, error) {
+	return "", errors.New("not used")
+}
+
+func (s *stubManager) GetSecrets(context.Context, string) (map[string]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.secrets, nil
+}


### PR DESCRIPTION
## Summary
Stacks API test and coverage work on **`test/api-coverage-integration`**.

Includes (from oldest to newest on this branch):
- Logger, secrets, realtime, and queue tests (incl. miniredis where used)
- Cache miniredis coverage
- Config package tests and test hooks for full coverage
- Queue test colocation (`machine_lifecycle`, `reply_mux` next to package)
- Redis client `New()` tests

## Base
**`test/api-coverage-integration`**

## Test plan
- [x] `go test ./internal/middleware/...` (and other touched packages as in CI)
- [ ] CI green on this PR