### PR TITLE
fix(view): make next build pass

### DIFF
--- a/view/app/apps/application/[id]/deployments/[deployment_id]/page.tsx
+++ b/view/app/apps/application/[id]/deployments/[deployment_id]/page.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
 import DeploymentLogsTable from '@/packages/components/deployments/deployment-logs';
 
-function page() {
+function Page() {
   const { deployment_id } = useParams();
   const deploymentId = deployment_id?.toString() || '';
 
@@ -37,4 +37,4 @@ function page() {
   );
 }
 
-export default page;
+export default Page;

--- a/view/app/apps/application/[id]/deployments/page.tsx
+++ b/view/app/apps/application/[id]/deployments/page.tsx
@@ -2,15 +2,14 @@
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 
-function page() {
+function Page() {
   const router = useRouter();
   useEffect(() => {
     router.push('/apps');
     return () => {};
-  }, []);
+  }, [router]);
 
-  return;
-  <></>;
+  return null;
 }
 
-export default page;
+export default Page;

--- a/view/app/apps/application/page.tsx
+++ b/view/app/apps/application/page.tsx
@@ -2,16 +2,15 @@
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 
-function page() {
+function Page() {
   const router = useRouter();
 
   useEffect(() => {
     router.push('/apps');
     return () => {};
-  }, []);
+  }, [router]);
 
-  return;
-  <></>;
+  return null;
 }
 
-export default page;
+export default Page;

--- a/view/app/apps/create/[id]/page.tsx
+++ b/view/app/apps/create/[id]/page.tsx
@@ -6,7 +6,7 @@ import { ResourceGuard } from '@/packages/components/rbac/rbac';
 import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
 
-function page() {
+function Page() {
   const { repository } = useFindRepository();
 
   return (
@@ -46,4 +46,4 @@ function page() {
   );
 }
 
-export default page;
+export default Page;

--- a/view/app/apps/create/page.tsx
+++ b/view/app/apps/create/page.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
 import { MainPageHeader } from '@nixopus/ui';
 
-function page() {
+function Page() {
   return (
     <ResourceGuard
       resource="deploy"
@@ -36,4 +36,4 @@ function page() {
   );
 }
 
-export default page;
+export default Page;

--- a/view/app/apps/page.tsx
+++ b/view/app/apps/page.tsx
@@ -178,8 +178,6 @@ function AppActionsCell({ app }: { app: Application }) {
 }
 
 function useAppTableColumns() {
-  const router = useRouter();
-
   return useMemo(
     () => [
       {
@@ -236,7 +234,7 @@ function useAppTableColumns() {
         render: (_: any, app: Application) => <AppActionsCell app={app} />
       }
     ],
-    [router]
+    []
   );
 }
 

--- a/view/app/charts/application/[id]/deployments/[deployment_id]/page.tsx
+++ b/view/app/charts/application/[id]/deployments/[deployment_id]/page.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
 import DeploymentLogsTable from '@/packages/components/deployments/deployment-logs';
 
-function page() {
+function Page() {
   const { deployment_id } = useParams();
   const deploymentId = deployment_id?.toString() || '';
 
@@ -37,4 +37,4 @@ function page() {
   );
 }
 
-export default page;
+export default Page;

--- a/view/app/charts/application/[id]/deployments/page.tsx
+++ b/view/app/charts/application/[id]/deployments/page.tsx
@@ -2,15 +2,14 @@
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 
-function page() {
+function Page() {
   const router = useRouter();
   useEffect(() => {
     router.push('/apps');
     return () => {};
-  }, []);
+  }, [router]);
 
-  return;
-  <></>;
+  return null;
 }
 
-export default page;
+export default Page;

--- a/view/app/charts/application/page.tsx
+++ b/view/app/charts/application/page.tsx
@@ -2,16 +2,15 @@
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 
-function page() {
+function Page() {
   const router = useRouter();
 
   useEffect(() => {
     router.push('/apps');
     return () => {};
-  }, []);
+  }, [router]);
 
-  return;
-  <></>;
+  return null;
 }
 
-export default page;
+export default Page;

--- a/view/app/charts/create/[id]/page.tsx
+++ b/view/app/charts/create/[id]/page.tsx
@@ -6,7 +6,7 @@ import { ResourceGuard } from '@/packages/components/rbac/rbac';
 import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
 
-function page() {
+function Page() {
   const { repository } = useFindRepository();
 
   return (
@@ -46,4 +46,4 @@ function page() {
   );
 }
 
-export default page;
+export default Page;

--- a/view/app/charts/create/page.tsx
+++ b/view/app/charts/create/page.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from '@nixopus/ui';
 import PageLayout from '@/packages/layouts/page-layout';
 import { MainPageHeader } from '@nixopus/ui';
 
-function page() {
+function Page() {
   return (
     <ResourceGuard
       resource="deploy"
@@ -36,4 +36,4 @@ function page() {
   );
 }
 
-export default page;
+export default Page;

--- a/view/app/client-layout.tsx
+++ b/view/app/client-layout.tsx
@@ -123,6 +123,15 @@ const AppShellSkeleton = () => (
   </div>
 );
 
+const PUBLIC_ROUTES = [
+  '/login',
+  '/register',
+  '/auth',
+  '/reset-password',
+  '/verify-email',
+  '/auth/organization-invite'
+] as const;
+
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   return (
     <Provider store={store}>
@@ -143,14 +152,6 @@ const ChildrenWrapper = ({ children }: { children: React.ReactNode }) => {
   const { isAuthenticated, isInitialized, user } = authState;
   const [isLoading, setIsLoading] = useState(true);
 
-  const PUBLIC_ROUTES = [
-    '/login',
-    '/register',
-    '/auth',
-    '/reset-password',
-    '/verify-email',
-    '/auth/organization-invite'
-  ];
   const isPublicRoute = useMemo(
     () => PUBLIC_ROUTES.some((route) => pathname === route || pathname.startsWith(route + '/')),
     [pathname]

--- a/view/app/verify-email/page.tsx
+++ b/view/app/verify-email/page.tsx
@@ -17,12 +17,14 @@ export default function VerifyEmailPage() {
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [message, setMessage] = useState(t('auth.verifyEmail.loading'));
   const isVerifying = useRef(false);
+  const tRef = useRef(t);
+  tRef.current = t;
   const token = searchParams.get('token');
 
   useEffect(() => {
     if (!token) {
       setStatus('error');
-      setMessage(t('auth.verifyEmail.error.invalidLink'));
+      setMessage(tRef.current('auth.verifyEmail.error.invalidLink'));
       return;
     }
 
@@ -33,10 +35,10 @@ export default function VerifyEmailPage() {
       try {
         await verifyEmail({ token }).unwrap();
         setStatus('success');
-        setMessage(t('auth.verifyEmail.success.message'));
+        setMessage(tRef.current('auth.verifyEmail.success.message'));
       } catch (error) {
         setStatus('error');
-        setMessage(t('auth.verifyEmail.error.message'));
+        setMessage(tRef.current('auth.verifyEmail.error.message'));
       } finally {
         isVerifying.current = false;
       }
@@ -47,14 +49,14 @@ export default function VerifyEmailPage() {
     return () => {
       isVerifying.current = false;
     };
-  }, [token]);
+  }, [token, verifyEmail]);
 
   useEffect(() => {
     if (status === 'success') {
       router.push('/chats');
-      toast.success(t('auth.verifyEmail.success.message'));
+      toast.success(tRef.current('auth.verifyEmail.success.message'));
     }
-  }, [status]);
+  }, [status, router]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/view/eslint.config.mjs
+++ b/view/eslint.config.mjs
@@ -1,15 +1,14 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
+import { FlatCompat } from '@eslint/eslintrc';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-/** @type {import('eslint').Linter.Config[]} */
+const compat = new FlatCompat({
+  baseDirectory: __dirname
+});
+
 export default [
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
-  { languageOptions: { globals: globals.browser } },
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-  pluginReact.configs.flat.recommended,
-  { extends: ["eslint:recommended", "plugin:react/recommended", "plugin:prettier/recommended"] }
+  ...compat.extends('next/core-web-vitals', 'prettier')
 ];

--- a/view/lib/i18n/load-translations.ts
+++ b/view/lib/i18n/load-translations.ts
@@ -116,9 +116,9 @@ export async function loadTranslations(locale: string) {
   // Each domain file exports { domainName: { ... } }, so we merge the objects
   const loadPromises = Object.entries(loaders).map(async ([domain, loader]) => {
     try {
-      const module = await loader();
-      // Each module.default is { domainName: { ... } }, so we merge it into translations
-      return { domain, data: module.default };
+      const mod = await loader();
+      // Each default export is { domainName: { ... } }, merged into translations
+      return { domain, data: mod.default };
     } catch (error) {
       console.warn(`Failed to load translation domain ${domain} for locale ${locale}:`, error);
       return { domain, data: null };

--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from 'next';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const nextConfigDir = path.dirname(fileURLToPath(import.meta.url));
+// Repo root: avoids "multiple lockfiles" warning when nixopus/ and view/ both have lockfiles.
+const monorepoRoot = path.join(nextConfigDir, '..');
 
 const nextConfig: NextConfig = {
+  outputFileTracingRoot: monorepoRoot,
   output: 'standalone',
   transpilePackages: [],
   basePath: process.env.BASE_PATH || '',

--- a/view/packages/components/machines/machines-view.tsx
+++ b/view/packages/components/machines/machines-view.tsx
@@ -48,6 +48,7 @@ import { useMachineCard } from '@/packages/hooks/machines/use-machine-card';
 import { useMachinesView } from '@/packages/hooks/machines/use-machines-view';
 import { useMachineLifecycle } from '@/packages/hooks/machines/use-machine-lifecycle';
 import { useMachineBackup } from '@/packages/hooks/backups/use-machine-backup';
+import { useTranslation } from '@/packages/hooks/shared/use-translation';
 import type { Machine } from '@/packages/hooks/machines/use-machines';
 import type { LiveState } from '@/packages/hooks/machines/use-machine-lifecycle';
 
@@ -204,6 +205,7 @@ const InlineEditName = React.memo(function InlineEditName({
   currentName: string;
   className?: string;
 }) {
+  const { t } = useTranslation();
   const [isEditing, setIsEditing] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
   const [value, setValue] = React.useState(currentName);


### PR DESCRIPTION
## Summary
- ESLint: use `FlatCompat` with `next/core-web-vitals` + `prettier` (invalid flat `extends` was breaking builds)
- Machines: add `useTranslation` for inline machine rename error toast
- i18n: rename dynamic import variable from `module` to `mod` (satisfies `@next/next/no-assign-module-variable`)
- App routes: rename `page` → `Page` where hooks are used; fix redirect pages to return `null` and correct `useEffect` deps
- Apps table: drop unused `router` from `useAppTableColumns` memo deps; hoist `PUBLIC_ROUTES` in client layout; `tRef` pattern in verify-email effects
- Next: set `outputFileTracingRoot` to repo root to silence multiple lockfile warning

## Test plan
- [x] `cd view && yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed navigation behavior in deployment and chart views by updating effect dependencies
  * Corrected component rendering for conditional navigation pages
  * Enhanced translation support for error messages in the machines view

* **Refactor**
  * Optimized route definition caching to reduce per-render overhead
  * Updated build configuration for improved standalone deployment handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->