### PR TITLE
feat(chat): show rate limit error banner when AI quota is exhausted

### DIFF
--- a/view/lib/i18n/locales/en/ai.json
+++ b/view/lib/i18n/locales/en/ai.json
@@ -65,6 +65,11 @@
         "label": "nixopus/sample-app"
       }
     },
+    "rateLimitError": {
+      "title": "AI provider rate limit reached",
+      "description": "The AI model's quota has been exhausted. This is a provider limitation — not an issue with Nixopus. Please wait a moment and try again, or switch to a different model.",
+      "action": "Try a different model"
+    },
     "threads": {
       "newChat": "New Chat",
       "recentChats": "Recent Chats",

--- a/view/lib/i18n/locales/en/ai.json
+++ b/view/lib/i18n/locales/en/ai.json
@@ -67,8 +67,7 @@
     },
     "rateLimitError": {
       "title": "AI provider rate limit reached",
-      "description": "The AI model's quota has been exhausted. This is a provider limitation — not an issue with Nixopus. Please wait a moment and try again, or switch to a different model.",
-      "action": "Try a different model"
+      "description": "The AI model's quota has been exhausted. This is a provider limitation — not an issue with Nixopus. Please wait a moment and try again, or switch to a different model."
     },
     "threads": {
       "newChat": "New Chat",

--- a/view/lib/i18n/locales/es/ai.json
+++ b/view/lib/i18n/locales/es/ai.json
@@ -14,6 +14,11 @@
       "placeholder": "Pregunta lo que quieras...",
       "hint": "Presiona Enter para enviar, Shift + Enter para nueva línea"
     },
+    "rateLimitError": {
+      "title": "Límite de velocidad del proveedor de IA alcanzado",
+      "description": "La cuota del modelo de IA se ha agotado. Esta es una limitación del proveedor, no un problema de Nixopus. Espera un momento e intenta de nuevo, o cambia a otro modelo.",
+      "action": "Probar otro modelo"
+    },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
       "helperText": "Starter prompt loaded - edit before sending.",

--- a/view/lib/i18n/locales/es/ai.json
+++ b/view/lib/i18n/locales/es/ai.json
@@ -16,8 +16,7 @@
     },
     "rateLimitError": {
       "title": "Límite de velocidad del proveedor de IA alcanzado",
-      "description": "La cuota del modelo de IA se ha agotado. Esta es una limitación del proveedor, no un problema de Nixopus. Espera un momento e intenta de nuevo, o cambia a otro modelo.",
-      "action": "Probar otro modelo"
+      "description": "La cuota del modelo de IA se ha agotado. Esta es una limitación del proveedor, no un problema de Nixopus. Espera un momento e intenta de nuevo, o cambia a otro modelo."
     },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",

--- a/view/lib/i18n/locales/fr/ai.json
+++ b/view/lib/i18n/locales/fr/ai.json
@@ -14,6 +14,11 @@
       "placeholder": "Demandez n'importe quoi...",
       "hint": "Appuyez sur Entrée pour envoyer, Shift + Entrée pour nouvelle ligne"
     },
+    "rateLimitError": {
+      "title": "Limite de taux du fournisseur IA atteinte",
+      "description": "Le quota du modèle IA a été épuisé. Il s'agit d'une limitation du fournisseur, pas d'un problème Nixopus. Veuillez patienter et réessayer, ou choisir un autre modèle.",
+      "action": "Essayer un autre modèle"
+    },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
       "helperText": "Starter prompt loaded - edit before sending.",

--- a/view/lib/i18n/locales/fr/ai.json
+++ b/view/lib/i18n/locales/fr/ai.json
@@ -16,8 +16,7 @@
     },
     "rateLimitError": {
       "title": "Limite de taux du fournisseur IA atteinte",
-      "description": "Le quota du modèle IA a été épuisé. Il s'agit d'une limitation du fournisseur, pas d'un problème Nixopus. Veuillez patienter et réessayer, ou choisir un autre modèle.",
-      "action": "Essayer un autre modèle"
+      "description": "Le quota du modèle IA a été épuisé. Il s'agit d'une limitation du fournisseur, pas d'un problème Nixopus. Veuillez patienter et réessayer, ou choisir un autre modèle."
     },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",

--- a/view/lib/i18n/locales/kn/ai.json
+++ b/view/lib/i18n/locales/kn/ai.json
@@ -16,8 +16,7 @@
     },
     "rateLimitError": {
       "title": "AI ಪ್ರೊವೈಡರ್ ದರ ಮಿತಿ ತಲುಪಿದೆ",
-      "description": "AI ಮಾದರಿಯ ಕೋಟಾ ಖಾಲಿಯಾಗಿದೆ. ಇದು ಪ್ರೊವೈಡರ್ ಮಿತಿಯಾಗಿದ್ದು, Nixopus ನ ತೊಂದರೆ ಅಲ್ಲ. ದಯವಿಟ್ಟು ಸ್ವಲ್ಪ ಕಾಯ್ದು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ಬೇರೆ ಮಾದರಿ ಆಯ್ಕೆ ಮಾಡಿ.",
-      "action": "ಬೇರೆ ಮಾದರಿ ಪ್ರಯತ್ನಿಸಿ"
+      "description": "AI ಮಾದರಿಯ ಕೋಟಾ ಖಾಲಿಯಾಗಿದೆ. ಇದು ಪ್ರೊವೈಡರ್ ಮಿತಿಯಾಗಿದ್ದು, Nixopus ನ ತೊಂದರೆ ಅಲ್ಲ. ದಯವಿಟ್ಟು ಸ್ವಲ್ಪ ಕಾಯ್ದು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ಬೇರೆ ಮಾದರಿ ಆಯ್ಕೆ ಮಾಡಿ."
     },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",

--- a/view/lib/i18n/locales/kn/ai.json
+++ b/view/lib/i18n/locales/kn/ai.json
@@ -14,6 +14,11 @@
       "placeholder": "ಏನಾದರೂ ಕೇಳಿ...",
       "hint": "ಕಳುಹಿಸಲು Enter ಒತ್ತಿ, ಹೊಸ ಸಾಲಿಗೆ Shift + Enter"
     },
+    "rateLimitError": {
+      "title": "AI ಪ್ರೊವೈಡರ್ ದರ ಮಿತಿ ತಲುಪಿದೆ",
+      "description": "AI ಮಾದರಿಯ ಕೋಟಾ ಖಾಲಿಯಾಗಿದೆ. ಇದು ಪ್ರೊವೈಡರ್ ಮಿತಿಯಾಗಿದ್ದು, Nixopus ನ ತೊಂದರೆ ಅಲ್ಲ. ದಯವಿಟ್ಟು ಸ್ವಲ್ಪ ಕಾಯ್ದು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ಬೇರೆ ಮಾದರಿ ಆಯ್ಕೆ ಮಾಡಿ.",
+      "action": "ಬೇರೆ ಮಾದರಿ ಪ್ರಯತ್ನಿಸಿ"
+    },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
       "helperText": "Starter prompt loaded - edit before sending.",

--- a/view/lib/i18n/locales/ml/ai.json
+++ b/view/lib/i18n/locales/ml/ai.json
@@ -14,6 +14,11 @@
       "placeholder": "എന്തെങ്കിലും ചോദിക്കുക...",
       "hint": "അയയ്ക്കാൻ Enter അമർത്തുക, പുതിയ വരിയിലേക്ക് Shift + Enter"
     },
+    "rateLimitError": {
+      "title": "AI പ്രൊവൈഡർ നിരക്ക് പരിധി കഴിഞ്ഞു",
+      "description": "AI മോഡലിന്റെ ക്വോട്ട തീർന്നു. ഇത് പ്രൊവൈഡറിന്റെ പരിമിതിയാണ്, Nixopus ന്റെ പ്രശ്നമല്ല. ഒരു നിമിഷം കാത്തിരുന്ന് വീണ്ടും ശ്രമിക്കുക, അല്ലെങ്കിൽ മറ്റൊരു മോഡൽ തിരഞ്ഞെടുക്കുക.",
+      "action": "മറ്റൊരു മോഡൽ ശ്രമിക്കുക"
+    },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",
       "helperText": "Starter prompt loaded - edit before sending.",

--- a/view/lib/i18n/locales/ml/ai.json
+++ b/view/lib/i18n/locales/ml/ai.json
@@ -16,8 +16,7 @@
     },
     "rateLimitError": {
       "title": "AI പ്രൊവൈഡർ നിരക്ക് പരിധി കഴിഞ്ഞു",
-      "description": "AI മോഡലിന്റെ ക്വോട്ട തീർന്നു. ഇത് പ്രൊവൈഡറിന്റെ പരിമിതിയാണ്, Nixopus ന്റെ പ്രശ്നമല്ല. ഒരു നിമിഷം കാത്തിരുന്ന് വീണ്ടും ശ്രമിക്കുക, അല്ലെങ്കിൽ മറ്റൊരു മോഡൽ തിരഞ്ഞെടുക്കുക.",
-      "action": "മറ്റൊരു മോഡൽ ശ്രമിക്കുക"
+      "description": "AI മോഡലിന്റെ ക്വോട്ട തീർന്നു. ഇത് പ്രൊവൈഡറിന്റെ പരിമിതിയാണ്, Nixopus ന്റെ പ്രശ്നമല്ല. ഒരു നിമിഷം കാത്തിരുന്ന് വീണ്ടും ശ്രമിക്കുക, അല്ലെങ്കിൽ മറ്റൊരു മോഡൽ തിരഞ്ഞെടുക്കുക."
     },
     "guidedPrefill": {
       "defaultPrompt": "I am new to Nixopus. Use this sample repository to guide me step by step: what Nixopus does, how deployments work, and what I can do next.",

--- a/view/packages/components/chat/ai-chat.tsx
+++ b/view/packages/components/chat/ai-chat.tsx
@@ -39,7 +39,8 @@ import {
   ChevronRight,
   ChevronDown,
   Copy,
-  Zap
+  Zap,
+  AlertTriangle
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTranslation } from '@/packages/hooks/shared/use-translation';
@@ -1015,6 +1016,7 @@ function MessageBubble({
             }
             return null;
           })}
+          {message.errorKind === 'rate-limited' && <RateLimitErrorBanner />}
           <div className="flex items-center gap-1 mt-1 px-1">
             <span className="text-xs text-muted-foreground">{formatTime(message.timestamp)}</span>
             <CopyButton text={message.content} />
@@ -1061,45 +1063,49 @@ function MessageBubble({
             ))}
           </div>
         )}
-        <div
-          className={cn(
-            'rounded-2xl px-4 py-3',
-            isUser
-              ? 'bg-primary text-primary-foreground rounded-tr-md'
-              : 'bg-muted/60 text-foreground rounded-tl-md'
-          )}
-        >
-          {isUser ? (
-            <p className="text-sm whitespace-pre-wrap">
-              {stripContextFromMessageText(message.content)}
-            </p>
-          ) : isStreaming && isLastAssistantMessage && !message.content.trim() ? (
-            <span className="text-sm text-muted-foreground">
-              Thinking
-              <span className="inline-flex">
-                <span className="animate-pulse" style={{ animationDelay: '0ms' }}>
-                  .
-                </span>
-                <span className="animate-pulse" style={{ animationDelay: '150ms' }}>
-                  .
-                </span>
-                <span className="animate-pulse" style={{ animationDelay: '300ms' }}>
-                  .
+        {message.errorKind === 'rate-limited' && !isUser ? (
+          <RateLimitErrorBanner />
+        ) : (
+          <div
+            className={cn(
+              'rounded-2xl px-4 py-3',
+              isUser
+                ? 'bg-primary text-primary-foreground rounded-tr-md'
+                : 'bg-muted/60 text-foreground rounded-tl-md'
+            )}
+          >
+            {isUser ? (
+              <p className="text-sm whitespace-pre-wrap">
+                {stripContextFromMessageText(message.content)}
+              </p>
+            ) : isStreaming && isLastAssistantMessage && !message.content.trim() ? (
+              <span className="text-sm text-muted-foreground">
+                Thinking
+                <span className="inline-flex">
+                  <span className="animate-pulse" style={{ animationDelay: '0ms' }}>
+                    .
+                  </span>
+                  <span className="animate-pulse" style={{ animationDelay: '150ms' }}>
+                    .
+                  </span>
+                  <span className="animate-pulse" style={{ animationDelay: '300ms' }}>
+                    .
+                  </span>
                 </span>
               </span>
-            </span>
-          ) : (
-            <Streamdown
-              plugins={STREAMDOWN_PLUGINS}
-              controls={STREAMDOWN_CONTROLS}
-              animated={STREAMDOWN_ANIMATED}
-              isAnimating={isStreaming && isLastAssistantMessage}
-              caret={isStreaming && isLastAssistantMessage ? 'block' : undefined}
-            >
-              {message.content}
-            </Streamdown>
-          )}
-        </div>
+            ) : (
+              <Streamdown
+                plugins={STREAMDOWN_PLUGINS}
+                controls={STREAMDOWN_CONTROLS}
+                animated={STREAMDOWN_ANIMATED}
+                isAnimating={isStreaming && isLastAssistantMessage}
+                caret={isStreaming && isLastAssistantMessage ? 'block' : undefined}
+              >
+                {message.content}
+              </Streamdown>
+            )}
+          </div>
+        )}
         <div
           className={cn(
             'flex items-center gap-1 mt-1 px-1',
@@ -1109,6 +1115,23 @@ function MessageBubble({
           <span className="text-xs text-muted-foreground">{formatTime(message.timestamp)}</span>
           {!isUser && <CopyButton text={message.content} />}
         </div>
+      </div>
+    </div>
+  );
+}
+
+function RateLimitErrorBanner() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex gap-2.5 rounded-xl border border-orange-500/30 bg-orange-500/5 px-4 py-3.5">
+      <AlertTriangle className="size-4 shrink-0 mt-0.5 text-orange-500" />
+      <div className="flex flex-col gap-1 min-w-0">
+        <p className="text-sm font-medium text-orange-600 dark:text-orange-400">
+          {t('ai.rateLimitError.title' as Parameters<typeof t>[0])}
+        </p>
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          {t('ai.rateLimitError.description' as Parameters<typeof t>[0])}
+        </p>
       </div>
     </div>
   );

--- a/view/packages/hooks/ai/chat-stream-store.ts
+++ b/view/packages/hooks/ai/chat-stream-store.ts
@@ -1,6 +1,14 @@
 import type { StreamChunk } from '@/packages/lib/agent-client';
 import type { ChatMessage, PendingToolApproval, OmStatus, TokenUsage } from './use-agent-chat';
 
+function isRateLimitError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as Record<string, unknown>;
+  if (e.statusCode === 429) return true;
+  const msg = typeof e.message === 'string' ? e.message.toLowerCase() : '';
+  return msg.includes('quota') || msg.includes('rate limit') || msg.includes('resource_exhausted');
+}
+
 export interface SessionSnapshot {
   messages: ChatMessage[];
   isStreaming: boolean;
@@ -356,6 +364,14 @@ class ChatStreamStore {
     if (chunk.type === 'finish' && chunk.payload) {
       const finishPayload = chunk.payload as Record<string, unknown>;
 
+      const payloadError = finishPayload.error;
+      if (payloadError) {
+        const kind = isRateLimitError(payloadError) ? 'rate-limited' : 'generic-error';
+        const errMsg = (payloadError as Record<string, unknown>).message as string | undefined;
+        this.finishStream(threadId, errMsg, kind);
+        return;
+      }
+
       const msg = s.snapshot.messages.find((m) => m.id === amId);
       if (!msg?.usage) {
         const finishUsage = extractUsageFromPayload(finishPayload);
@@ -441,7 +457,11 @@ class ChatStreamStore {
     }
   }
 
-  finishStream(threadId: string, errorMessage?: string) {
+  finishStream(
+    threadId: string,
+    errorMessage?: string,
+    errorKind?: 'rate-limited' | 'generic-error'
+  ) {
     const s = this.sessions.get(threadId);
     if (!s) return;
     const amId = s.assistantMessageId;
@@ -475,7 +495,7 @@ class ChatStreamStore {
             : durationMs != null
               ? { promptTokens: 0, completionTokens: 0, totalTokens: 0, durationMs }
               : m.usage;
-          return { ...m, content, parts, usage };
+          return { ...m, content, parts, usage, ...(errorKind ? { errorKind } : {}) };
         })
       };
     }

--- a/view/packages/hooks/ai/chat-stream-store.ts
+++ b/view/packages/hooks/ai/chat-stream-store.ts
@@ -1,12 +1,18 @@
 import type { StreamChunk } from '@/packages/lib/agent-client';
 import type { ChatMessage, PendingToolApproval, OmStatus, TokenUsage } from './use-agent-chat';
 
-function isRateLimitError(error: unknown): boolean {
+export function isRateLimitError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const e = error as Record<string, unknown>;
-  if (e.statusCode === 429) return true;
+  if (e.statusCode === 429 || e.status === 429) return true;
   const msg = typeof e.message === 'string' ? e.message.toLowerCase() : '';
-  return msg.includes('quota') || msg.includes('rate limit') || msg.includes('resource_exhausted');
+  return (
+    msg.includes('quota') ||
+    msg.includes('rate limit') ||
+    msg.includes('rate_limit') ||
+    msg.includes('resource_exhausted') ||
+    msg.includes('too_many_requests')
+  );
 }
 
 export interface SessionSnapshot {
@@ -367,7 +373,9 @@ class ChatStreamStore {
       const payloadError = finishPayload.error;
       if (payloadError) {
         const kind = isRateLimitError(payloadError) ? 'rate-limited' : 'generic-error';
-        const errMsg = (payloadError as Record<string, unknown>).message as string | undefined;
+        const errMsg =
+          ((payloadError as Record<string, unknown>).message as string | undefined) ??
+          'An unexpected error occurred';
         this.finishStream(threadId, errMsg, kind);
         return;
       }

--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -13,7 +13,7 @@ import {
 } from '@/packages/lib/agent-client';
 import { type ChatContext, formatContextsForAgent } from './chat-context';
 import { v4 as uuid } from 'uuid';
-import { chatStreamStore } from './chat-stream-store';
+import { chatStreamStore, isRateLimitError } from './chat-stream-store';
 
 export type MessagePart =
   | { type: 'text'; content: string }
@@ -343,16 +343,10 @@ export function useAgentChat({
         if (err instanceof Error && err.name === 'AbortError') return;
         const errorMessage =
           err instanceof Error ? err.message : 'Failed to get response from AI agent';
-        const isRateLimit =
-          err instanceof Error &&
-          (err.message.includes('429') ||
-            err.message.toLowerCase().includes('quota') ||
-            err.message.toLowerCase().includes('resource_exhausted') ||
-            err.message.toLowerCase().includes('rate limit'));
         chatStreamStore.finishStream(
           threadId,
           errorMessage,
-          isRateLimit ? 'rate-limited' : 'generic-error'
+          isRateLimitError(err) ? 'rate-limited' : 'generic-error'
         );
         return;
       }

--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -42,6 +42,7 @@ export interface ChatMessage {
   contexts?: ChatContext[];
   kind?: 'status';
   usage?: TokenUsage;
+  errorKind?: 'rate-limited' | 'generic-error';
 }
 
 interface UseAgentChatOptions {
@@ -342,7 +343,17 @@ export function useAgentChat({
         if (err instanceof Error && err.name === 'AbortError') return;
         const errorMessage =
           err instanceof Error ? err.message : 'Failed to get response from AI agent';
-        chatStreamStore.finishStream(threadId, errorMessage);
+        const isRateLimit =
+          err instanceof Error &&
+          (err.message.includes('429') ||
+            err.message.toLowerCase().includes('quota') ||
+            err.message.toLowerCase().includes('resource_exhausted') ||
+            err.message.toLowerCase().includes('rate limit'));
+        chatStreamStore.finishStream(
+          threadId,
+          errorMessage,
+          isRateLimit ? 'rate-limited' : 'generic-error'
+        );
         return;
       }
       chatStreamStore.finishStream(threadId);


### PR DESCRIPTION
## Summary

- Detects `Quota exceeded` / 429 errors from the AI provider in both the SSE `finish` chunk payload and HTTP-level catch blocks
- Tags the affected assistant message with `errorKind: 'rate-limited'`
- Renders a distinct amber banner explaining the failure is a **provider quota limit — not a Nixopus bug**, so users know to wait or switch models
- Adds `isRateLimitError()` as a single exported helper covering all major provider error shapes (Gemini `RESOURCE_EXHAUSTED`, OpenRouter `rate_limit`, Anthropic `too_many_requests`, HTTP `status`/`statusCode` 429)
- Translations added for en / es / fr / kn / ml

## What the user sees

Before: cryptic `Error: Quota exceeded for quota metric...` text in a chat bubble

After:

> ⚠ **AI provider rate limit reached**
> The AI model's quota has been exhausted. This is a provider limitation — not an issue with Nixopus. Please wait a moment and try again, or switch to a different model.

## Files changed

| File | Change |
|---|---|
| `packages/hooks/ai/use-agent-chat.ts` | Added `errorKind` to `ChatMessage`; use shared helper in catch block |
| `packages/hooks/ai/chat-stream-store.ts` | Exported `isRateLimitError()`; detect error in `finish` chunk; stamp `errorKind` on message |
| `packages/components/chat/ai-chat.tsx` | `RateLimitErrorBanner` component; render in `MessageBubble` for both parts and no-parts paths |
| `lib/i18n/locales/{en,es,fr,kn,ml}/ai.json` | Added `ai.rateLimitError.{title,description}` keys |

## Test plan

- [ ] Trigger a Gemini free-tier quota exceeded error — banner should appear instead of raw error text
- [ ] Verify partial streamed content (if any) is preserved before the banner
- [ ] Verify other non-rate-limit errors still show `Error: <message>` as before
- [ ] Check banner renders correctly in dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized error messaging for AI provider rate limits in English, Spanish, French, Kannada, and Malayalam.
  * Introduced a rate-limit error banner in the chat interface that displays when an AI provider reaches its quota, with guidance to retry or switch models.
  * Enhanced error handling to distinguish between rate-limit and generic errors in chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->