### PR TITLE
feat(api): add explicit OpenAPI docs

### DIFF
--- a/api/doc/openapi.json
+++ b/api/doc/openapi.json
@@ -22,27 +22,37 @@
 				"description": "AddApplicationToFamilyRequest schema",
 				"properties": {
 					"branch": {
+						"description": "Git branch. Defaults to main if not specified",
+						"example": "main",
 						"nullable": true,
 						"type": "string"
 					},
 					"build_pack": {
+						"description": "Build strategy. Defaults to dockerfile if not specified",
+						"example": "dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"build_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs passed as build arguments to Docker",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Key-value pairs passed as build arguments to Docker",
 						"nullable": true,
 						"type": "object"
 					},
 					"dockerfile_path": {
+						"description": "Path to the Dockerfile. Defaults to Dockerfile if not specified",
+						"example": "Dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"domains": {
+						"description": "Custom domains for the application",
 						"items": {
+							"description": "Custom domains for the application",
 							"nullable": true,
 							"type": "string"
 						},
@@ -50,52 +60,81 @@
 						"type": "array"
 					},
 					"environment": {
+						"description": "Deployment environment. Defaults to development if not specified",
+						"example": "development",
 						"nullable": true,
 						"type": "string"
 					},
 					"environment_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs set as runtime environment variables",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Key-value pairs set as runtime environment variables",
 						"nullable": true,
 						"type": "object"
 					},
 					"family_id": {
+						"description": "Family ID to add the application to. Creates new family if not provided",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"name": {
+						"description": "Application name",
+						"example": "my-api",
 						"type": "string"
 					},
 					"path": {
+						"description": "Base path for the application. Defaults to /",
+						"example": "api/",
 						"type": "string"
 					},
 					"port": {
+						"description": "Port the application listens on. Defaults to 8080 if not specified",
+						"example": 8080,
 						"nullable": true,
 						"type": "integer"
 					},
 					"post_run_command": {
+						"description": "Command to run after the application starts",
+						"example": "npm run seed",
 						"nullable": true,
 						"type": "string"
 					},
 					"pre_run_command": {
+						"description": "Command to run before the application starts",
+						"example": "npm run migrate",
 						"nullable": true,
 						"type": "string"
 					},
 					"repository": {
+						"description": "Git repository URL or identifier",
+						"example": "github.com/org/repo",
 						"type": "string"
 					}
 				},
+				"required": [
+					"name",
+					"repository"
+				],
 				"type": "object"
 			},
 			"AddCustomDomainRequest": {
 				"description": "AddCustomDomainRequest schema",
 				"properties": {
 					"name": {
+						"description": "Fully qualified domain name to add",
+						"example": "app.example.com",
+						"maxLength": 255,
+						"minLength": 3,
 						"type": "string"
 					}
 				},
+				"required": [
+					"name"
+				],
 				"type": "object"
 			},
 			"AdminRegisteredResponse": {
@@ -2022,27 +2061,40 @@
 							"description": "Variable value (string, number, boolean, or JSON as string)",
 							"type": "string"
 						},
+						"description": "Tool-specific arguments as key-value pairs",
 						"nullable": true,
 						"type": "object"
 					},
 					"server_id": {
+						"description": "ID of the MCP server to call the tool on",
 						"format": "uuid",
 						"type": "string"
 					},
 					"tool_name": {
+						"description": "Name of the MCP tool to invoke",
+						"example": "search",
 						"type": "string"
 					}
 				},
+				"required": [
+					"server_id",
+					"tool_name"
+				],
 				"type": "object"
 			},
 			"CancelDeploymentRequest": {
 				"description": "CancelDeploymentRequest schema",
 				"properties": {
 					"deployment_id": {
+						"description": "Deployment ID to cancel",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"deployment_id"
+				],
 				"type": "object"
 			},
 			"CategoriesResponse": {
@@ -2283,48 +2335,72 @@
 				"description": "CreateDeploymentRequest schema",
 				"properties": {
 					"base_path": {
+						"description": "Base path for the application. Defaults to /",
+						"example": "/",
 						"nullable": true,
 						"type": "string"
 					},
 					"branch": {
+						"description": "Git branch to deploy",
+						"example": "main",
 						"type": "string"
 					},
 					"build_pack": {
+						"description": "Build strategy for the application",
+						"example": "dockerfile",
 						"type": "string"
 					},
 					"build_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs passed as build arguments to Docker",
 							"type": "string"
 						},
+						"description": "Key-value pairs passed as build arguments to Docker",
 						"type": "object"
 					},
 					"compose_domains": {
+						"description": "Domain-to-service mappings for compose deployments",
 						"items": {
+							"description": "Domain-to-service mappings for compose deployments",
 							"nullable": true,
 							"properties": {
 								"domain": {
+									"description": "Domain name for the compose service",
+									"example": "app.example.com",
 									"type": "string"
 								},
 								"port": {
+									"description": "Port override for the compose service",
+									"example": 8080,
 									"nullable": true,
 									"type": "integer"
 								},
 								"service_name": {
+									"description": "Name of the compose service to route to",
+									"example": "web",
 									"nullable": true,
 									"type": "string"
 								}
 							},
+							"required": [
+								"domain"
+							],
 							"type": "object"
 						},
 						"nullable": true,
 						"type": "array"
 					},
 					"dockerfile_path": {
+						"description": "Path to the Dockerfile relative to the repository root",
+						"example": "Dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"domains": {
+						"description": "Custom domains for the application",
 						"items": {
+							"description": "Custom domains for the application",
+							"maxLength": 5,
 							"nullable": true,
 							"type": "string"
 						},
@@ -2332,39 +2408,61 @@
 						"type": "array"
 					},
 					"environment": {
+						"description": "Deployment environment",
+						"example": "production",
 						"type": "string"
 					},
 					"environment_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs set as runtime environment variables",
 							"type": "string"
 						},
+						"description": "Key-value pairs set as runtime environment variables",
 						"type": "object"
 					},
 					"name": {
+						"description": "Application name",
+						"example": "my-web-app",
 						"type": "string"
 					},
 					"port": {
+						"description": "Port the application listens on",
+						"example": 3000,
+						"maximum": 65535,
+						"minimum": 1,
 						"type": "integer"
 					},
 					"post_run_command": {
+						"description": "Command to run after the application starts",
+						"example": "npm run seed",
 						"type": "string"
 					},
 					"pre_run_command": {
+						"description": "Command to run before the application starts",
+						"example": "npm run migrate",
 						"type": "string"
 					},
 					"primary_server_id": {
+						"description": "Primary server ID for routing",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"repository": {
+						"description": "Git repository URL or identifier",
+						"example": "github.com/org/repo",
 						"type": "string"
 					},
 					"routing_strategy": {
+						"description": "Routing strategy for multi-server deployments",
+						"example": "round-robin",
 						"nullable": true,
 						"type": "string"
 					},
 					"server_ids": {
+						"description": "Server IDs to deploy the application to",
 						"items": {
+							"description": "Server IDs to deploy the application to",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -2372,11 +2470,15 @@
 						"type": "array"
 					},
 					"source": {
+						"description": "Source type of the repository",
+						"example": "github",
 						"nullable": true,
 						"type": "string"
 					},
 					"target_server_ids": {
+						"description": "Specific server IDs to target for this deployment",
 						"items": {
+							"description": "Specific server IDs to target for this deployment",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -2384,6 +2486,14 @@
 						"type": "array"
 					}
 				},
+				"required": [
+					"branch",
+					"build_pack",
+					"environment",
+					"name",
+					"port",
+					"repository"
+				],
 				"type": "object"
 			},
 			"CreateDirectoryRequest": {
@@ -2399,28 +2509,39 @@
 				"description": "CreateGithubConnectorRequest schema",
 				"properties": {
 					"app_id": {
+						"description": "GitHub App ID. Required if providing custom app credentials",
+						"example": "123456",
 						"format": "uuid",
 						"type": "string"
 					},
 					"client_id": {
+						"description": "GitHub App OAuth client ID",
+						"example": "Iv1.abc123def456",
 						"format": "uuid",
 						"type": "string"
 					},
 					"client_secret": {
+						"description": "GitHub App OAuth client secret",
 						"type": "string"
 					},
 					"installation_id": {
+						"description": "GitHub App installation ID",
+						"example": "12345678",
 						"format": "uuid",
 						"nullable": true,
 						"type": "string"
 					},
 					"pem": {
+						"description": "GitHub App private key in PEM format",
 						"type": "string"
 					},
 					"slug": {
+						"description": "GitHub App slug",
+						"example": "my-github-app",
 						"type": "string"
 					},
 					"webhook_secret": {
+						"description": "GitHub App webhook secret",
 						"type": "string"
 					}
 				},
@@ -2430,18 +2551,25 @@
 				"description": "CreateHealthCheckRequest schema",
 				"properties": {
 					"application_id": {
+						"description": "ID of the application to monitor",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"body": {
+						"description": "Request body to send with health check requests",
 						"nullable": true,
 						"type": "string"
 					},
 					"endpoint": {
+						"description": "Health check endpoint path or URL. Defaults to /",
+						"example": "/health",
 						"type": "string"
 					},
 					"expected_status_codes": {
+						"description": "Expected HTTP status codes. Defaults to [200]",
 						"items": {
+							"description": "Expected HTTP status codes. Defaults to [200]",
 							"nullable": true,
 							"type": "integer"
 						},
@@ -2449,33 +2577,57 @@
 						"type": "array"
 					},
 					"failure_threshold": {
+						"description": "Consecutive failures before marking unhealthy (1-10). Defaults to 3",
+						"example": 3,
+						"maximum": 10,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"headers": {
 						"additionalProperties": {
+							"description": "Custom HTTP headers to include in health check requests",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Custom HTTP headers to include in health check requests",
 						"nullable": true,
 						"type": "object"
 					},
 					"interval_seconds": {
+						"description": "Check interval in seconds (30-3600). Defaults to 60",
+						"example": 60,
+						"maximum": 3600,
+						"minimum": 30,
 						"nullable": true,
 						"type": "integer"
 					},
 					"method": {
+						"description": "HTTP method to use. Must be GET, POST, or HEAD. Defaults to GET",
+						"example": "GET",
 						"type": "string"
 					},
 					"retention_days": {
+						"description": "Number of days to retain health check results (1-365). Defaults to 30",
+						"example": 30,
+						"maximum": 365,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"success_threshold": {
+						"description": "Consecutive successes before marking healthy (1-10). Defaults to 1",
+						"example": 1,
+						"maximum": 10,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"timeout_seconds": {
+						"description": "Request timeout in seconds (5-120). Defaults to 30",
+						"example": 30,
+						"maximum": 120,
+						"minimum": 5,
 						"nullable": true,
 						"type": "integer"
 					}
@@ -2536,68 +2688,101 @@
 				"description": "CreateProjectRequest schema",
 				"properties": {
 					"base_path": {
+						"description": "Base path for the application. Defaults to / if not specified",
+						"example": "/",
 						"nullable": true,
 						"type": "string"
 					},
 					"branch": {
+						"description": "Git branch to deploy. Defaults to main if not specified",
+						"example": "main",
 						"nullable": true,
 						"type": "string"
 					},
 					"build_pack": {
+						"description": "Build strategy. Defaults to dockerfile if not specified",
+						"example": "dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"build_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs passed as build arguments to Docker",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Key-value pairs passed as build arguments to Docker",
 						"nullable": true,
 						"type": "object"
 					},
 					"compose_domains": {
+						"description": "Domain-to-service mappings for compose deployments",
 						"items": {
+							"description": "Domain-to-service mappings for compose deployments",
 							"nullable": true,
 							"properties": {
 								"domain": {
+									"description": "Domain name for the compose service",
+									"example": "app.example.com",
 									"type": "string"
 								},
 								"port": {
+									"description": "Port override for the compose service",
+									"example": 8080,
 									"nullable": true,
 									"type": "integer"
 								},
 								"service_name": {
+									"description": "Name of the compose service to route to",
+									"example": "web",
 									"nullable": true,
 									"type": "string"
 								}
 							},
+							"required": [
+								"domain"
+							],
 							"type": "object"
 						},
 						"nullable": true,
 						"type": "array"
 					},
 					"compose_services": {
+						"description": "Compose services configuration",
 						"items": {
+							"description": "Compose services configuration",
 							"nullable": true,
 							"properties": {
 								"port": {
+									"description": "Port the service listens on",
+									"example": 8080,
 									"type": "integer"
 								},
 								"service_name": {
+									"description": "Name of the compose service",
+									"example": "web",
 									"type": "string"
 								}
 							},
+							"required": [
+								"port",
+								"service_name"
+							],
 							"type": "object"
 						},
 						"nullable": true,
 						"type": "array"
 					},
 					"dockerfile_path": {
+						"description": "Path to the Dockerfile. Defaults to Dockerfile if not specified",
+						"example": "Dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"domains": {
+						"description": "Custom domains for the project",
 						"items": {
+							"description": "Custom domains for the project",
 							"nullable": true,
 							"type": "string"
 						},
@@ -2605,45 +2790,65 @@
 						"type": "array"
 					},
 					"environment": {
+						"description": "Deployment environment. Defaults to production if not specified",
+						"example": "production",
 						"nullable": true,
 						"type": "string"
 					},
 					"environment_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs set as runtime environment variables",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Key-value pairs set as runtime environment variables",
 						"nullable": true,
 						"type": "object"
 					},
 					"name": {
+						"description": "Project name",
+						"example": "my-web-app",
 						"type": "string"
 					},
 					"port": {
+						"description": "Port the application listens on. Defaults to 3000 if not specified",
+						"example": 3000,
 						"nullable": true,
 						"type": "integer"
 					},
 					"post_run_command": {
+						"description": "Command to run after the application starts",
+						"example": "npm run seed",
 						"nullable": true,
 						"type": "string"
 					},
 					"pre_run_command": {
+						"description": "Command to run before the application starts",
+						"example": "npm run migrate",
 						"nullable": true,
 						"type": "string"
 					},
 					"primary_server_id": {
+						"description": "Primary server ID for routing",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"repository": {
+						"description": "Git repository URL or identifier",
+						"example": "github.com/org/repo",
 						"type": "string"
 					},
 					"routing_strategy": {
+						"description": "Routing strategy for multi-server deployments",
+						"example": "round-robin",
 						"nullable": true,
 						"type": "string"
 					},
 					"server_ids": {
+						"description": "Server IDs to deploy the application to",
 						"items": {
+							"description": "Server IDs to deploy the application to",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -2651,38 +2856,65 @@
 						"type": "array"
 					},
 					"source": {
+						"description": "Source type of the repository",
+						"example": "github",
 						"nullable": true,
 						"type": "string"
 					}
 				},
+				"required": [
+					"name",
+					"repository"
+				],
 				"type": "object"
 			},
 			"CreateSMTPConfigRequest": {
 				"description": "CreateSMTPConfigRequest schema",
 				"properties": {
 					"from_email": {
+						"description": "Sender email address for outgoing emails",
+						"example": "noreply@example.com",
 						"type": "string"
 					},
 					"from_name": {
+						"description": "Display name for outgoing emails",
+						"example": "Nixopus",
 						"type": "string"
 					},
 					"host": {
+						"description": "SMTP server hostname",
+						"example": "smtp.gmail.com",
 						"type": "string"
 					},
 					"organization_id": {
+						"description": "Organization this SMTP config belongs to",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"password": {
+						"description": "SMTP authentication password",
+						"example": "app-password",
 						"type": "string"
 					},
 					"port": {
+						"description": "SMTP server port",
+						"example": 587,
 						"type": "integer"
 					},
 					"username": {
+						"description": "SMTP authentication username",
+						"example": "user@gmail.com",
 						"type": "string"
 					}
 				},
+				"required": [
+					"host",
+					"organization_id",
+					"password",
+					"port",
+					"username"
+				],
 				"type": "object"
 			},
 			"CreateServerRequest": {
@@ -2690,47 +2922,69 @@
 				"properties": {
 					"credentials": {
 						"additionalProperties": {
+							"description": "Provider-specific credential key-value pairs",
 							"type": "string"
 						},
+						"description": "Provider-specific credential key-value pairs",
 						"type": "object"
 					},
 					"custom_url": {
+						"description": "Custom server URL. Required when provider_id is 'custom'. Must use HTTPS",
 						"nullable": true,
 						"type": "string"
 					},
 					"enabled": {
+						"description": "Whether the server is active",
 						"type": "boolean"
 					},
 					"name": {
+						"description": "Display name for this MCP server",
+						"example": "My OpenAI Server",
 						"type": "string"
 					},
 					"provider_id": {
+						"description": "MCP provider identifier (e.g. 'openai', 'anthropic', 'custom')",
+						"example": "openai",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"name",
+					"provider_id"
+				],
 				"type": "object"
 			},
 			"CreateTemplateDeploymentRequest": {
 				"description": "CreateTemplateDeploymentRequest schema",
 				"properties": {
 					"environment": {
+						"description": "Deployment environment",
+						"example": "production",
 						"nullable": true,
 						"type": "string"
 					},
 					"name": {
+						"description": "Name for the deployed application",
+						"example": "my-wordpress",
 						"type": "string"
 					},
 					"primary_server_id": {
+						"description": "Primary server ID for routing",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"routing_strategy": {
+						"description": "Routing strategy for multi-server deployments",
+						"example": "round-robin",
 						"nullable": true,
 						"type": "string"
 					},
 					"server_ids": {
+						"description": "Server IDs to deploy to",
 						"items": {
+							"description": "Server IDs to deploy to",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -2738,6 +2992,8 @@
 						"type": "array"
 					},
 					"template_id": {
+						"description": "Template ID to deploy from",
+						"example": "wordpress",
 						"format": "uuid",
 						"type": "string"
 					},
@@ -2746,23 +3002,33 @@
 							"description": "Variable value (string, number, boolean, or JSON as string)",
 							"type": "string"
 						},
+						"description": "Template-specific configuration variables",
 						"type": "object"
 					}
 				},
+				"required": [
+					"name",
+					"template_id"
+				],
 				"type": "object"
 			},
 			"CreateWebhookConfigRequest": {
 				"description": "CreateWebhookConfigRequest schema",
 				"properties": {
 					"type": {
+						"description": "Webhook integration type",
+						"example": "slack",
 						"type": "string"
 					},
 					"webhook_url": {
+						"description": "Webhook URL for the integration",
+						"example": "https://hooks.slack.com/services/...",
 						"type": "string"
 					}
 				},
 				"required": [
-					"type"
+					"type",
+					"webhook_url"
 				],
 				"type": "object"
 			},
@@ -2939,10 +3205,15 @@
 				"description": "DeleteDeploymentRequest schema",
 				"properties": {
 					"id": {
+						"description": "Application ID to delete",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"DeleteDirectoryRequest": {
@@ -2958,6 +3229,8 @@
 				"description": "DeleteGithubConnectorRequest schema",
 				"properties": {
 					"id": {
+						"description": "GitHub connector ID to delete",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
@@ -2980,10 +3253,15 @@
 				"description": "DeleteSMTPConfigRequest schema",
 				"properties": {
 					"id": {
+						"description": "SMTP configuration ID to delete",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"DeleteServerRequest": {
@@ -3000,6 +3278,8 @@
 				"description": "DeleteWebhookConfigRequest schema",
 				"properties": {
 					"type": {
+						"description": "Webhook integration type to delete",
+						"example": "slack",
 						"type": "string"
 					}
 				},
@@ -3012,10 +3292,15 @@
 				"description": "DeployProjectRequest schema",
 				"properties": {
 					"id": {
+						"description": "Project ID to deploy",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"DeploymentResponse": {
@@ -3550,11 +3835,15 @@
 				"description": "DuplicateProjectRequest schema",
 				"properties": {
 					"branch": {
+						"description": "Git branch override for the duplicate",
+						"example": "develop",
 						"nullable": true,
 						"type": "string"
 					},
 					"domains": {
+						"description": "Custom domains for the duplicated project",
 						"items": {
+							"description": "Custom domains for the duplicated project",
 							"nullable": true,
 							"type": "string"
 						},
@@ -3562,18 +3851,26 @@
 						"type": "array"
 					},
 					"environment": {
+						"description": "Environment for the duplicated project",
+						"example": "staging",
 						"type": "string"
 					},
 					"primary_server_id": {
+						"description": "Primary server ID for routing",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"routing_strategy": {
+						"description": "Routing strategy for multi-server deployments",
+						"example": "round-robin",
 						"nullable": true,
 						"type": "string"
 					},
 					"server_ids": {
+						"description": "Server IDs to deploy the duplicate to",
 						"items": {
+							"description": "Server IDs to deploy the duplicate to",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -3581,10 +3878,16 @@
 						"type": "array"
 					},
 					"source_project_id": {
+						"description": "ID of the project to duplicate",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"environment",
+					"source_project_id"
+				],
 				"type": "object"
 			},
 			"EnvironmentsInFamilyResponse": {
@@ -7400,16 +7703,24 @@
 								"items": {
 									"properties": {
 										"description": {
+											"description": "Description of the preference type",
+											"example": "Notifies when a deployment succeeds",
 											"type": "string"
 										},
 										"enabled": {
+											"description": "Whether this preference is enabled",
+											"example": true,
 											"type": "boolean"
 										},
 										"id": {
+											"description": "Preference type identifier",
+											"example": "deployment_success",
 											"format": "uuid",
 											"type": "string"
 										},
 										"label": {
+											"description": "Display label for the preference",
+											"example": "Deployment Success",
 											"type": "string"
 										}
 									},
@@ -7426,16 +7737,24 @@
 								"items": {
 									"properties": {
 										"description": {
+											"description": "Description of the preference type",
+											"example": "Notifies when a deployment succeeds",
 											"type": "string"
 										},
 										"enabled": {
+											"description": "Whether this preference is enabled",
+											"example": true,
 											"type": "boolean"
 										},
 										"id": {
+											"description": "Preference type identifier",
+											"example": "deployment_success",
 											"format": "uuid",
 											"type": "string"
 										},
 										"label": {
+											"description": "Display label for the preference",
+											"example": "Deployment Success",
 											"type": "string"
 										}
 									},
@@ -7452,16 +7771,24 @@
 								"items": {
 									"properties": {
 										"description": {
+											"description": "Description of the preference type",
+											"example": "Notifies when a deployment succeeds",
 											"type": "string"
 										},
 										"enabled": {
+											"description": "Whether this preference is enabled",
+											"example": true,
 											"type": "boolean"
 										},
 										"id": {
+											"description": "Preference type identifier",
+											"example": "deployment_success",
 											"format": "uuid",
 											"type": "string"
 										},
 										"label": {
+											"description": "Display label for the preference",
+											"example": "Deployment Success",
 											"type": "string"
 										}
 									},
@@ -7490,20 +7817,32 @@
 				"description": "PreviewComposeRequest schema",
 				"properties": {
 					"base_path": {
+						"description": "Base path within the repository",
+						"example": "/",
 						"nullable": true,
 						"type": "string"
 					},
 					"branch": {
+						"description": "Git branch to preview",
+						"example": "main",
 						"type": "string"
 					},
 					"dockerfile_path": {
+						"description": "Path to the Dockerfile",
+						"example": "Dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"repository": {
+						"description": "Git repository URL or identifier",
+						"example": "github.com/org/repo",
 						"type": "string"
 					}
 				},
+				"required": [
+					"branch",
+					"repository"
+				],
 				"type": "object"
 			},
 			"PreviewComposeResponse": {
@@ -7513,12 +7852,20 @@
 						"items": {
 							"properties": {
 								"port": {
+									"description": "Port the service listens on",
+									"example": 8080,
 									"type": "integer"
 								},
 								"service_name": {
+									"description": "Name of the compose service",
+									"example": "web",
 									"type": "string"
 								}
 							},
+							"required": [
+								"port",
+								"service_name"
+							],
 							"type": "object"
 						},
 						"type": "array"
@@ -8203,17 +8550,23 @@
 				"description": "ReDeployApplicationRequest schema",
 				"properties": {
 					"force": {
+						"description": "Force redeployment even if already deploying",
 						"type": "boolean"
 					},
 					"force_without_cache": {
+						"description": "Force redeployment without using Docker build cache",
 						"type": "boolean"
 					},
 					"id": {
+						"description": "Application ID to redeploy",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"target_server_ids": {
+						"description": "Specific server IDs to target for this redeployment",
 						"items": {
+							"description": "Specific server IDs to target for this redeployment",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -8221,12 +8574,17 @@
 						"type": "array"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"RecoverRequest": {
 				"description": "RecoverRequest schema",
 				"properties": {
 					"application_id": {
+						"description": "Application ID to recover. If not provided, recovers all applications",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
@@ -8317,10 +8675,15 @@
 				"description": "RemoveCustomDomainRequest schema",
 				"properties": {
 					"id": {
+						"description": "Custom domain ID to remove",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"RenameMachineRequest": {
@@ -8367,21 +8730,30 @@
 				"description": "RestartDeploymentRequest schema",
 				"properties": {
 					"id": {
+						"description": "Application ID to restart",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"RollbackDeploymentRequest": {
 				"description": "RollbackDeploymentRequest schema",
 				"properties": {
 					"id": {
+						"description": "Application ID to roll back",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"target_server_ids": {
+						"description": "Specific server IDs to target for the rollback",
 						"items": {
+							"description": "Specific server IDs to target for the rollback",
 							"format": "uuid",
 							"type": "string"
 						},
@@ -8389,6 +8761,9 @@
 						"type": "array"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"SMTPConfigResponse": {
@@ -8556,24 +8931,34 @@
 				"description": "SendNotificationRequest schema",
 				"properties": {
 					"channel": {
+						"description": "Notification delivery channel",
+						"example": "email",
 						"type": "string"
 					},
 					"message": {
+						"description": "Notification message body",
+						"example": "Deployment completed successfully",
 						"type": "string"
 					},
 					"metadata": {
 						"additionalProperties": {
+							"description": "Additional key-value metadata for the notification",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Additional key-value metadata for the notification",
 						"nullable": true,
 						"type": "object"
 					},
 					"subject": {
+						"description": "Email subject line (only for email channel)",
+						"example": "Deployment Update",
 						"nullable": true,
 						"type": "string"
 					},
 					"to": {
+						"description": "Recipient email address (only for email channel)",
+						"example": "user@example.com",
 						"nullable": true,
 						"type": "string"
 					}
@@ -8616,25 +9001,38 @@
 				"description": "SetApplicationServersRequest schema",
 				"properties": {
 					"application_id": {
+						"description": "Application ID to assign servers to",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"primary_server_id": {
+						"description": "Primary server ID for routing",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"routing_strategy": {
+						"description": "Routing strategy for multi-server deployments",
+						"example": "round-robin",
 						"nullable": true,
 						"type": "string"
 					},
 					"server_ids": {
+						"description": "Server IDs to assign to the application",
 						"items": {
+							"description": "Server IDs to assign to the application",
 							"format": "uuid",
-							"type": "string"
+							"type": "string",
+							"x-fuego-required-marker": true
 						},
 						"type": "array"
 					}
 				},
+				"required": [
+					"application_id",
+					"server_ids"
+				],
 				"type": "object"
 			},
 			"SetDefaultMachineResponse": {
@@ -8970,29 +9368,39 @@
 				"properties": {
 					"credentials": {
 						"additionalProperties": {
+							"description": "Credentials to use for the test",
 							"type": "string"
 						},
+						"description": "Credentials to use for the test",
 						"type": "object"
 					},
 					"custom_url": {
+						"description": "Custom URL to test. Required when provider_id is 'custom'",
 						"nullable": true,
 						"type": "string"
 					},
 					"provider_id": {
+						"description": "MCP provider to test connection for",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"provider_id"
+				],
 				"type": "object"
 			},
 			"ToggleHealthCheckRequest": {
 				"description": "ToggleHealthCheckRequest schema",
 				"properties": {
 					"application_id": {
+						"description": "ID of the application to toggle health check for",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"enabled": {
+						"description": "Whether the health check should be enabled",
 						"type": "boolean"
 					}
 				},
@@ -9005,25 +9413,43 @@
 				"description": "TrackInstallRequest schema",
 				"properties": {
 					"arch": {
+						"description": "CPU architecture. Valid values: amd64, arm64, unknown",
 						"type": "string"
 					},
 					"duration": {
+						"description": "Installation duration in seconds",
+						"example": 120,
+						"maximum": 7200,
+						"minimum": 0,
 						"type": "integer"
 					},
 					"error": {
+						"description": "Error message if installation failed",
+						"maxLength": 200,
 						"nullable": true,
 						"type": "string"
 					},
 					"event_type": {
+						"description": "Type of installation event",
+						"example": "install_success",
 						"type": "string"
 					},
 					"os": {
+						"description": "Operating system identifier. Valid values: ubuntu, debian, centos, fedora, rhel, alpine, arch, opensuse, sles, amzn, ol, rocky, almalinux, raspbian, pop, mint, manjaro, kali, nixos, gentoo, void, slackware, clear-linux-os, unknown",
 						"type": "string"
 					},
 					"version": {
+						"description": "Semantic version string (e.g. 1.2.3 or 1.2.3-beta.1)",
+						"example": "1.0.0",
 						"type": "string"
 					}
 				},
+				"required": [
+					"arch",
+					"event_type",
+					"os",
+					"version"
+				],
 				"type": "object"
 			},
 			"TrackInstallResponse": {
@@ -9106,6 +9532,8 @@
 				"description": "UpdateAutoUpdateRequest schema",
 				"properties": {
 					"auto_update": {
+						"description": "Whether to automatically apply updates",
+						"example": true,
 						"type": "boolean"
 					}
 				},
@@ -9115,9 +9543,14 @@
 				"description": "UpdateAvatarRequest schema",
 				"properties": {
 					"avatarData": {
+						"description": "Base64-encoded image data URI. Must start with data:image/{jpeg,jpg,png,gif};base64,",
+						"example": "data:image/png;base64,iVBORw0KGgo...",
 						"type": "string"
 					}
 				},
+				"required": [
+					"avatarData"
+				],
 				"type": "object"
 			},
 			"UpdateCheckResponse": {
@@ -9205,48 +9638,70 @@
 				"description": "UpdateDeploymentRequest schema",
 				"properties": {
 					"base_path": {
+						"description": "Base path for the application",
+						"example": "/",
 						"nullable": true,
 						"type": "string"
 					},
 					"build_pack": {
+						"description": "Build strategy. Must be valid if provided",
+						"example": "dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"build_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs passed as build arguments to Docker",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Key-value pairs passed as build arguments to Docker",
 						"nullable": true,
 						"type": "object"
 					},
 					"compose_domains": {
+						"description": "Domain-to-service mappings for compose deployments",
 						"items": {
+							"description": "Domain-to-service mappings for compose deployments",
 							"nullable": true,
 							"properties": {
 								"domain": {
+									"description": "Domain name for the compose service",
+									"example": "app.example.com",
 									"type": "string"
 								},
 								"port": {
+									"description": "Port override for the compose service",
+									"example": 8080,
 									"nullable": true,
 									"type": "integer"
 								},
 								"service_name": {
+									"description": "Name of the compose service to route to",
+									"example": "web",
 									"nullable": true,
 									"type": "string"
 								}
 							},
+							"required": [
+								"domain"
+							],
 							"type": "object"
 						},
 						"nullable": true,
 						"type": "array"
 					},
 					"dockerfile_path": {
+						"description": "Path to the Dockerfile relative to the repository root",
+						"example": "Dockerfile",
 						"nullable": true,
 						"type": "string"
 					},
 					"domains": {
+						"description": "Custom domains for the application. Maximum 5 allowed",
 						"items": {
+							"description": "Custom domains for the application. Maximum 5 allowed",
+							"maxLength": 5,
 							"nullable": true,
 							"type": "string"
 						},
@@ -9254,42 +9709,62 @@
 						"type": "array"
 					},
 					"environment": {
+						"description": "Deployment environment. Must be valid if provided",
+						"example": "production",
 						"nullable": true,
 						"type": "string"
 					},
 					"environment_variables": {
 						"additionalProperties": {
+							"description": "Key-value pairs set as runtime environment variables",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Key-value pairs set as runtime environment variables",
 						"nullable": true,
 						"type": "object"
 					},
 					"force": {
+						"description": "Force the update even if a deployment is in progress",
 						"nullable": true,
 						"type": "boolean"
 					},
 					"id": {
+						"description": "Application ID to update",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"name": {
+						"description": "Application name. Minimum 3 characters if provided",
+						"example": "my-web-app",
+						"minLength": 3,
 						"nullable": true,
 						"type": "string"
 					},
 					"port": {
+						"description": "Port the application listens on",
+						"example": 3000,
+						"maximum": 65535,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"post_run_command": {
+						"description": "Command to run after the application starts",
+						"example": "npm run seed",
 						"nullable": true,
 						"type": "string"
 					},
 					"pre_run_command": {
+						"description": "Command to run before the application starts",
+						"example": "npm run migrate",
 						"nullable": true,
 						"type": "string"
 					},
 					"routing_strategy": {
+						"description": "Routing strategy for multi-server deployments",
+						"example": "round-robin",
 						"nullable": true,
 						"type": "string"
 					}
@@ -9315,46 +9790,70 @@
 				"description": "UpdateFontRequest schema",
 				"properties": {
 					"font_family": {
+						"description": "Font family name for the editor",
+						"example": "JetBrains Mono",
 						"type": "string"
 					},
 					"font_size": {
+						"description": "Font size in pixels",
+						"example": 14,
+						"maximum": 32,
+						"minimum": 8,
 						"type": "integer"
 					}
 				},
+				"required": [
+					"font_family",
+					"font_size"
+				],
 				"type": "object"
 			},
 			"UpdateGithubConnectorRequest": {
 				"description": "UpdateGithubConnectorRequest schema",
 				"properties": {
 					"connector_id": {
+						"description": "Connector ID to update. If provided, updates this specific connector",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"nullable": true,
 						"type": "string"
 					},
 					"installation_id": {
+						"description": "GitHub App installation ID",
+						"example": "12345678",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"installation_id"
+				],
 				"type": "object"
 			},
 			"UpdateHealthCheckRequest": {
 				"description": "UpdateHealthCheckRequest schema",
 				"properties": {
 					"application_id": {
+						"description": "ID of the application to update health check for",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"body": {
+						"description": "Request body to send with health check requests",
 						"nullable": true,
 						"type": "string"
 					},
 					"endpoint": {
+						"description": "Health check endpoint path or URL. Must start with /, http://, or https://",
+						"example": "/health",
 						"nullable": true,
 						"type": "string"
 					},
 					"expected_status_codes": {
+						"description": "Expected HTTP status codes",
 						"items": {
+							"description": "Expected HTTP status codes",
 							"nullable": true,
 							"type": "integer"
 						},
@@ -9362,34 +9861,58 @@
 						"type": "array"
 					},
 					"failure_threshold": {
+						"description": "Consecutive failures before marking unhealthy (1-10)",
+						"example": 3,
+						"maximum": 10,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"headers": {
 						"additionalProperties": {
+							"description": "Custom HTTP headers to include in health check requests",
 							"nullable": true,
 							"type": "string"
 						},
+						"description": "Custom HTTP headers to include in health check requests",
 						"nullable": true,
 						"type": "object"
 					},
 					"interval_seconds": {
+						"description": "Check interval in seconds (30-3600)",
+						"example": 60,
+						"maximum": 3600,
+						"minimum": 30,
 						"nullable": true,
 						"type": "integer"
 					},
 					"method": {
+						"description": "HTTP method to use. Must be GET, POST, or HEAD",
+						"example": "GET",
 						"nullable": true,
 						"type": "string"
 					},
 					"retention_days": {
+						"description": "Number of days to retain health check results (1-365)",
+						"example": 30,
+						"maximum": 365,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"success_threshold": {
+						"description": "Consecutive successes before marking healthy (1-10)",
+						"example": 1,
+						"maximum": 10,
+						"minimum": 1,
 						"nullable": true,
 						"type": "integer"
 					},
 					"timeout_seconds": {
+						"description": "Request timeout in seconds (5-120)",
+						"example": 30,
+						"maximum": 120,
+						"minimum": 5,
 						"nullable": true,
 						"type": "integer"
 					}
@@ -9419,21 +9942,32 @@
 				"description": "UpdateLanguageRequest schema",
 				"properties": {
 					"language": {
+						"description": "Preferred language code",
+						"example": "en",
 						"type": "string"
 					}
 				},
+				"required": [
+					"language"
+				],
 				"type": "object"
 			},
 			"UpdatePreferenceRequest": {
 				"description": "UpdatePreferenceRequest schema",
 				"properties": {
 					"category": {
+						"description": "Notification category",
+						"example": "activity",
 						"type": "string"
 					},
 					"enabled": {
+						"description": "Whether this notification preference is enabled",
+						"example": true,
 						"type": "boolean"
 					},
 					"type": {
+						"description": "Preference type identifier",
+						"example": "deployment_success",
 						"type": "string"
 					}
 				},
@@ -9468,38 +10002,58 @@
 				"description": "UpdateSMTPConfigRequest schema",
 				"properties": {
 					"from_email": {
+						"description": "Sender email address for outgoing emails",
+						"example": "noreply@example.com",
 						"nullable": true,
 						"type": "string"
 					},
 					"from_name": {
+						"description": "Display name for outgoing emails",
+						"example": "Nixopus",
 						"nullable": true,
 						"type": "string"
 					},
 					"host": {
+						"description": "SMTP server hostname",
+						"example": "smtp.gmail.com",
 						"nullable": true,
 						"type": "string"
 					},
 					"id": {
+						"description": "SMTP configuration ID to update",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"organization_id": {
+						"description": "Organization this SMTP config belongs to",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					},
 					"password": {
+						"description": "SMTP authentication password",
+						"example": "app-password",
 						"nullable": true,
 						"type": "string"
 					},
 					"port": {
+						"description": "SMTP server port",
+						"example": 587,
 						"nullable": true,
 						"type": "integer"
 					},
 					"username": {
+						"description": "SMTP authentication username",
+						"example": "user@gmail.com",
 						"nullable": true,
 						"type": "string"
 					}
 				},
+				"required": [
+					"id",
+					"organization_id"
+				],
 				"type": "object"
 			},
 			"UpdateServerRequest": {
@@ -9507,43 +10061,65 @@
 				"properties": {
 					"credentials": {
 						"additionalProperties": {
+							"description": "Updated provider credentials",
 							"type": "string"
 						},
+						"description": "Updated provider credentials",
 						"type": "object"
 					},
 					"custom_url": {
+						"description": "Updated custom server URL. Must use HTTPS if provided",
 						"nullable": true,
 						"type": "string"
 					},
 					"enabled": {
+						"description": "Whether the server is active",
 						"type": "boolean"
 					},
 					"id": {
+						"description": "MCP server ID to update",
 						"format": "uuid",
 						"type": "string"
 					},
 					"name": {
+						"description": "Updated display name",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id",
+					"name"
+				],
 				"type": "object"
 			},
 			"UpdateThemeRequest": {
 				"description": "UpdateThemeRequest schema",
 				"properties": {
 					"theme": {
+						"description": "UI theme name",
+						"example": "dark",
 						"type": "string"
 					}
 				},
+				"required": [
+					"theme"
+				],
 				"type": "object"
 			},
 			"UpdateUserNameRequest": {
 				"description": "UpdateUserNameRequest schema",
 				"properties": {
 					"name": {
+						"description": "New username. Must be 3-50 characters with no spaces",
+						"example": "johndoe",
+						"maxLength": 50,
+						"minLength": 3,
 						"type": "string"
 					}
 				},
+				"required": [
+					"name"
+				],
 				"type": "object"
 			},
 			"UpdateUsernameResponse": {
@@ -9570,13 +10146,19 @@
 				"description": "UpdateWebhookConfigRequest schema",
 				"properties": {
 					"is_active": {
+						"description": "Whether the webhook integration is active",
+						"example": true,
 						"nullable": true,
 						"type": "boolean"
 					},
 					"type": {
+						"description": "Webhook integration type",
+						"example": "slack",
 						"type": "string"
 					},
 					"webhook_url": {
+						"description": "Updated webhook URL",
+						"example": "https://hooks.slack.com/services/...",
 						"nullable": true,
 						"type": "string"
 					}
@@ -10075,10 +10657,15 @@
 				"description": "VerifyCustomDomainRequest schema",
 				"properties": {
 					"id": {
+						"description": "Custom domain ID to verify DNS records for",
+						"example": "550e8400-e29b-41d4-a716-446655440000",
 						"format": "uuid",
 						"type": "string"
 					}
 				},
+				"required": [
+					"id"
+				],
 				"type": "object"
 			},
 			"VerifyMachineResponse": {
@@ -10299,8 +10886,7 @@
 				},
 				"summary": "List audit logs",
 				"tags": [
-					"logs",
-					"api/v1/audit"
+					"Audit"
 				]
 			}
 		},
@@ -10405,8 +10991,7 @@
 				},
 				"summary": "Get bootstrap session data",
 				"tags": [
-					"bootstrap",
-					"api/v1/auth"
+					"Auth"
 				]
 			}
 		},
@@ -10505,8 +11090,7 @@
 				},
 				"summary": "Check admin registration",
 				"tags": [
-					"is-admin-registered",
-					"api/v1/auth"
+					"Auth"
 				]
 			}
 		},
@@ -10528,11 +11112,11 @@
 						"*/*": {
 							"example": {
 								"arch": "string",
-								"duration": 1,
+								"duration": 120,
 								"error": "string",
-								"event_type": "string",
+								"event_type": "install_success",
 								"os": "string",
-								"version": "string"
+								"version": "1.0.0"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/TrackInstallRequest"
@@ -10543,7 +11127,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -10564,7 +11148,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -10622,7 +11206,7 @@
 				},
 				"summary": "Track CLI installation event",
 				"tags": [
-					"api/v1/cli/telemetry"
+					"Telemetry"
 				]
 			}
 		},
@@ -10721,7 +11305,7 @@
 				},
 				"summary": "List containers",
 				"tags": [
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -10836,8 +11420,7 @@
 				},
 				"summary": "List images",
 				"tags": [
-					"images",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -10949,8 +11532,7 @@
 				},
 				"summary": "Prune build cache",
 				"tags": [
-					"prune",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11065,8 +11647,7 @@
 				},
 				"summary": "Prune images",
 				"tags": [
-					"prune",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11173,8 +11754,7 @@
 				},
 				"summary": "Remove container",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			},
 			"get": {
@@ -11279,8 +11859,7 @@
 				},
 				"summary": "Get container",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11407,8 +11986,7 @@
 				},
 				"summary": "Get container logs",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11531,8 +12109,7 @@
 				},
 				"summary": "Update container resources",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11639,8 +12216,7 @@
 				},
 				"summary": "Restart container",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11747,8 +12323,7 @@
 				},
 				"summary": "Start container",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11855,8 +12430,7 @@
 				},
 				"summary": "Stop container",
 				"tags": [
-					"{container_id}",
-					"api/v1/container"
+					"Containers"
 				]
 			}
 		},
@@ -11877,7 +12451,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/DeleteDeploymentRequest"
@@ -11967,8 +12541,7 @@
 				},
 				"summary": "Delete application",
 				"tags": [
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			},
 			"get": {
@@ -12075,8 +12648,7 @@
 				},
 				"summary": "Get application",
 				"tags": [
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			},
 			"post": {
@@ -12095,24 +12667,24 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"base_path": "string",
-								"branch": "string",
-								"build_pack": "string",
+								"base_path": "/",
+								"branch": "main",
+								"build_pack": "dockerfile",
 								"build_variables": {},
 								"compose_domains": [],
-								"dockerfile_path": "string",
+								"dockerfile_path": "Dockerfile",
 								"domains": [],
-								"environment": "string",
+								"environment": "production",
 								"environment_variables": {},
-								"name": "string",
-								"port": 1,
-								"post_run_command": "string",
-								"pre_run_command": "string",
-								"primary_server_id": "00000000-0000-0000-0000-000000000000",
-								"repository": "string",
-								"routing_strategy": "string",
+								"name": "my-web-app",
+								"port": 3000,
+								"post_run_command": "npm run seed",
+								"pre_run_command": "npm run migrate",
+								"primary_server_id": "550e8400-e29b-41d4-a716-446655440000",
+								"repository": "github.com/org/repo",
+								"routing_strategy": "round-robin",
 								"server_ids": [],
-								"source": "string",
+								"source": "github",
 								"target_server_ids": []
 							},
 							"schema": {
@@ -12124,7 +12696,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -12147,7 +12719,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -12205,8 +12777,7 @@
 				},
 				"summary": "Deploy application",
 				"tags": [
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			},
 			"put": {
@@ -12225,21 +12796,21 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"base_path": "string",
-								"build_pack": "string",
+								"base_path": "/",
+								"build_pack": "dockerfile",
 								"build_variables": {},
 								"compose_domains": [],
-								"dockerfile_path": "string",
+								"dockerfile_path": "Dockerfile",
 								"domains": [],
-								"environment": "string",
+								"environment": "production",
 								"environment_variables": {},
 								"force": true,
-								"id": "00000000-0000-0000-0000-000000000000",
-								"name": "string",
-								"port": 1,
-								"post_run_command": "string",
-								"pre_run_command": "string",
-								"routing_strategy": "string"
+								"id": "550e8400-e29b-41d4-a716-446655440000",
+								"name": "my-web-app",
+								"port": 3000,
+								"post_run_command": "npm run seed",
+								"pre_run_command": "npm run migrate",
+								"routing_strategy": "round-robin"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateDeploymentRequest"
@@ -12331,8 +12902,7 @@
 				},
 				"summary": "Update application",
 				"tags": [
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -12353,7 +12923,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"deployment_id": "00000000-0000-0000-0000-000000000000"
+								"deployment_id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CancelDeploymentRequest"
@@ -12443,9 +13013,7 @@
 				},
 				"summary": "Cancel deployment",
 				"tags": [
-					"cancel-deployment",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -12554,9 +13122,7 @@
 				},
 				"summary": "List compose services",
 				"tags": [
-					"compose-services",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -12590,7 +13156,7 @@
 						"description": "Page size",
 						"example": 20,
 						"in": "query",
-						"name": "limit",
+						"name": "page_size",
 						"schema": {
 							"default": 20,
 							"maximum": 100,
@@ -12688,9 +13254,7 @@
 				},
 				"summary": "List application deployments",
 				"tags": [
-					"deployments",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -12797,9 +13361,7 @@
 				},
 				"summary": "Get deployment",
 				"tags": [
-					"deployments",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -12965,9 +13527,7 @@
 				},
 				"summary": "Get deployment logs",
 				"tags": [
-					"deployments",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13090,9 +13650,7 @@
 				},
 				"summary": "Remove application domain",
 				"tags": [
-					"domains",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			},
 			"post": {
@@ -13134,7 +13692,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -13157,7 +13715,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -13215,9 +13773,7 @@
 				},
 				"summary": "Add application domain",
 				"tags": [
-					"domains",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13340,9 +13896,7 @@
 				},
 				"summary": "Update application labels",
 				"tags": [
-					"labels",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13508,9 +14062,7 @@
 				},
 				"summary": "Get application logs",
 				"tags": [
-					"logs",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13531,10 +14083,10 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"base_path": "string",
-								"branch": "string",
-								"dockerfile_path": "string",
-								"repository": "string"
+								"base_path": "/",
+								"branch": "main",
+								"dockerfile_path": "Dockerfile",
+								"repository": "github.com/org/repo"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/PreviewComposeRequest"
@@ -13622,9 +14174,7 @@
 				},
 				"summary": "Preview compose services",
 				"tags": [
-					"preview-compose",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13645,25 +14195,25 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"base_path": "string",
-								"branch": "string",
-								"build_pack": "string",
+								"base_path": "/",
+								"branch": "main",
+								"build_pack": "dockerfile",
 								"build_variables": {},
 								"compose_domains": [],
 								"compose_services": [],
-								"dockerfile_path": "string",
+								"dockerfile_path": "Dockerfile",
 								"domains": [],
-								"environment": "string",
+								"environment": "production",
 								"environment_variables": {},
-								"name": "string",
-								"port": 1,
-								"post_run_command": "string",
-								"pre_run_command": "string",
-								"primary_server_id": "00000000-0000-0000-0000-000000000000",
-								"repository": "string",
-								"routing_strategy": "string",
+								"name": "my-web-app",
+								"port": 3000,
+								"post_run_command": "npm run seed",
+								"pre_run_command": "npm run migrate",
+								"primary_server_id": "550e8400-e29b-41d4-a716-446655440000",
+								"repository": "github.com/org/repo",
+								"routing_strategy": "round-robin",
 								"server_ids": [],
-								"source": "string"
+								"source": "github"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CreateProjectRequest"
@@ -13674,7 +14224,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -13697,7 +14247,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -13755,9 +14305,7 @@
 				},
 				"summary": "Create project",
 				"tags": [
-					"project",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13778,20 +14326,20 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"branch": "string",
-								"build_pack": "string",
+								"branch": "main",
+								"build_pack": "dockerfile",
 								"build_variables": {},
-								"dockerfile_path": "string",
+								"dockerfile_path": "Dockerfile",
 								"domains": [],
-								"environment": "string",
+								"environment": "development",
 								"environment_variables": {},
-								"family_id": "00000000-0000-0000-0000-000000000000",
-								"name": "string",
-								"path": "string",
-								"port": 1,
-								"post_run_command": "string",
-								"pre_run_command": "string",
-								"repository": "string"
+								"family_id": "550e8400-e29b-41d4-a716-446655440000",
+								"name": "my-api",
+								"path": "api/",
+								"port": 8080,
+								"post_run_command": "npm run seed",
+								"pre_run_command": "npm run migrate",
+								"repository": "github.com/org/repo"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/AddApplicationToFamilyRequest"
@@ -13802,7 +14350,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -13825,7 +14373,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -13883,9 +14431,7 @@
 				},
 				"summary": "Add project to family",
 				"tags": [
-					"project",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -13906,7 +14452,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/DeployProjectRequest"
@@ -13998,9 +14544,7 @@
 				},
 				"summary": "Deploy project",
 				"tags": [
-					"project",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14021,13 +14565,13 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"branch": "string",
+								"branch": "develop",
 								"domains": [],
-								"environment": "string",
-								"primary_server_id": "00000000-0000-0000-0000-000000000000",
-								"routing_strategy": "string",
+								"environment": "staging",
+								"primary_server_id": "550e8400-e29b-41d4-a716-446655440000",
+								"routing_strategy": "round-robin",
 								"server_ids": [],
-								"source_project_id": "00000000-0000-0000-0000-000000000000"
+								"source_project_id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/DuplicateProjectRequest"
@@ -14038,7 +14582,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -14061,7 +14605,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -14119,9 +14663,7 @@
 				},
 				"summary": "Duplicate project",
 				"tags": [
-					"project",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14230,9 +14772,7 @@
 				},
 				"summary": "List projects in family",
 				"tags": [
-					"project",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14341,9 +14881,7 @@
 				},
 				"summary": "List family environments",
 				"tags": [
-					"project",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14364,7 +14902,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"application_id": "00000000-0000-0000-0000-000000000000"
+								"application_id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/RecoverRequest"
@@ -14456,9 +14994,7 @@
 				},
 				"summary": "Recover application",
 				"tags": [
-					"recover",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14481,7 +15017,7 @@
 							"example": {
 								"force": true,
 								"force_without_cache": true,
-								"id": "00000000-0000-0000-0000-000000000000",
+								"id": "550e8400-e29b-41d4-a716-446655440000",
 								"target_server_ids": []
 							},
 							"schema": {
@@ -14574,9 +15110,7 @@
 				},
 				"summary": "Redeploy application",
 				"tags": [
-					"redeploy",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14597,7 +15131,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/RestartDeploymentRequest"
@@ -14687,9 +15221,7 @@
 				},
 				"summary": "Restart deployment",
 				"tags": [
-					"restart",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14710,7 +15242,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000",
+								"id": "550e8400-e29b-41d4-a716-446655440000",
 								"target_server_ids": []
 							},
 							"schema": {
@@ -14801,9 +15333,7 @@
 				},
 				"summary": "Rollback deployment",
 				"tags": [
-					"rollback",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -14912,9 +15442,7 @@
 				},
 				"summary": "Get application servers",
 				"tags": [
-					"servers",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			},
 			"put": {
@@ -14933,9 +15461,9 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"application_id": "00000000-0000-0000-0000-000000000000",
-								"primary_server_id": "00000000-0000-0000-0000-000000000000",
-								"routing_strategy": "string",
+								"application_id": "550e8400-e29b-41d4-a716-446655440000",
+								"primary_server_id": "550e8400-e29b-41d4-a716-446655440000",
+								"routing_strategy": "round-robin",
 								"server_ids": []
 							},
 							"schema": {
@@ -15028,9 +15556,7 @@
 				},
 				"summary": "Set application servers",
 				"tags": [
-					"servers",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -15051,12 +15577,12 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"environment": "string",
-								"name": "string",
-								"primary_server_id": "00000000-0000-0000-0000-000000000000",
-								"routing_strategy": "string",
+								"environment": "production",
+								"name": "my-wordpress",
+								"primary_server_id": "550e8400-e29b-41d4-a716-446655440000",
+								"routing_strategy": "round-robin",
 								"server_ids": [],
-								"template_id": "00000000-0000-0000-0000-000000000000",
+								"template_id": "wordpress",
 								"variables": {}
 							},
 							"schema": {
@@ -15068,7 +15594,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -15091,7 +15617,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -15149,9 +15675,7 @@
 				},
 				"summary": "Deploy application from template",
 				"tags": [
-					"template",
-					"api/v1/deploy",
-					"application"
+					"Deploy"
 				]
 			}
 		},
@@ -15295,8 +15819,7 @@
 				},
 				"summary": "List applications",
 				"tags": [
-					"applications",
-					"api/v1/deploy"
+					"Deploy"
 				]
 			}
 		},
@@ -15405,8 +15928,7 @@
 				},
 				"summary": "List deployment artifacts for an application",
 				"tags": [
-					"api/v1/deploy",
-					"artifacts"
+					"Deploy"
 				]
 			}
 		},
@@ -15511,9 +16033,7 @@
 				},
 				"summary": "Delete deployment artifact",
 				"tags": [
-					"{deployment_id}",
-					"api/v1/deploy",
-					"artifacts"
+					"Deploy"
 				]
 			}
 		},
@@ -15620,9 +16140,7 @@
 				},
 				"summary": "Get artifact download URL",
 				"tags": [
-					"{deployment_id}",
-					"api/v1/deploy",
-					"artifacts"
+					"Deploy"
 				]
 			}
 		},
@@ -15729,7 +16247,7 @@
 				},
 				"summary": "List domains",
 				"tags": [
-					"api/v1/domain"
+					"Domains"
 				]
 			}
 		},
@@ -15750,7 +16268,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/RemoveCustomDomainRequest"
@@ -15840,8 +16358,7 @@
 				},
 				"summary": "Remove custom domain",
 				"tags": [
-					"custom",
-					"api/v1/domain"
+					"Domains"
 				]
 			},
 			"post": {
@@ -15860,7 +16377,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"name": "string"
+								"name": "app.example.com"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/AddCustomDomainRequest"
@@ -15871,7 +16388,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -15898,7 +16415,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -15956,8 +16473,7 @@
 				},
 				"summary": "Add custom domain",
 				"tags": [
-					"custom",
-					"api/v1/domain"
+					"Domains"
 				]
 			}
 		},
@@ -16068,8 +16584,7 @@
 				},
 				"summary": "Check custom domain DNS",
 				"tags": [
-					"dns-check",
-					"api/v1/domain"
+					"Domains"
 				]
 			}
 		},
@@ -16168,8 +16683,7 @@
 				},
 				"summary": "Generate random subdomain",
 				"tags": [
-					"generate",
-					"api/v1/domain"
+					"Domains"
 				]
 			}
 		},
@@ -16190,7 +16704,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/VerifyCustomDomainRequest"
@@ -16282,8 +16796,7 @@
 				},
 				"summary": "Verify custom domain",
 				"tags": [
-					"verify",
-					"api/v1/domain"
+					"Domains"
 				]
 			}
 		},
@@ -16447,7 +16960,7 @@
 				},
 				"summary": "List extensions",
 				"tags": [
-					"api/v1/extensions"
+					"Extensions"
 				]
 			}
 		},
@@ -16554,8 +17067,7 @@
 				},
 				"summary": "Get extension by extension ID",
 				"tags": [
-					"by-extension-id",
-					"api/v1/extensions"
+					"Extensions"
 				]
 			}
 		},
@@ -16654,8 +17166,7 @@
 				},
 				"summary": "List extension categories",
 				"tags": [
-					"categories",
-					"api/v1/extensions"
+					"Extensions"
 				]
 			}
 		},
@@ -16762,8 +17273,7 @@
 				},
 				"summary": "Get extension by ID",
 				"tags": [
-					"{id}",
-					"api/v1/extensions"
+					"Extensions"
 				]
 			}
 		},
@@ -16862,7 +17372,7 @@
 				},
 				"summary": "List feature flags",
 				"tags": [
-					"api/v1/feature-flags"
+					"Feature Flags"
 				]
 			},
 			"put": {
@@ -16972,7 +17482,7 @@
 				},
 				"summary": "Update feature flag",
 				"tags": [
-					"api/v1/feature-flags"
+					"Feature Flags"
 				]
 			}
 		},
@@ -17080,8 +17590,7 @@
 				},
 				"summary": "Check if feature is enabled",
 				"tags": [
-					"check",
-					"api/v1/feature-flags"
+					"Feature Flags"
 				]
 			}
 		},
@@ -17189,7 +17698,7 @@
 				},
 				"summary": "List files",
 				"tags": [
-					"api/v1/file-manager"
+					"File Manager"
 				]
 			}
 		},
@@ -17301,8 +17810,7 @@
 				},
 				"summary": "Copy directory",
 				"tags": [
-					"copy-directory",
-					"api/v1/file-manager"
+					"File Manager"
 				]
 			}
 		},
@@ -17413,8 +17921,7 @@
 				},
 				"summary": "Create directory",
 				"tags": [
-					"create-directory",
-					"api/v1/file-manager"
+					"File Manager"
 				]
 			}
 		},
@@ -17525,8 +18032,7 @@
 				},
 				"summary": "Delete directory",
 				"tags": [
-					"delete-directory",
-					"api/v1/file-manager"
+					"File Manager"
 				]
 			}
 		},
@@ -17638,8 +18144,7 @@
 				},
 				"summary": "Move directory",
 				"tags": [
-					"move-directory",
-					"api/v1/file-manager"
+					"File Manager"
 				]
 			}
 		},
@@ -17736,8 +18241,7 @@
 				},
 				"summary": "Upload file",
 				"tags": [
-					"upload",
-					"api/v1/file-manager"
+					"File Manager"
 				]
 			}
 		},
@@ -17758,7 +18262,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/DeleteGithubConnectorRequest"
@@ -17848,7 +18352,7 @@
 				},
 				"summary": "Delete GitHub connector",
 				"tags": [
-					"api/v1/github-connector"
+					"GitHub Connector"
 				]
 			},
 			"post": {
@@ -17867,12 +18371,12 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"app_id": "00000000-0000-0000-0000-000000000000",
-								"client_id": "00000000-0000-0000-0000-000000000000",
+								"app_id": "123456",
+								"client_id": "Iv1.abc123def456",
 								"client_secret": "string",
-								"installation_id": "00000000-0000-0000-0000-000000000000",
+								"installation_id": "12345678",
 								"pem": "string",
-								"slug": "string",
+								"slug": "my-github-app",
 								"webhook_secret": "string"
 							},
 							"schema": {
@@ -17884,7 +18388,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -17905,7 +18409,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -17963,7 +18467,7 @@
 				},
 				"summary": "Create GitHub connector",
 				"tags": [
-					"api/v1/github-connector"
+					"GitHub Connector"
 				]
 			},
 			"put": {
@@ -17982,8 +18486,8 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"connector_id": "00000000-0000-0000-0000-000000000000",
-								"installation_id": "00000000-0000-0000-0000-000000000000"
+								"connector_id": "550e8400-e29b-41d4-a716-446655440000",
+								"installation_id": "12345678"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateGithubConnectorRequest"
@@ -18073,7 +18577,7 @@
 				},
 				"summary": "Update GitHub connector",
 				"tags": [
-					"api/v1/github-connector"
+					"GitHub Connector"
 				]
 			}
 		},
@@ -18172,8 +18676,7 @@
 				},
 				"summary": "List GitHub connectors",
 				"tags": [
-					"all",
-					"api/v1/github-connector"
+					"GitHub Connector"
 				]
 			}
 		},
@@ -18272,8 +18775,7 @@
 				},
 				"summary": "List GitHub repositories",
 				"tags": [
-					"repositories",
-					"api/v1/github-connector"
+					"GitHub Connector"
 				]
 			}
 		},
@@ -18386,8 +18888,7 @@
 				},
 				"summary": "List repository branches",
 				"tags": [
-					"repository",
-					"api/v1/github-connector"
+					"GitHub Connector"
 				]
 			}
 		},
@@ -18484,7 +18985,7 @@
 				},
 				"summary": "Health check",
 				"tags": [
-					"api/v1/health"
+					"Health"
 				]
 			}
 		},
@@ -18593,7 +19094,7 @@
 				},
 				"summary": "Delete health check",
 				"tags": [
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			},
 			"get": {
@@ -18698,7 +19199,7 @@
 				},
 				"summary": "Get health checks",
 				"tags": [
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			},
 			"post": {
@@ -18717,17 +19218,17 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"application_id": "00000000-0000-0000-0000-000000000000",
+								"application_id": "550e8400-e29b-41d4-a716-446655440000",
 								"body": "string",
-								"endpoint": "string",
+								"endpoint": "/health",
 								"expected_status_codes": [],
-								"failure_threshold": 1,
+								"failure_threshold": 3,
 								"headers": {},
-								"interval_seconds": 1,
-								"method": "string",
-								"retention_days": 1,
+								"interval_seconds": 60,
+								"method": "GET",
+								"retention_days": 30,
 								"success_threshold": 1,
-								"timeout_seconds": 1
+								"timeout_seconds": 30
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CreateHealthCheckRequest"
@@ -18738,7 +19239,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -18759,7 +19260,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -18817,7 +19318,7 @@
 				},
 				"summary": "Create health check",
 				"tags": [
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			},
 			"put": {
@@ -18836,17 +19337,17 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"application_id": "00000000-0000-0000-0000-000000000000",
+								"application_id": "550e8400-e29b-41d4-a716-446655440000",
 								"body": "string",
-								"endpoint": "string",
+								"endpoint": "/health",
 								"expected_status_codes": [],
-								"failure_threshold": 1,
+								"failure_threshold": 3,
 								"headers": {},
-								"interval_seconds": 1,
-								"method": "string",
-								"retention_days": 1,
+								"interval_seconds": 60,
+								"method": "GET",
+								"retention_days": 30,
 								"success_threshold": 1,
-								"timeout_seconds": 1
+								"timeout_seconds": 30
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateHealthCheckRequest"
@@ -18936,7 +19437,7 @@
 				},
 				"summary": "Update health check",
 				"tags": [
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			}
 		},
@@ -19077,8 +19578,7 @@
 				},
 				"summary": "List health check results",
 				"tags": [
-					"results",
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			}
 		},
@@ -19205,8 +19705,7 @@
 				},
 				"summary": "Get health check stats",
 				"tags": [
-					"stats",
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			}
 		},
@@ -19227,7 +19726,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"application_id": "00000000-0000-0000-0000-000000000000",
+								"application_id": "550e8400-e29b-41d4-a716-446655440000",
 								"enabled": true
 							},
 							"schema": {
@@ -19318,8 +19817,7 @@
 				},
 				"summary": "Toggle health check",
 				"tags": [
-					"toggle",
-					"api/v1/healthcheck"
+					"Health Checks"
 				]
 			}
 		},
@@ -19489,7 +19987,7 @@
 				},
 				"summary": "List machines",
 				"tags": [
-					"api/v1/machines"
+					"Machines"
 				]
 			},
 			"post": {
@@ -19522,7 +20020,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -19551,7 +20049,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -19609,7 +20107,7 @@
 				},
 				"summary": "Register a BYOS machine",
 				"tags": [
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -19708,8 +20206,7 @@
 				},
 				"summary": "Trigger machine backup",
 				"tags": [
-					"backup",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -19808,8 +20305,7 @@
 				},
 				"summary": "Get backup schedule",
 				"tags": [
-					"backup",
-					"api/v1/machines"
+					"Machines"
 				]
 			},
 			"put": {
@@ -19925,8 +20421,7 @@
 				},
 				"summary": "Update backup schedule",
 				"tags": [
-					"backup",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20087,8 +20582,7 @@
 				},
 				"summary": "List machine backups",
 				"tags": [
-					"backups",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20185,8 +20679,7 @@
 				},
 				"summary": "Get machine billing status",
 				"tags": [
-					"billing",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20313,8 +20806,7 @@
 				},
 				"summary": "Get machine events",
 				"tags": [
-					"events",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20427,8 +20919,7 @@
 				},
 				"summary": "Execute a command on the host machine",
 				"tags": [
-					"exec",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20555,8 +21046,7 @@
 				},
 				"summary": "Get machine metrics",
 				"tags": [
-					"metrics",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20671,8 +21161,7 @@
 				},
 				"summary": "Get machine metrics summary",
 				"tags": [
-					"metrics",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20769,8 +21258,7 @@
 				},
 				"summary": "Pause machine",
 				"tags": [
-					"pause",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20891,8 +21379,7 @@
 				},
 				"summary": "Select a machine plan",
 				"tags": [
-					"plan",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -20989,8 +21476,7 @@
 				},
 				"summary": "List available machine plans",
 				"tags": [
-					"plans",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21087,8 +21573,7 @@
 				},
 				"summary": "Restart machine",
 				"tags": [
-					"restart",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21185,8 +21670,7 @@
 				},
 				"summary": "Resume machine",
 				"tags": [
-					"resume",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21287,8 +21771,7 @@
 				},
 				"summary": "Get SSH connection status",
 				"tags": [
-					"ssh",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21387,8 +21870,7 @@
 				},
 				"summary": "Get machine system stats",
 				"tags": [
-					"stats",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21487,8 +21969,7 @@
 				},
 				"summary": "Get machine lifecycle status",
 				"tags": [
-					"status",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21603,8 +22084,7 @@
 				},
 				"summary": "Provision trail resources",
 				"tags": [
-					"provision",
-					"api/v1/machines/trial"
+					"Machines"
 				]
 			}
 		},
@@ -21713,8 +22193,7 @@
 				},
 				"summary": "Get trail session status",
 				"tags": [
-					"status",
-					"api/v1/machines/trial"
+					"Machines"
 				]
 			}
 		},
@@ -21817,8 +22296,7 @@
 				},
 				"summary": "Remove a machine",
 				"tags": [
-					"{id}",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -21937,8 +22415,7 @@
 				},
 				"summary": "Rename a machine",
 				"tags": [
-					"{id}",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -22045,8 +22522,7 @@
 				},
 				"summary": "Set machine as org default",
 				"tags": [
-					"{id}",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -22151,8 +22627,7 @@
 				},
 				"summary": "SSH connection status",
 				"tags": [
-					"{id}",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -22257,8 +22732,7 @@
 				},
 				"summary": "Verify SSH connection",
 				"tags": [
-					"{id}",
-					"api/v1/machines"
+					"Machines"
 				]
 			}
 		},
@@ -22357,8 +22831,7 @@
 				},
 				"summary": "List MCP provider catalog",
 				"tags": [
-					"api/v1/mcp",
-					"catalog"
+					"MCP"
 				]
 			}
 		},
@@ -22455,9 +22928,7 @@
 				},
 				"summary": "Get provider icon",
 				"tags": [
-					"{provider_id}",
-					"api/v1/mcp",
-					"catalog"
+					"MCP"
 				]
 			}
 		},
@@ -22556,9 +23027,7 @@
 				},
 				"summary": "Agent: list enabled servers with credentials",
 				"tags": [
-					"servers",
-					"api/v1/mcp",
-					"internal"
+					"MCP"
 				]
 			}
 		},
@@ -22657,9 +23126,7 @@
 				},
 				"summary": "Agent: discover tools from all enabled MCP servers",
 				"tags": [
-					"tools",
-					"api/v1/mcp",
-					"internal"
+					"MCP"
 				]
 			}
 		},
@@ -22682,7 +23149,7 @@
 							"example": {
 								"arguments": {},
 								"server_id": "00000000-0000-0000-0000-000000000000",
-								"tool_name": "string"
+								"tool_name": "search"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CallToolRequest"
@@ -22774,9 +23241,7 @@
 				},
 				"summary": "Agent: invoke a tool on an MCP server",
 				"tags": [
-					"tools",
-					"api/v1/mcp",
-					"internal"
+					"MCP"
 				]
 			}
 		},
@@ -22889,8 +23354,7 @@
 				},
 				"summary": "Delete MCP server",
 				"tags": [
-					"api/v1/mcp",
-					"servers"
+					"MCP"
 				]
 			},
 			"get": {
@@ -22987,8 +23451,7 @@
 				},
 				"summary": "List org MCP servers",
 				"tags": [
-					"api/v1/mcp",
-					"servers"
+					"MCP"
 				]
 			},
 			"post": {
@@ -23010,8 +23473,8 @@
 								"credentials": {},
 								"custom_url": "string",
 								"enabled": true,
-								"name": "string",
-								"provider_id": "00000000-0000-0000-0000-000000000000"
+								"name": "My OpenAI Server",
+								"provider_id": "openai"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CreateServerRequest"
@@ -23022,7 +23485,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -23045,7 +23508,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -23103,8 +23566,7 @@
 				},
 				"summary": "Add MCP server",
 				"tags": [
-					"api/v1/mcp",
-					"servers"
+					"MCP"
 				]
 			}
 		},
@@ -23219,9 +23681,7 @@
 				},
 				"summary": "Test MCP server connection",
 				"tags": [
-					"test",
-					"api/v1/mcp",
-					"servers"
+					"MCP"
 				]
 			}
 		},
@@ -23346,9 +23806,7 @@
 				},
 				"summary": "Update MCP server",
 				"tags": [
-					"{id}",
-					"api/v1/mcp",
-					"servers"
+					"MCP"
 				]
 			}
 		},
@@ -23447,11 +23905,10 @@
 				},
 				"summary": "Get notification preferences",
 				"tags": [
-					"api/v1/notification",
-					"preferences"
+					"Notifications"
 				]
 			},
-			"post": {
+			"patch": {
 				"description": "Update notification preferences.\n\nAuth: Required (bearer token).\nScope: Organization-scoped in authenticated context.\nSide effects: May mutate server state.",
 				"operationId": "updateNotificationPreferences",
 				"parameters": [
@@ -23467,9 +23924,9 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"category": "string",
+								"category": "activity",
 								"enabled": true,
-								"type": "string"
+								"type": "deployment_success"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdatePreferenceRequest"
@@ -23559,8 +24016,7 @@
 				},
 				"summary": "Update notification preferences",
 				"tags": [
-					"api/v1/notification",
-					"preferences"
+					"Notifications"
 				]
 			}
 		},
@@ -23581,11 +24037,11 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"channel": "string",
-								"message": "string",
+								"channel": "email",
+								"message": "Deployment completed successfully",
 								"metadata": {},
-								"subject": "string",
-								"to": "string"
+								"subject": "Deployment Update",
+								"to": "user@example.com"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/SendNotificationRequest"
@@ -23677,8 +24133,7 @@
 				},
 				"summary": "Send notification",
 				"tags": [
-					"send",
-					"api/v1/notification"
+					"Notifications"
 				]
 			}
 		},
@@ -23699,7 +24154,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"id": "00000000-0000-0000-0000-000000000000"
+								"id": "550e8400-e29b-41d4-a716-446655440000"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/DeleteSMTPConfigRequest"
@@ -23789,8 +24244,7 @@
 				},
 				"summary": "Delete SMTP config",
 				"tags": [
-					"api/v1/notification",
-					"smtp"
+					"Notifications"
 				]
 			},
 			"get": {
@@ -23897,8 +24351,7 @@
 				},
 				"summary": "Get SMTP config",
 				"tags": [
-					"api/v1/notification",
-					"smtp"
+					"Notifications"
 				]
 			},
 			"post": {
@@ -23917,13 +24370,13 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"from_email": "user@example.com",
-								"from_name": "string",
-								"host": "string",
-								"organization_id": "00000000-0000-0000-0000-000000000000",
-								"password": "string",
-								"port": 1,
-								"username": "string"
+								"from_email": "noreply@example.com",
+								"from_name": "Nixopus",
+								"host": "smtp.gmail.com",
+								"organization_id": "550e8400-e29b-41d4-a716-446655440000",
+								"password": "app-password",
+								"port": 587,
+								"username": "user@gmail.com"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CreateSMTPConfigRequest"
@@ -23934,7 +24387,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -23955,7 +24408,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -24013,8 +24466,7 @@
 				},
 				"summary": "Create SMTP config",
 				"tags": [
-					"api/v1/notification",
-					"smtp"
+					"Notifications"
 				]
 			},
 			"put": {
@@ -24033,14 +24485,14 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"from_email": "user@example.com",
-								"from_name": "string",
-								"host": "string",
-								"id": "00000000-0000-0000-0000-000000000000",
-								"organization_id": "00000000-0000-0000-0000-000000000000",
-								"password": "string",
-								"port": 1,
-								"username": "string"
+								"from_email": "noreply@example.com",
+								"from_name": "Nixopus",
+								"host": "smtp.gmail.com",
+								"id": "550e8400-e29b-41d4-a716-446655440000",
+								"organization_id": "550e8400-e29b-41d4-a716-446655440000",
+								"password": "app-password",
+								"port": 587,
+								"username": "user@gmail.com"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateSMTPConfigRequest"
@@ -24130,8 +24582,7 @@
 				},
 				"summary": "Update SMTP config",
 				"tags": [
-					"api/v1/notification",
-					"smtp"
+					"Notifications"
 				]
 			}
 		},
@@ -24152,7 +24603,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"type": "string"
+								"type": "slack"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/DeleteWebhookConfigRequest"
@@ -24242,8 +24693,7 @@
 				},
 				"summary": "Delete webhook config",
 				"tags": [
-					"api/v1/notification",
-					"webhook"
+					"Notifications"
 				]
 			},
 			"post": {
@@ -24262,8 +24712,8 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"type": "string",
-								"webhook_url": "string"
+								"type": "slack",
+								"webhook_url": "https://hooks.slack.com/services/..."
 							},
 							"schema": {
 								"$ref": "#/components/schemas/CreateWebhookConfigRequest"
@@ -24274,7 +24724,7 @@
 					"required": true
 				},
 				"responses": {
-					"200": {
+					"201": {
 						"content": {
 							"application/json": {
 								"example": {
@@ -24297,7 +24747,7 @@
 								}
 							}
 						},
-						"description": "OK"
+						"description": "Created"
 					},
 					"400": {
 						"content": {
@@ -24355,8 +24805,7 @@
 				},
 				"summary": "Create webhook config",
 				"tags": [
-					"api/v1/notification",
-					"webhook"
+					"Notifications"
 				]
 			},
 			"put": {
@@ -24376,8 +24825,8 @@
 						"*/*": {
 							"example": {
 								"is_active": true,
-								"type": "string",
-								"webhook_url": "string"
+								"type": "slack",
+								"webhook_url": "https://hooks.slack.com/services/..."
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateWebhookConfigRequest"
@@ -24469,8 +24918,7 @@
 				},
 				"summary": "Update webhook config",
 				"tags": [
-					"api/v1/notification",
-					"webhook"
+					"Notifications"
 				]
 			}
 		},
@@ -24577,9 +25025,7 @@
 				},
 				"summary": "Get webhook config",
 				"tags": [
-					"{type}",
-					"api/v1/notification",
-					"webhook"
+					"Notifications"
 				]
 			}
 		},
@@ -24690,7 +25136,7 @@
 				},
 				"summary": "Perform update",
 				"tags": [
-					"api/v1/update"
+					"Update"
 				]
 			}
 		},
@@ -24793,8 +25239,7 @@
 				},
 				"summary": "Check for updates",
 				"tags": [
-					"check",
-					"api/v1/update"
+					"Update"
 				]
 			}
 		},
@@ -24893,7 +25338,7 @@
 				},
 				"summary": "Get current user profile",
 				"tags": [
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -24914,7 +25359,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"avatarData": "string"
+								"avatarData": "data:image/png;base64,iVBORw0KGgo..."
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateAvatarRequest"
@@ -25004,8 +25449,7 @@
 				},
 				"summary": "Update user avatar",
 				"tags": [
-					"avatar",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25026,7 +25470,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"name": "string"
+								"name": "johndoe"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateUserNameRequest"
@@ -25118,8 +25562,7 @@
 				},
 				"summary": "Update user name",
 				"tags": [
-					"name",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25218,8 +25661,7 @@
 				},
 				"summary": "Check onboarding status",
 				"tags": [
-					"onboarded",
-					"api/v1/user"
+					"User"
 				]
 			},
 			"post": {
@@ -25312,8 +25754,7 @@
 				},
 				"summary": "Mark onboarding complete",
 				"tags": [
-					"onboarded",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25412,8 +25853,7 @@
 				},
 				"summary": "Get user preferences",
 				"tags": [
-					"preferences",
-					"api/v1/user"
+					"User"
 				]
 			},
 			"put": {
@@ -25535,8 +25975,7 @@
 				},
 				"summary": "Update user preferences",
 				"tags": [
-					"preferences",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25635,8 +26074,7 @@
 				},
 				"summary": "Get user settings",
 				"tags": [
-					"settings",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25749,8 +26187,7 @@
 				},
 				"summary": "Update auto-update settings",
 				"tags": [
-					"settings",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25771,8 +26208,8 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"font_family": "string",
-								"font_size": 1
+								"font_family": "JetBrains Mono",
+								"font_size": 14
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateFontRequest"
@@ -25864,8 +26301,7 @@
 				},
 				"summary": "Update font settings",
 				"tags": [
-					"settings",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -25886,7 +26322,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"language": "string"
+								"language": "en"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateLanguageRequest"
@@ -25978,8 +26414,7 @@
 				},
 				"summary": "Update language settings",
 				"tags": [
-					"settings",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -26000,7 +26435,7 @@
 					"content": {
 						"*/*": {
 							"example": {
-								"theme": "string"
+								"theme": "dark"
 							},
 							"schema": {
 								"$ref": "#/components/schemas/UpdateThemeRequest"
@@ -26092,8 +26527,7 @@
 				},
 				"summary": "Update theme settings",
 				"tags": [
-					"settings",
-					"api/v1/user"
+					"User"
 				]
 			}
 		},
@@ -26190,7 +26624,7 @@
 				},
 				"summary": "Handle GitHub webhook",
 				"tags": [
-					"api/v1/webhook"
+					"Webhooks"
 				]
 			}
 		}
@@ -26203,268 +26637,58 @@
 	],
 	"tags": [
 		{
-			"name": "all"
+			"name": "Audit"
 		},
 		{
-			"name": "api/v1/audit"
+			"name": "Auth"
 		},
 		{
-			"name": "api/v1/auth"
+			"name": "Containers"
 		},
 		{
-			"name": "api/v1/cli/telemetry"
+			"name": "Deploy"
 		},
 		{
-			"name": "api/v1/container"
+			"name": "Domains"
 		},
 		{
-			"name": "api/v1/deploy"
+			"name": "Extensions"
 		},
 		{
-			"name": "api/v1/domain"
+			"name": "Feature Flags"
 		},
 		{
-			"name": "api/v1/extensions"
+			"name": "File Manager"
 		},
 		{
-			"name": "api/v1/feature-flags"
+			"name": "GitHub Connector"
 		},
 		{
-			"name": "api/v1/file-manager"
+			"name": "Health"
 		},
 		{
-			"name": "api/v1/github-connector"
+			"name": "Health Checks"
 		},
 		{
-			"name": "api/v1/health"
+			"name": "MCP"
 		},
 		{
-			"name": "api/v1/healthcheck"
+			"name": "Machines"
 		},
 		{
-			"name": "api/v1/machines"
+			"name": "Notifications"
 		},
 		{
-			"name": "api/v1/machines/trial"
+			"name": "Telemetry"
 		},
 		{
-			"name": "api/v1/mcp"
+			"name": "Update"
 		},
 		{
-			"name": "api/v1/notification"
+			"name": "User"
 		},
 		{
-			"name": "api/v1/update"
-		},
-		{
-			"name": "api/v1/user"
-		},
-		{
-			"name": "api/v1/webhook"
-		},
-		{
-			"name": "application"
-		},
-		{
-			"name": "applications"
-		},
-		{
-			"name": "artifacts"
-		},
-		{
-			"name": "avatar"
-		},
-		{
-			"name": "backup"
-		},
-		{
-			"name": "backups"
-		},
-		{
-			"name": "billing"
-		},
-		{
-			"name": "bootstrap"
-		},
-		{
-			"name": "by-extension-id"
-		},
-		{
-			"name": "cancel-deployment"
-		},
-		{
-			"name": "catalog"
-		},
-		{
-			"name": "categories"
-		},
-		{
-			"name": "check"
-		},
-		{
-			"name": "compose-services"
-		},
-		{
-			"name": "copy-directory"
-		},
-		{
-			"name": "create-directory"
-		},
-		{
-			"name": "custom"
-		},
-		{
-			"name": "delete-directory"
-		},
-		{
-			"name": "deployments"
-		},
-		{
-			"name": "dns-check"
-		},
-		{
-			"name": "domains"
-		},
-		{
-			"name": "events"
-		},
-		{
-			"name": "exec"
-		},
-		{
-			"name": "generate"
-		},
-		{
-			"name": "images"
-		},
-		{
-			"name": "internal"
-		},
-		{
-			"name": "is-admin-registered"
-		},
-		{
-			"name": "labels"
-		},
-		{
-			"name": "logs"
-		},
-		{
-			"name": "metrics"
-		},
-		{
-			"name": "move-directory"
-		},
-		{
-			"name": "name"
-		},
-		{
-			"name": "onboarded"
-		},
-		{
-			"name": "pause"
-		},
-		{
-			"name": "plan"
-		},
-		{
-			"name": "plans"
-		},
-		{
-			"name": "preferences"
-		},
-		{
-			"name": "preview-compose"
-		},
-		{
-			"name": "project"
-		},
-		{
-			"name": "provision"
-		},
-		{
-			"name": "prune"
-		},
-		{
-			"name": "recover"
-		},
-		{
-			"name": "redeploy"
-		},
-		{
-			"name": "repositories"
-		},
-		{
-			"name": "repository"
-		},
-		{
-			"name": "restart"
-		},
-		{
-			"name": "results"
-		},
-		{
-			"name": "resume"
-		},
-		{
-			"name": "rollback"
-		},
-		{
-			"name": "send"
-		},
-		{
-			"name": "servers"
-		},
-		{
-			"name": "settings"
-		},
-		{
-			"name": "smtp"
-		},
-		{
-			"name": "ssh"
-		},
-		{
-			"name": "stats"
-		},
-		{
-			"name": "status"
-		},
-		{
-			"name": "template"
-		},
-		{
-			"name": "test"
-		},
-		{
-			"name": "toggle"
-		},
-		{
-			"name": "tools"
-		},
-		{
-			"name": "upload"
-		},
-		{
-			"name": "verify"
-		},
-		{
-			"name": "webhook"
-		},
-		{
-			"name": "{container_id}"
-		},
-		{
-			"name": "{deployment_id}"
-		},
-		{
-			"name": "{id}"
-		},
-		{
-			"name": "{provider_id}"
-		},
-		{
-			"name": "{type}"
+			"name": "Webhooks"
 		}
 	]
 }

--- a/api/internal/features/auth/types/auth.go
+++ b/api/internal/features/auth/types/auth.go
@@ -17,40 +17,40 @@ type AuthResponse struct {
 
 // PASSWORDLESS AUTHENTICATION - Commented out password-based login request
 type LoginRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	Email    string `json:"email" validate:"required" description:"User email address" example:"user@example.com"`
+	Password string `json:"password" validate:"required" description:"User password" example:"P@ssw0rd!"`
 }
 
 // PASSWORDLESS AUTHENTICATION - Commented out password-based register request
 type RegisterRequest struct {
-	Username     string `json:"username"`
-	Email        string `json:"email"`
-	Password     string `json:"password"`
-	Type         string `json:"type"`
-	Organization string `json:"organization"`
+	Username     string `json:"username" validate:"required,max=50" description:"Username, max 50 characters, no spaces" example:"johndoe"`
+	Email        string `json:"email" validate:"required,email" description:"User email address" example:"user@example.com"`
+	Password     string `json:"password" validate:"required,min=8" description:"Password with min 8 chars, 1 number, 1 special char, 1 uppercase, 1 lowercase" example:"P@ssw0rd!"`
+	Type         string `json:"type" validate:"required" description:"User type" example:"admin"`
+	Organization string `json:"organization" validate:"required" description:"Organization name" example:"my-org"`
 }
 
 type UpdateUserRequest struct {
-	Username string `json:"username"`
-	Email    string `json:"email"`
-	Avatar   string `json:"avatar"`
-	Role     string `json:"role"`
+	Username string `json:"username" validate:"omitempty,max=50" description:"Updated username" example:"johndoe"`
+	Email    string `json:"email" validate:"omitempty,email" description:"Updated email address" example:"user@example.com"`
+	Avatar   string `json:"avatar" validate:"omitempty" description:"URL of user avatar image" example:"https://example.com/avatar.png"`
+	Role     string `json:"role" validate:"omitempty" description:"User role" example:"admin"`
 }
 
 type DeleteUserRequest struct {
-	Password string `json:"password"`
+	Password string `json:"password" validate:"required" description:"Current password for account deletion confirmation" example:"P@ssw0rd!"`
 }
 
 type ResetPasswordRequest struct {
-	Password string `json:"password"`
+	Password string `json:"password" validate:"required,min=8" description:"New password with min 8 chars, 1 number, 1 special char, 1 uppercase, 1 lowercase" example:"N3wP@ssw0rd!"`
 }
 
 type LogoutRequest struct {
-	RefreshToken string `json:"refresh_token"`
+	RefreshToken string `json:"refresh_token" validate:"required" description:"Refresh token to revoke" example:"eyJhbGciOiJIUzI1NiIs..."`
 }
 
 type RefreshTokenRequest struct {
-	RefreshToken string `json:"refresh_token"`
+	RefreshToken string `json:"refresh_token" validate:"required" description:"Refresh token to exchange for a new access token" example:"eyJhbGciOiJIUzI1NiIs..."`
 }
 
 type VerificationToken struct {
@@ -67,7 +67,7 @@ type TwoFactorSetupResponse struct {
 }
 
 type TwoFactorVerifyRequest struct {
-	Code string `json:"code"`
+	Code string `json:"code" validate:"required,len=6" description:"6-digit TOTP verification code" example:"123456"`
 }
 
 // PASSWORDLESS AUTHENTICATION - Commented out password-based 2FA login request

--- a/api/internal/features/deploy/controller/get_application_deployments.go
+++ b/api/internal/features/deploy/controller/get_application_deployments.go
@@ -14,7 +14,10 @@ func (c *DeployController) GetApplicationDeployments(f fuego.ContextNoBody) (*ty
 	r := f.Request()
 	id := r.URL.Query().Get("id")
 	page := r.URL.Query().Get("page")
-	pageSize := r.URL.Query().Get("limit")
+	pageSize := r.URL.Query().Get("page_size")
+	if pageSize == "" {
+		pageSize = r.URL.Query().Get("limit")
+	}
 
 	if id == "" {
 		c.logger.Log(logger.Error, "application ID is required", "")

--- a/api/internal/features/deploy/types/init.go
+++ b/api/internal/features/deploy/types/init.go
@@ -8,83 +8,83 @@ import (
 )
 
 type IsNameAlreadyTakenRequest struct {
-	Name string `json:"name"`
+	Name string `json:"name" validate:"required" description:"Application name to check for uniqueness" example:"my-web-app"`
 }
 
 type IsDomainAlreadyTakenRequest struct {
-	Domain string `json:"domain"`
+	Domain string `json:"domain" validate:"required" description:"Domain to check for availability" example:"app.example.com"`
 }
 
 type IsDomainValidRequest struct {
-	Domain string `json:"domain"`
+	Domain string `json:"domain" validate:"required" description:"Domain to validate" example:"app.example.com"`
 }
 
 type IsPortAlreadyTakenRequest struct {
-	Port int `json:"port"`
+	Port int `json:"port" validate:"required" description:"Port number to check for availability" example:"3000"`
 }
 
 // ComposeDomain maps a domain to a specific compose service or port override.
 type ComposeDomain struct {
-	Domain      string `json:"domain"`
-	ServiceName string `json:"service_name,omitempty"`
-	Port        int    `json:"port,omitempty"`
+	Domain      string `json:"domain" validate:"required" description:"Domain name for the compose service" example:"app.example.com"`
+	ServiceName string `json:"service_name,omitempty" description:"Name of the compose service to route to" example:"web"`
+	Port        int    `json:"port,omitempty" description:"Port override for the compose service" example:"8080"`
 }
 
 type CreateDeploymentRequest struct {
-	Name                 string                       `json:"name"`
-	Domains              []string                     `json:"domains,omitempty"`
-	ComposeDomains       []ComposeDomain              `json:"compose_domains,omitempty"`
-	Environment          shared_types.Environment     `json:"environment"`
-	BuildPack            shared_types.BuildPack       `json:"build_pack"`
-	Repository           string                       `json:"repository"`
-	Branch               string                       `json:"branch"`
-	PreRunCommand        string                       `json:"pre_run_command"`
-	PostRunCommand       string                       `json:"post_run_command"`
-	BuildVariables       map[string]string            `json:"build_variables"`
-	EnvironmentVariables map[string]string            `json:"environment_variables"`
-	Port                 int                          `json:"port"`
-	DockerfilePath       string                       `json:"dockerfile_path,omitempty"`
-	BasePath             string                       `json:"base_path,omitempty"`
-	Source               shared_types.Source          `json:"source,omitempty"`
-	ServerIDs            []uuid.UUID                  `json:"server_ids,omitempty"`
-	PrimaryServerID      *uuid.UUID                   `json:"primary_server_id,omitempty"`
-	RoutingStrategy      shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
-	TargetServerIDs      []uuid.UUID                  `json:"target_server_ids,omitempty"`
+	Name                 string                       `json:"name" validate:"required" description:"Application name" example:"my-web-app"`
+	Domains              []string                     `json:"domains,omitempty" validate:"omitempty,max=5" description:"Custom domains for the application"`
+	ComposeDomains       []ComposeDomain              `json:"compose_domains,omitempty" description:"Domain-to-service mappings for compose deployments"`
+	Environment          shared_types.Environment     `json:"environment" validate:"required" description:"Deployment environment" example:"production"`
+	BuildPack            shared_types.BuildPack       `json:"build_pack" validate:"required" description:"Build strategy for the application" example:"dockerfile"`
+	Repository           string                       `json:"repository" validate:"required" description:"Git repository URL or identifier" example:"github.com/org/repo"`
+	Branch               string                       `json:"branch" validate:"required" description:"Git branch to deploy" example:"main"`
+	PreRunCommand        string                       `json:"pre_run_command" description:"Command to run before the application starts" example:"npm run migrate"`
+	PostRunCommand       string                       `json:"post_run_command" description:"Command to run after the application starts" example:"npm run seed"`
+	BuildVariables       map[string]string            `json:"build_variables" description:"Key-value pairs passed as build arguments to Docker"`
+	EnvironmentVariables map[string]string            `json:"environment_variables" description:"Key-value pairs set as runtime environment variables"`
+	Port                 int                          `json:"port" validate:"required,min=1,max=65535" description:"Port the application listens on" example:"3000"`
+	DockerfilePath       string                       `json:"dockerfile_path,omitempty" description:"Path to the Dockerfile relative to the repository root" example:"Dockerfile"`
+	BasePath             string                       `json:"base_path,omitempty" description:"Base path for the application. Defaults to /" example:"/"`
+	Source               shared_types.Source          `json:"source,omitempty" description:"Source type of the repository" example:"github"`
+	ServerIDs            []uuid.UUID                  `json:"server_ids,omitempty" description:"Server IDs to deploy the application to"`
+	PrimaryServerID      *uuid.UUID                   `json:"primary_server_id,omitempty" description:"Primary server ID for routing" example:"550e8400-e29b-41d4-a716-446655440000"`
+	RoutingStrategy      shared_types.RoutingStrategy `json:"routing_strategy,omitempty" description:"Routing strategy for multi-server deployments" example:"round-robin"`
+	TargetServerIDs      []uuid.UUID                  `json:"target_server_ids,omitempty" description:"Specific server IDs to target for this deployment"`
 }
 
 // CreateProjectRequest is used to create a project (application) without triggering deployment.
 type CreateProjectRequest struct {
-	Name                 string                       `json:"name"`
-	Domains              []string                     `json:"domains,omitempty"`
-	ComposeDomains       []ComposeDomain              `json:"compose_domains,omitempty"`
-	ComposeServices      []PreviewComposeService      `json:"compose_services,omitempty"`
-	Environment          shared_types.Environment     `json:"environment,omitempty"`
-	BuildPack            shared_types.BuildPack       `json:"build_pack,omitempty"`
-	Repository           string                       `json:"repository"`
-	Branch               string                       `json:"branch,omitempty"`
-	PreRunCommand        string                       `json:"pre_run_command,omitempty"`
-	PostRunCommand       string                       `json:"post_run_command,omitempty"`
-	BuildVariables       map[string]string            `json:"build_variables,omitempty"`
-	EnvironmentVariables map[string]string            `json:"environment_variables,omitempty"`
-	Port                 int                          `json:"port,omitempty"`
-	DockerfilePath       string                       `json:"dockerfile_path,omitempty"`
-	BasePath             string                       `json:"base_path,omitempty"`
-	Source               shared_types.Source          `json:"source,omitempty"`
-	ServerIDs            []uuid.UUID                  `json:"server_ids,omitempty"`
-	PrimaryServerID      *uuid.UUID                   `json:"primary_server_id,omitempty"`
-	RoutingStrategy      shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
+	Name                 string                       `json:"name" validate:"required" description:"Project name" example:"my-web-app"`
+	Domains              []string                     `json:"domains,omitempty" description:"Custom domains for the project"`
+	ComposeDomains       []ComposeDomain              `json:"compose_domains,omitempty" description:"Domain-to-service mappings for compose deployments"`
+	ComposeServices      []PreviewComposeService      `json:"compose_services,omitempty" description:"Compose services configuration"`
+	Environment          shared_types.Environment     `json:"environment,omitempty" description:"Deployment environment. Defaults to production if not specified" example:"production"`
+	BuildPack            shared_types.BuildPack       `json:"build_pack,omitempty" description:"Build strategy. Defaults to dockerfile if not specified" example:"dockerfile"`
+	Repository           string                       `json:"repository" validate:"required" description:"Git repository URL or identifier" example:"github.com/org/repo"`
+	Branch               string                       `json:"branch,omitempty" description:"Git branch to deploy. Defaults to main if not specified" example:"main"`
+	PreRunCommand        string                       `json:"pre_run_command,omitempty" description:"Command to run before the application starts" example:"npm run migrate"`
+	PostRunCommand       string                       `json:"post_run_command,omitempty" description:"Command to run after the application starts" example:"npm run seed"`
+	BuildVariables       map[string]string            `json:"build_variables,omitempty" description:"Key-value pairs passed as build arguments to Docker"`
+	EnvironmentVariables map[string]string            `json:"environment_variables,omitempty" description:"Key-value pairs set as runtime environment variables"`
+	Port                 int                          `json:"port,omitempty" description:"Port the application listens on. Defaults to 3000 if not specified" example:"3000"`
+	DockerfilePath       string                       `json:"dockerfile_path,omitempty" description:"Path to the Dockerfile. Defaults to Dockerfile if not specified" example:"Dockerfile"`
+	BasePath             string                       `json:"base_path,omitempty" description:"Base path for the application. Defaults to / if not specified" example:"/"`
+	Source               shared_types.Source          `json:"source,omitempty" description:"Source type of the repository" example:"github"`
+	ServerIDs            []uuid.UUID                  `json:"server_ids,omitempty" description:"Server IDs to deploy the application to"`
+	PrimaryServerID      *uuid.UUID                   `json:"primary_server_id,omitempty" description:"Primary server ID for routing" example:"550e8400-e29b-41d4-a716-446655440000"`
+	RoutingStrategy      shared_types.RoutingStrategy `json:"routing_strategy,omitempty" description:"Routing strategy for multi-server deployments" example:"round-robin"`
 }
 
 type PreviewComposeRequest struct {
-	Repository     string `json:"repository"`
-	Branch         string `json:"branch"`
-	BasePath       string `json:"base_path,omitempty"`
-	DockerfilePath string `json:"dockerfile_path,omitempty"`
+	Repository     string `json:"repository" validate:"required" description:"Git repository URL or identifier" example:"github.com/org/repo"`
+	Branch         string `json:"branch" validate:"required" description:"Git branch to preview" example:"main"`
+	BasePath       string `json:"base_path,omitempty" description:"Base path within the repository" example:"/"`
+	DockerfilePath string `json:"dockerfile_path,omitempty" description:"Path to the Dockerfile" example:"Dockerfile"`
 }
 
 type PreviewComposeService struct {
-	ServiceName string `json:"service_name"`
-	Port        int    `json:"port"`
+	ServiceName string `json:"service_name" validate:"required" description:"Name of the compose service" example:"web"`
+	Port        int    `json:"port" validate:"required" description:"Port the service listens on" example:"8080"`
 }
 
 type PreviewComposeResponse struct {
@@ -93,87 +93,87 @@ type PreviewComposeResponse struct {
 
 // DeployProjectRequest is used to trigger deployment of an existing project (application).
 type DeployProjectRequest struct {
-	ID uuid.UUID `json:"id"`
+	ID uuid.UUID `json:"id" validate:"required" description:"Project ID to deploy" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type UpdateDeploymentRequest struct {
-	Name                 string                       `json:"name,omitempty"`
-	Environment          shared_types.Environment     `json:"environment,omitempty"`
-	BuildPack            shared_types.BuildPack       `json:"build_pack,omitempty"`
-	PreRunCommand        string                       `json:"pre_run_command,omitempty"`
-	PostRunCommand       string                       `json:"post_run_command,omitempty"`
-	BuildVariables       map[string]string            `json:"build_variables,omitempty"`
-	EnvironmentVariables map[string]string            `json:"environment_variables,omitempty"`
-	Port                 int                          `json:"port,omitempty"`
-	ID                   uuid.UUID                    `json:"id,omitempty"`
-	Force                bool                         `json:"force,omitempty"`
-	DockerfilePath       string                       `json:"dockerfile_path,omitempty"`
-	BasePath             string                       `json:"base_path,omitempty"`
-	Domains              []string                     `json:"domains,omitempty"`
-	ComposeDomains       []ComposeDomain              `json:"compose_domains,omitempty"`
-	RoutingStrategy      shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
+	Name                 string                       `json:"name,omitempty" validate:"omitempty,min=3" description:"Application name. Minimum 3 characters if provided" example:"my-web-app"`
+	Environment          shared_types.Environment     `json:"environment,omitempty" validate:"omitempty" description:"Deployment environment. Must be valid if provided" example:"production"`
+	BuildPack            shared_types.BuildPack       `json:"build_pack,omitempty" validate:"omitempty" description:"Build strategy. Must be valid if provided" example:"dockerfile"`
+	PreRunCommand        string                       `json:"pre_run_command,omitempty" description:"Command to run before the application starts" example:"npm run migrate"`
+	PostRunCommand       string                       `json:"post_run_command,omitempty" description:"Command to run after the application starts" example:"npm run seed"`
+	BuildVariables       map[string]string            `json:"build_variables,omitempty" description:"Key-value pairs passed as build arguments to Docker"`
+	EnvironmentVariables map[string]string            `json:"environment_variables,omitempty" description:"Key-value pairs set as runtime environment variables"`
+	Port                 int                          `json:"port,omitempty" validate:"omitempty,min=1,max=65535" description:"Port the application listens on" example:"3000"`
+	ID                   uuid.UUID                    `json:"id,omitempty" description:"Application ID to update" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Force                bool                         `json:"force,omitempty" description:"Force the update even if a deployment is in progress"`
+	DockerfilePath       string                       `json:"dockerfile_path,omitempty" description:"Path to the Dockerfile relative to the repository root" example:"Dockerfile"`
+	BasePath             string                       `json:"base_path,omitempty" description:"Base path for the application" example:"/"`
+	Domains              []string                     `json:"domains,omitempty" validate:"omitempty,max=5" description:"Custom domains for the application. Maximum 5 allowed"`
+	ComposeDomains       []ComposeDomain              `json:"compose_domains,omitempty" description:"Domain-to-service mappings for compose deployments"`
+	RoutingStrategy      shared_types.RoutingStrategy `json:"routing_strategy,omitempty" description:"Routing strategy for multi-server deployments" example:"round-robin"`
 }
 
 type DeleteDeploymentRequest struct {
-	ID uuid.UUID `json:"id"`
+	ID uuid.UUID `json:"id" validate:"required" description:"Application ID to delete" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type ReDeployApplicationRequest struct {
-	ID                uuid.UUID   `json:"id"`
-	Force             bool        `json:"force"`
-	ForceWithoutCache bool        `json:"force_without_cache"`
-	TargetServerIDs   []uuid.UUID `json:"target_server_ids,omitempty"`
+	ID                uuid.UUID   `json:"id" validate:"required" description:"Application ID to redeploy" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Force             bool        `json:"force" description:"Force redeployment even if already deploying"`
+	ForceWithoutCache bool        `json:"force_without_cache" description:"Force redeployment without using Docker build cache"`
+	TargetServerIDs   []uuid.UUID `json:"target_server_ids,omitempty" description:"Specific server IDs to target for this redeployment"`
 }
 
 type RollbackDeploymentRequest struct {
-	ID              uuid.UUID   `json:"id"`
-	TargetServerIDs []uuid.UUID `json:"target_server_ids,omitempty"`
+	ID              uuid.UUID   `json:"id" validate:"required" description:"Application ID to roll back" example:"550e8400-e29b-41d4-a716-446655440000"`
+	TargetServerIDs []uuid.UUID `json:"target_server_ids,omitempty" description:"Specific server IDs to target for the rollback"`
 }
 
 type RestartDeploymentRequest struct {
-	ID uuid.UUID `json:"id"`
+	ID uuid.UUID `json:"id" validate:"required" description:"Application ID to restart" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 // DuplicateProjectRequest is used to create a duplicate of an existing project with a different environment.
 type DuplicateProjectRequest struct {
-	SourceProjectID uuid.UUID                    `json:"source_project_id"`
-	Domains         []string                     `json:"domains,omitempty"`
-	Environment     shared_types.Environment     `json:"environment"`
-	Branch          string                       `json:"branch,omitempty"`
-	ServerIDs       []uuid.UUID                  `json:"server_ids,omitempty"`
-	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty"`
-	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
+	SourceProjectID uuid.UUID                    `json:"source_project_id" validate:"required" description:"ID of the project to duplicate" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Domains         []string                     `json:"domains,omitempty" description:"Custom domains for the duplicated project"`
+	Environment     shared_types.Environment     `json:"environment" validate:"required" description:"Environment for the duplicated project" example:"staging"`
+	Branch          string                       `json:"branch,omitempty" description:"Git branch override for the duplicate" example:"develop"`
+	ServerIDs       []uuid.UUID                  `json:"server_ids,omitempty" description:"Server IDs to deploy the duplicate to"`
+	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty" description:"Primary server ID for routing" example:"550e8400-e29b-41d4-a716-446655440000"`
+	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty" description:"Routing strategy for multi-server deployments" example:"round-robin"`
 }
 
 // GetProjectFamilyRequest is used to get all projects in a family.
 type GetProjectFamilyRequest struct {
-	FamilyID uuid.UUID `json:"family_id"`
+	FamilyID uuid.UUID `json:"family_id" validate:"required" description:"Project family ID" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 // SetApplicationServersRequest is used to assign servers to an existing application.
 type SetApplicationServersRequest struct {
-	ApplicationID   uuid.UUID                    `json:"application_id"`
-	ServerIDs       []uuid.UUID                  `json:"server_ids"`
-	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty"`
-	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
+	ApplicationID   uuid.UUID                    `json:"application_id" validate:"required" description:"Application ID to assign servers to" example:"550e8400-e29b-41d4-a716-446655440000"`
+	ServerIDs       []uuid.UUID                  `json:"server_ids" validate:"required" description:"Server IDs to assign to the application"`
+	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty" description:"Primary server ID for routing" example:"550e8400-e29b-41d4-a716-446655440000"`
+	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty" description:"Routing strategy for multi-server deployments" example:"round-robin"`
 }
 
 // AddApplicationToFamilyRequest is used to add a new application to an existing family.
 type AddApplicationToFamilyRequest struct {
-	FamilyID             *uuid.UUID               `json:"family_id,omitempty"` // If nil, creates new family
-	Name                 string                   `json:"name"`
-	Path                 string                   `json:"path"` // Base path for the application, e.g., "api/" or "view/"
-	Repository           string                   `json:"repository"`
-	Branch               string                   `json:"branch,omitempty"`
-	Environment          shared_types.Environment `json:"environment,omitempty"`
-	BuildPack            shared_types.BuildPack   `json:"build_pack,omitempty"`
-	Port                 int                      `json:"port,omitempty"`
-	DockerfilePath       string                   `json:"dockerfile_path,omitempty"`
-	PreRunCommand        string                   `json:"pre_run_command,omitempty"`
-	PostRunCommand       string                   `json:"post_run_command,omitempty"`
-	BuildVariables       map[string]string        `json:"build_variables,omitempty"`
-	EnvironmentVariables map[string]string        `json:"environment_variables,omitempty"`
-	Domains              []string                 `json:"domains,omitempty"`
+	FamilyID             *uuid.UUID               `json:"family_id,omitempty" description:"Family ID to add the application to. Creates new family if not provided" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Name                 string                   `json:"name" validate:"required" description:"Application name" example:"my-api"`
+	Path                 string                   `json:"path" description:"Base path for the application. Defaults to /" example:"api/"`
+	Repository           string                   `json:"repository" validate:"required" description:"Git repository URL or identifier" example:"github.com/org/repo"`
+	Branch               string                   `json:"branch,omitempty" description:"Git branch. Defaults to main if not specified" example:"main"`
+	Environment          shared_types.Environment `json:"environment,omitempty" description:"Deployment environment. Defaults to development if not specified" example:"development"`
+	BuildPack            shared_types.BuildPack   `json:"build_pack,omitempty" description:"Build strategy. Defaults to dockerfile if not specified" example:"dockerfile"`
+	Port                 int                      `json:"port,omitempty" description:"Port the application listens on. Defaults to 8080 if not specified" example:"8080"`
+	DockerfilePath       string                   `json:"dockerfile_path,omitempty" description:"Path to the Dockerfile. Defaults to Dockerfile if not specified" example:"Dockerfile"`
+	PreRunCommand        string                   `json:"pre_run_command,omitempty" description:"Command to run before the application starts" example:"npm run migrate"`
+	PostRunCommand       string                   `json:"post_run_command,omitempty" description:"Command to run after the application starts" example:"npm run seed"`
+	BuildVariables       map[string]string        `json:"build_variables,omitempty" description:"Key-value pairs passed as build arguments to Docker"`
+	EnvironmentVariables map[string]string        `json:"environment_variables,omitempty" description:"Key-value pairs set as runtime environment variables"`
+	Domains              []string                 `json:"domains,omitempty" description:"Custom domains for the application"`
 }
 
 // ProjectFamilyResponseData contains the data for project family response.
@@ -287,21 +287,21 @@ type ApplicationServersResponse struct {
 }
 
 type CreateTemplateDeploymentRequest struct {
-	TemplateID      string                       `json:"template_id"`
-	Name            string                       `json:"name"`
-	Variables       map[string]interface{}       `json:"variables"`
-	ServerIDs       []uuid.UUID                  `json:"server_ids,omitempty"`
-	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty"`
-	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty"`
-	Environment     shared_types.Environment     `json:"environment,omitempty"`
+	TemplateID      string                       `json:"template_id" validate:"required" description:"Template ID to deploy from" example:"wordpress"`
+	Name            string                       `json:"name" validate:"required" description:"Name for the deployed application" example:"my-wordpress"`
+	Variables       map[string]interface{}       `json:"variables" description:"Template-specific configuration variables"`
+	ServerIDs       []uuid.UUID                  `json:"server_ids,omitempty" description:"Server IDs to deploy to"`
+	PrimaryServerID *uuid.UUID                   `json:"primary_server_id,omitempty" description:"Primary server ID for routing" example:"550e8400-e29b-41d4-a716-446655440000"`
+	RoutingStrategy shared_types.RoutingStrategy `json:"routing_strategy,omitempty" description:"Routing strategy for multi-server deployments" example:"round-robin"`
+	Environment     shared_types.Environment     `json:"environment,omitempty" description:"Deployment environment" example:"production"`
 }
 
 type CancelDeploymentRequest struct {
-	DeploymentID uuid.UUID `json:"deployment_id"`
+	DeploymentID uuid.UUID `json:"deployment_id" validate:"required" description:"Deployment ID to cancel" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type RecoverRequest struct {
-	ApplicationID *uuid.UUID `json:"application_id,omitempty"`
+	ApplicationID *uuid.UUID `json:"application_id,omitempty" description:"Application ID to recover. If not provided, recovers all applications" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type RecoverAppResult struct {

--- a/api/internal/features/domain/types/custom_domains.go
+++ b/api/internal/features/domain/types/custom_domains.go
@@ -7,15 +7,15 @@ import (
 )
 
 type AddCustomDomainRequest struct {
-	Name string `json:"name"`
+	Name string `json:"name" validate:"required,min=3,max=255" description:"Fully qualified domain name to add" example:"app.example.com"`
 }
 
 type VerifyCustomDomainRequest struct {
-	ID string `json:"id"`
+	ID string `json:"id" validate:"required" description:"Custom domain ID to verify DNS records for" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type RemoveCustomDomainRequest struct {
-	ID string `json:"id"`
+	ID string `json:"id" validate:"required" description:"Custom domain ID to remove" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type CustomDomainResponse struct {

--- a/api/internal/features/github-connector/controller/create_connector.go
+++ b/api/internal/features/github-connector/controller/create_connector.go
@@ -18,8 +18,8 @@ func (c *GithubConnectorController) CreateGithubConnector(f fuego.ContextWithBod
 	}
 
 	w, r := f.Response(), f.Request()
-	if !c.parseAndValidate(w, r, &githubConnectorRequest) {
-		return nil, fuego.BadRequestError{Detail: "invalid request"}
+	if err := c.parseAndValidate(w, r, &githubConnectorRequest); err != nil {
+		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	user := utils.GetUser(w, r)

--- a/api/internal/features/github-connector/controller/delete_connector.go
+++ b/api/internal/features/github-connector/controller/delete_connector.go
@@ -18,9 +18,8 @@ func (c *GithubConnectorController) DeleteGithubConnector(f fuego.ContextWithBod
 
 	w, r := f.Response(), f.Request()
 
-	if !c.parseAndValidate(w, r, &deleteRequest) {
-		// parseAndValidate already sent the error response, so return nil to prevent duplicate response
-		return nil, nil
+	if err := c.parseAndValidate(w, r, &deleteRequest); err != nil {
+		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	user := utils.GetUser(w, r)

--- a/api/internal/features/github-connector/controller/init.go
+++ b/api/internal/features/github-connector/controller/init.go
@@ -39,20 +39,18 @@ func NewGithubConnectorController(
 	}
 }
 
-func (c *GithubConnectorController) parseAndValidate(w http.ResponseWriter, r *http.Request, req interface{}) bool {
+func (c *GithubConnectorController) parseAndValidate(w http.ResponseWriter, r *http.Request, req interface{}) error {
 	user := utils.GetUser(w, r)
 
 	if user == nil {
 		c.logger.Log(logger.Error, shared_types.ErrFailedToGetUserFromContext.Error(), shared_types.ErrFailedToGetUserFromContext.Error())
-		utils.SendErrorResponse(w, shared_types.ErrFailedToGetUserFromContext.Error(), http.StatusInternalServerError)
-		return false
+		return shared_types.ErrFailedToGetUserFromContext
 	}
 
 	if err := c.validator.ValidateRequest(req); err != nil {
 		c.logger.Log(logger.Error, err.Error(), err.Error())
-		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
-		return false
+		return err
 	}
 
-	return true
+	return nil
 }

--- a/api/internal/features/github-connector/controller/update_connector.go
+++ b/api/internal/features/github-connector/controller/update_connector.go
@@ -20,8 +20,8 @@ func (c *GithubConnectorController) UpdateGithubConnectorRequest(f fuego.Context
 
 	w, r := f.Response(), f.Request()
 
-	if !c.parseAndValidate(w, r, &UpdateConnectorRequest) {
-		return nil, fuego.BadRequestError{Detail: "invalid request"}
+	if err := c.parseAndValidate(w, r, &UpdateConnectorRequest); err != nil {
+		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	user := utils.GetUser(w, r)

--- a/api/internal/features/github-connector/types/delete.go
+++ b/api/internal/features/github-connector/types/delete.go
@@ -1,5 +1,5 @@
 package types
 
 type DeleteGithubConnectorRequest struct {
-	ID string `json:"id" validate:"required"`
+	ID string `json:"id" validate:"required" description:"GitHub connector ID to delete" example:"550e8400-e29b-41d4-a716-446655440000"`
 }

--- a/api/internal/features/github-connector/types/init.go
+++ b/api/internal/features/github-connector/types/init.go
@@ -7,18 +7,18 @@ import (
 )
 
 type CreateGithubConnectorRequest struct {
-	AppID          string `json:"app_id"`
-	Slug           string `json:"slug"`
-	Pem            string `json:"pem"`
-	ClientID       string `json:"client_id"`
-	ClientSecret   string `json:"client_secret"`
-	WebhookSecret  string `json:"webhook_secret"`
-	InstallationID string `json:"installation_id,omitempty"`
+	AppID          string `json:"app_id" description:"GitHub App ID. Required if providing custom app credentials" example:"123456"`
+	Slug           string `json:"slug" description:"GitHub App slug" example:"my-github-app"`
+	Pem            string `json:"pem" description:"GitHub App private key in PEM format"`
+	ClientID       string `json:"client_id" description:"GitHub App OAuth client ID" example:"Iv1.abc123def456"`
+	ClientSecret   string `json:"client_secret" description:"GitHub App OAuth client secret"`
+	WebhookSecret  string `json:"webhook_secret" description:"GitHub App webhook secret"`
+	InstallationID string `json:"installation_id,omitempty" description:"GitHub App installation ID" example:"12345678"`
 }
 
 type UpdateGithubConnectorRequest struct {
-	InstallationID string `json:"installation_id"`
-	ConnectorID    string `json:"connector_id,omitempty"` // Optional: if provided, update this specific connector
+	InstallationID string `json:"installation_id" validate:"required" description:"GitHub App installation ID" example:"12345678"`
+	ConnectorID    string `json:"connector_id,omitempty" description:"Connector ID to update. If provided, updates this specific connector" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 // MessageResponse is a generic response with just status and message

--- a/api/internal/features/healthcheck/types/init.go
+++ b/api/internal/features/healthcheck/types/init.go
@@ -8,52 +8,52 @@ import (
 
 // CreateHealthCheckRequest represents a request to create a health check
 type CreateHealthCheckRequest struct {
-	ApplicationID    string            `json:"application_id" validate:"required,uuid"`
-	Endpoint         string            `json:"endpoint"`
-	Method           string            `json:"method"`
-	ExpectedStatus   []int             `json:"expected_status_codes,omitempty"`
-	TimeoutSeconds   int               `json:"timeout_seconds,omitempty"`
-	IntervalSeconds  int               `json:"interval_seconds,omitempty"`
-	FailureThreshold int               `json:"failure_threshold,omitempty"`
-	SuccessThreshold int               `json:"success_threshold,omitempty"`
-	Headers          map[string]string `json:"headers,omitempty"`
-	Body             string            `json:"body,omitempty"`
-	RetentionDays    int               `json:"retention_days,omitempty"`
+	ApplicationID    string            `json:"application_id" validate:"required,uuid" description:"ID of the application to monitor" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Endpoint         string            `json:"endpoint" description:"Health check endpoint path or URL. Defaults to /" example:"/health"`
+	Method           string            `json:"method" description:"HTTP method to use. Must be GET, POST, or HEAD. Defaults to GET" example:"GET"`
+	ExpectedStatus   []int             `json:"expected_status_codes,omitempty" description:"Expected HTTP status codes. Defaults to [200]"`
+	TimeoutSeconds   int               `json:"timeout_seconds,omitempty" validate:"omitempty,min=5,max=120" description:"Request timeout in seconds (5-120). Defaults to 30" example:"30"`
+	IntervalSeconds  int               `json:"interval_seconds,omitempty" validate:"omitempty,min=30,max=3600" description:"Check interval in seconds (30-3600). Defaults to 60" example:"60"`
+	FailureThreshold int               `json:"failure_threshold,omitempty" validate:"omitempty,min=1,max=10" description:"Consecutive failures before marking unhealthy (1-10). Defaults to 3" example:"3"`
+	SuccessThreshold int               `json:"success_threshold,omitempty" validate:"omitempty,min=1,max=10" description:"Consecutive successes before marking healthy (1-10). Defaults to 1" example:"1"`
+	Headers          map[string]string `json:"headers,omitempty" description:"Custom HTTP headers to include in health check requests"`
+	Body             string            `json:"body,omitempty" description:"Request body to send with health check requests"`
+	RetentionDays    int               `json:"retention_days,omitempty" validate:"omitempty,min=1,max=365" description:"Number of days to retain health check results (1-365). Defaults to 30" example:"30"`
 }
 
 // UpdateHealthCheckRequest represents a request to update a health check
 type UpdateHealthCheckRequest struct {
-	ApplicationID    string            `json:"application_id" validate:"required,uuid"`
-	Endpoint         string            `json:"endpoint,omitempty"`
-	Method           string            `json:"method,omitempty"`
-	ExpectedStatus   []int             `json:"expected_status_codes,omitempty"`
-	TimeoutSeconds   int               `json:"timeout_seconds,omitempty"`
-	IntervalSeconds  int               `json:"interval_seconds,omitempty"`
-	FailureThreshold int               `json:"failure_threshold,omitempty"`
-	SuccessThreshold int               `json:"success_threshold,omitempty"`
-	Headers          map[string]string `json:"headers,omitempty"`
-	Body             string            `json:"body,omitempty"`
-	RetentionDays    int               `json:"retention_days,omitempty"`
+	ApplicationID    string            `json:"application_id" validate:"required,uuid" description:"ID of the application to update health check for" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Endpoint         string            `json:"endpoint,omitempty" description:"Health check endpoint path or URL. Must start with /, http://, or https://" example:"/health"`
+	Method           string            `json:"method,omitempty" description:"HTTP method to use. Must be GET, POST, or HEAD" example:"GET"`
+	ExpectedStatus   []int             `json:"expected_status_codes,omitempty" description:"Expected HTTP status codes"`
+	TimeoutSeconds   int               `json:"timeout_seconds,omitempty" validate:"omitempty,min=5,max=120" description:"Request timeout in seconds (5-120)" example:"30"`
+	IntervalSeconds  int               `json:"interval_seconds,omitempty" validate:"omitempty,min=30,max=3600" description:"Check interval in seconds (30-3600)" example:"60"`
+	FailureThreshold int               `json:"failure_threshold,omitempty" validate:"omitempty,min=1,max=10" description:"Consecutive failures before marking unhealthy (1-10)" example:"3"`
+	SuccessThreshold int               `json:"success_threshold,omitempty" validate:"omitempty,min=1,max=10" description:"Consecutive successes before marking healthy (1-10)" example:"1"`
+	Headers          map[string]string `json:"headers,omitempty" description:"Custom HTTP headers to include in health check requests"`
+	Body             string            `json:"body,omitempty" description:"Request body to send with health check requests"`
+	RetentionDays    int               `json:"retention_days,omitempty" validate:"omitempty,min=1,max=365" description:"Number of days to retain health check results (1-365)" example:"30"`
 }
 
 // ToggleHealthCheckRequest represents a request to enable/disable a health check
 type ToggleHealthCheckRequest struct {
-	ApplicationID string `json:"application_id" validate:"required,uuid"`
-	Enabled       bool   `json:"enabled"`
+	ApplicationID string `json:"application_id" validate:"required,uuid" description:"ID of the application to toggle health check for" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Enabled       bool   `json:"enabled" description:"Whether the health check should be enabled"`
 }
 
 // GetHealthCheckResultsRequest represents a request to get health check results
 type GetHealthCheckResultsRequest struct {
-	ApplicationID string `json:"application_id" validate:"required,uuid"`
-	Limit         int    `json:"limit,omitempty"`
-	StartTime     string `json:"start_time,omitempty"`
-	EndTime       string `json:"end_time,omitempty"`
+	ApplicationID string `json:"application_id" validate:"required,uuid" description:"ID of the application to get results for" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Limit         int    `json:"limit,omitempty" validate:"omitempty,min=0,max=1000" description:"Maximum number of results to return (0-1000). Defaults to 100" example:"100"`
+	StartTime     string `json:"start_time,omitempty" description:"Filter results after this time (RFC 3339 format)" example:"2024-01-01T00:00:00Z"`
+	EndTime       string `json:"end_time,omitempty" description:"Filter results before this time (RFC 3339 format)" example:"2024-12-31T23:59:59Z"`
 }
 
 // GetHealthCheckStatsRequest represents a request to get health check statistics
 type GetHealthCheckStatsRequest struct {
-	ApplicationID string `json:"application_id" validate:"required,uuid"`
-	Period        string `json:"period,omitempty"`
+	ApplicationID string `json:"application_id" validate:"required,uuid" description:"ID of the application to get statistics for" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Period        string `json:"period,omitempty" description:"Time period for statistics aggregation" example:"24h"`
 }
 
 // Domain-specific errors

--- a/api/internal/features/mcp/validation/validator.go
+++ b/api/internal/features/mcp/validation/validator.go
@@ -59,25 +59,25 @@ func isPrivate(ip net.IP) bool {
 }
 
 type CreateServerRequest struct {
-	ProviderID  string            `json:"provider_id"`
-	Name        string            `json:"name"`
-	Credentials map[string]string `json:"credentials"`
-	CustomURL   string            `json:"custom_url,omitempty"`
-	Enabled     bool              `json:"enabled"`
+	ProviderID  string            `json:"provider_id" validate:"required" description:"MCP provider identifier (e.g. 'openai', 'anthropic', 'custom')" example:"openai"`
+	Name        string            `json:"name" validate:"required" description:"Display name for this MCP server" example:"My OpenAI Server"`
+	Credentials map[string]string `json:"credentials" description:"Provider-specific credential key-value pairs"`
+	CustomURL   string            `json:"custom_url,omitempty" description:"Custom server URL. Required when provider_id is 'custom'. Must use HTTPS"`
+	Enabled     bool              `json:"enabled" description:"Whether the server is active"`
 }
 
 type UpdateServerRequest struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	Credentials map[string]string `json:"credentials"`
-	CustomURL   string            `json:"custom_url,omitempty"`
-	Enabled     bool              `json:"enabled"`
+	ID          string            `json:"id" validate:"required" description:"MCP server ID to update"`
+	Name        string            `json:"name" validate:"required" description:"Updated display name"`
+	Credentials map[string]string `json:"credentials" description:"Updated provider credentials"`
+	CustomURL   string            `json:"custom_url,omitempty" description:"Updated custom server URL. Must use HTTPS if provided"`
+	Enabled     bool              `json:"enabled" description:"Whether the server is active"`
 }
 
 type TestServerRequest struct {
-	ProviderID  string            `json:"provider_id"`
-	Credentials map[string]string `json:"credentials"`
-	CustomURL   string            `json:"custom_url,omitempty"`
+	ProviderID  string            `json:"provider_id" validate:"required" description:"MCP provider to test connection for"`
+	Credentials map[string]string `json:"credentials" description:"Credentials to use for the test"`
+	CustomURL   string            `json:"custom_url,omitempty" description:"Custom URL to test. Required when provider_id is 'custom'"`
 }
 
 func ValidateCreateRequest(req *CreateServerRequest) error {
@@ -122,9 +122,9 @@ func ValidateUpdateRequest(req *UpdateServerRequest) error {
 }
 
 type CallToolRequest struct {
-	ServerID  string         `json:"server_id"`
-	ToolName  string         `json:"tool_name"`
-	Arguments map[string]any `json:"arguments,omitempty"`
+	ServerID  string         `json:"server_id" validate:"required" description:"ID of the MCP server to call the tool on"`
+	ToolName  string         `json:"tool_name" validate:"required" description:"Name of the MCP tool to invoke" example:"search"`
+	Arguments map[string]any `json:"arguments,omitempty" description:"Tool-specific arguments as key-value pairs"`
 }
 
 func ValidateCallToolRequest(req *CallToolRequest) error {

--- a/api/internal/features/notification/controller/get_preferences.go
+++ b/api/internal/features/notification/controller/get_preferences.go
@@ -22,7 +22,6 @@ func (c *NotificationController) GetPreferences(f fuego.ContextNoBody) (*types.P
 	preferences, err := c.service.GetPreferences(user.ID)
 	if err != nil {
 		c.logger.Log(logger.Error, err.Error(), "")
-		utils.SendErrorResponse(w, err.Error(), http.StatusInternalServerError)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/types.go
+++ b/api/internal/features/notification/types.go
@@ -10,13 +10,13 @@ import (
 )
 
 type CreateSMTPConfigRequest struct {
-	Host           string    `json:"host"`
-	Port           int       `json:"port"`
-	Username       string    `json:"username"`
-	Password       string    `json:"password"`
-	FromName       string    `json:"from_name"`
-	FromEmail      string    `json:"from_email"`
-	OrganizationID uuid.UUID `json:"organization_id"`
+	Host           string    `json:"host" validate:"required" description:"SMTP server hostname" example:"smtp.gmail.com"`
+	Port           int       `json:"port" validate:"required,gt=0" description:"SMTP server port" example:"587"`
+	Username       string    `json:"username" validate:"required" description:"SMTP authentication username" example:"user@gmail.com"`
+	Password       string    `json:"password" validate:"required" description:"SMTP authentication password" example:"app-password"`
+	FromName       string    `json:"from_name" description:"Display name for outgoing emails" example:"Nixopus"`
+	FromEmail      string    `json:"from_email" description:"Sender email address for outgoing emails" example:"noreply@example.com"`
+	OrganizationID uuid.UUID `json:"organization_id" validate:"required" description:"Organization this SMTP config belongs to" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 func (r CreateSMTPConfigRequest) String() string {
@@ -25,22 +25,22 @@ func (r CreateSMTPConfigRequest) String() string {
 }
 
 type UpdateSMTPConfigRequest struct {
-	ID             uuid.UUID `json:"id"`
-	Host           *string   `json:"host,omitempty"`
-	Port           *int      `json:"port,omitempty"`
-	Username       *string   `json:"username,omitempty"`
-	Password       *string   `json:"password,omitempty"`
-	FromName       *string   `json:"from_name,omitempty"`
-	FromEmail      *string   `json:"from_email,omitempty"`
-	OrganizationID uuid.UUID `json:"organization_id"`
+	ID             uuid.UUID `json:"id" validate:"required" description:"SMTP configuration ID to update" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Host           *string   `json:"host,omitempty" description:"SMTP server hostname" example:"smtp.gmail.com"`
+	Port           *int      `json:"port,omitempty" description:"SMTP server port" example:"587"`
+	Username       *string   `json:"username,omitempty" description:"SMTP authentication username" example:"user@gmail.com"`
+	Password       *string   `json:"password,omitempty" description:"SMTP authentication password" example:"app-password"`
+	FromName       *string   `json:"from_name,omitempty" description:"Display name for outgoing emails" example:"Nixopus"`
+	FromEmail      *string   `json:"from_email,omitempty" description:"Sender email address for outgoing emails" example:"noreply@example.com"`
+	OrganizationID uuid.UUID `json:"organization_id" validate:"required" description:"Organization this SMTP config belongs to" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type DeleteSMTPConfigRequest struct {
-	ID uuid.UUID `json:"id"`
+	ID uuid.UUID `json:"id" validate:"required" description:"SMTP configuration ID to delete" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 type GetSMTPConfigRequest struct {
-	ID uuid.UUID `json:"id"`
+	ID uuid.UUID `json:"id" validate:"required" description:"SMTP configuration ID to retrieve" example:"550e8400-e29b-41d4-a716-446655440000"`
 }
 
 func NewSMTPConfig(c *CreateSMTPConfigRequest, userID uuid.UUID) *shared_types.SMTPConfigs {
@@ -71,22 +71,30 @@ const (
 	UpdateCategory   Category = "update"
 )
 
+func (Category) OpenAPISchemaType() []string { return []string{"string"} }
+func (Category) OpenAPISchemaEnum() []any {
+	return []any{string(ActivityCategory), string(SecurityCategory), string(UpdateCategory)}
+}
+func (Category) Description() string {
+	return "Notification category: activity, security, or update."
+}
+
 type PreferenceType struct {
-	ID          string `json:"id" validate:"required"`
-	Label       string `json:"label" validate:"required"`
-	Description string `json:"description" validate:"required"`
-	Enabled     bool   `json:"enabled"`
+	ID          string `json:"id" validate:"required" description:"Preference type identifier" example:"deployment_success"`
+	Label       string `json:"label" validate:"required" description:"Display label for the preference" example:"Deployment Success"`
+	Description string `json:"description" validate:"required" description:"Description of the preference type" example:"Notifies when a deployment succeeds"`
+	Enabled     bool   `json:"enabled" description:"Whether this preference is enabled" example:"true"`
 }
 
 type CategoryPreferences struct {
-	Category    Category         `json:"category" validate:"required"`
-	Preferences []PreferenceType `json:"preferences" validate:"required"`
+	Category    Category         `json:"category" validate:"required" description:"Notification category" example:"activity"`
+	Preferences []PreferenceType `json:"preferences" validate:"required" description:"List of preference types in this category"`
 }
 
 type UpdatePreferenceRequest struct {
-	Category string `json:"category" validate:"required,oneof=activity security update"`
-	Type     string `json:"type" validate:"required"`
-	Enabled  bool   `json:"enabled"`
+	Category string `json:"category" validate:"required,oneof=activity security update" description:"Notification category" example:"activity"`
+	Type     string `json:"type" validate:"required" description:"Preference type identifier" example:"deployment_success"`
+	Enabled  bool   `json:"enabled" description:"Whether this notification preference is enabled" example:"true"`
 }
 
 type GetPreferencesResponse struct {
@@ -104,30 +112,30 @@ type PreferenceItem struct {
 }
 
 type CreateWebhookConfigRequest struct {
-	Type       string `json:"type" validate:"required,oneof=slack discord"`
-	WebhookURL string `json:"webhook_url"`
+	Type       string `json:"type" validate:"required,oneof=slack discord" description:"Webhook integration type" example:"slack"`
+	WebhookURL string `json:"webhook_url" validate:"required" description:"Webhook URL for the integration" example:"https://hooks.slack.com/services/..."`
 }
 
 type UpdateWebhookConfigRequest struct {
-	Type       string  `json:"type" validate:"required,oneof=slack discord"`
-	WebhookURL *string `json:"webhook_url,omitempty"`
-	IsActive   *bool   `json:"is_active,omitempty"`
+	Type       string  `json:"type" validate:"required,oneof=slack discord" description:"Webhook integration type" example:"slack"`
+	WebhookURL *string `json:"webhook_url,omitempty" description:"Updated webhook URL" example:"https://hooks.slack.com/services/..."`
+	IsActive   *bool   `json:"is_active,omitempty" description:"Whether the webhook integration is active" example:"true"`
 }
 
 type DeleteWebhookConfigRequest struct {
-	Type string `json:"type" validate:"required,oneof=slack discord"`
+	Type string `json:"type" validate:"required,oneof=slack discord" description:"Webhook integration type to delete" example:"slack"`
 }
 
 type GetWebhookConfigRequest struct {
-	Type string `json:"type" validate:"required,oneof=slack discord"`
+	Type string `json:"type" validate:"required,oneof=slack discord" description:"Webhook integration type to retrieve" example:"slack"`
 }
 
 type SendNotificationRequest struct {
-	Channel  string            `json:"channel" validate:"required,oneof=slack discord email"`
-	Message  string            `json:"message" validate:"required"`
-	Subject  string            `json:"subject,omitempty"`
-	To       string            `json:"to,omitempty"`
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Channel  string            `json:"channel" validate:"required,oneof=slack discord email" description:"Notification delivery channel" example:"email"`
+	Message  string            `json:"message" validate:"required" description:"Notification message body" example:"Deployment completed successfully"`
+	Subject  string            `json:"subject,omitempty" description:"Email subject line (only for email channel)" example:"Deployment Update"`
+	To       string            `json:"to,omitempty" description:"Recipient email address (only for email channel)" example:"user@example.com"`
+	Metadata map[string]string `json:"metadata,omitempty" description:"Additional key-value metadata for the notification"`
 }
 
 type SendNotificationResponse struct {

--- a/api/internal/features/telemetry/types/init.go
+++ b/api/internal/features/telemetry/types/init.go
@@ -23,12 +23,12 @@ type CliInstallation struct {
 }
 
 type TrackInstallRequest struct {
-	EventType string `json:"event_type"`
-	OS        string `json:"os"`
-	Arch      string `json:"arch"`
-	Version   string `json:"version"`
-	Duration  int    `json:"duration"`
-	Error     string `json:"error,omitempty"`
+	EventType string `json:"event_type" validate:"required" description:"Type of installation event" example:"install_success"`
+	OS        string `json:"os" validate:"required" description:"Operating system identifier. Valid values: ubuntu, debian, centos, fedora, rhel, alpine, arch, opensuse, sles, amzn, ol, rocky, almalinux, raspbian, pop, mint, manjaro, kali, nixos, gentoo, void, slackware, clear-linux-os, unknown"`
+	Arch      string `json:"arch" validate:"required" description:"CPU architecture. Valid values: amd64, arm64, unknown"`
+	Version   string `json:"version" validate:"required" description:"Semantic version string (e.g. 1.2.3 or 1.2.3-beta.1)" example:"1.0.0"`
+	Duration  int    `json:"duration" validate:"min=0,max=7200" description:"Installation duration in seconds" example:"120"`
+	Error     string `json:"error,omitempty" validate:"max=200" description:"Error message if installation failed"`
 }
 
 type TrackInstallResponse struct {

--- a/api/internal/features/user/controller/avatar.go
+++ b/api/internal/features/user/controller/avatar.go
@@ -22,9 +22,10 @@ func (u *UserController) UpdateAvatar(s fuego.ContextWithBody[types.UpdateAvatar
 
 	w, r := s.Response(), s.Request()
 
-	if !u.parseAndValidate(w, r, &req) {
+	if err := u.parseAndValidate(w, r, &req); err != nil {
 		return nil, fuego.BadRequestError{
-			Detail: "validation failed",
+			Detail: err.Error(),
+			Err:    err,
 		}
 	}
 

--- a/api/internal/features/user/controller/init.go
+++ b/api/internal/features/user/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	cache "github.com/nixopus/nixopus/api/internal/cache"
@@ -36,34 +37,17 @@ func NewUserController(
 	}
 }
 
-// parseAndValidate parses and validates the request body.
-//
-// This method attempts to parse the request body into the provided 'req' interface
-// using the controller's validator. If parsing fails, an error response is sent
-// and the method returns false. It also validates the parsed request object and
-// returns false if validation fails. If both operations are successful, it returns true.
-//
-// Parameters:
-//
-//	w - the HTTP response writer to send error responses.
-//	r - the HTTP request containing the body to parse.
-//	req - the interface to populate with the parsed request body.
-//
-// Returns:
-//
-//	bool - true if parsing and validation succeed, false otherwise.
-func (c *UserController) parseAndValidate(w http.ResponseWriter, r *http.Request, req interface{}) bool {
+func (c *UserController) parseAndValidate(w http.ResponseWriter, r *http.Request, req interface{}) error {
 	user := utils.GetUser(w, r)
 
 	if user == nil {
-		return false
+		return errors.New("authentication required")
 	}
 
 	if err := c.validator.ValidateRequest(req, *user); err != nil {
 		c.logger.Log(logger.Error, err.Error(), err.Error())
-		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
-		return false
+		return err
 	}
 
-	return true
+	return nil
 }

--- a/api/internal/features/user/controller/settings.go
+++ b/api/internal/features/user/controller/settings.go
@@ -10,8 +10,8 @@ import (
 )
 
 type UpdateFontRequest struct {
-	FontFamily string `json:"font_family"`
-	FontSize   int    `json:"font_size"`
+	FontFamily string `json:"font_family" validate:"required" description:"Font family name for the editor" example:"JetBrains Mono"`
+	FontSize   int    `json:"font_size" validate:"required,min=8,max=32" description:"Font size in pixels" example:"14"`
 }
 
 func (c *UserController) UpdateFont(s fuego.ContextWithBody[UpdateFontRequest]) (*types.UserSettingsResponse, error) {
@@ -50,7 +50,7 @@ func (c *UserController) UpdateFont(s fuego.ContextWithBody[UpdateFontRequest]) 
 }
 
 type UpdateThemeRequest struct {
-	Theme string `json:"theme"`
+	Theme string `json:"theme" validate:"required" description:"UI theme name" example:"dark"`
 }
 
 func (c *UserController) UpdateTheme(s fuego.ContextWithBody[UpdateThemeRequest]) (*types.UserSettingsResponse, error) {
@@ -89,7 +89,7 @@ func (c *UserController) UpdateTheme(s fuego.ContextWithBody[UpdateThemeRequest]
 }
 
 type UpdateLanguageRequest struct {
-	Language string `json:"language"`
+	Language string `json:"language" validate:"required" description:"Preferred language code" example:"en"`
 }
 
 func (c *UserController) UpdateLanguage(s fuego.ContextWithBody[UpdateLanguageRequest]) (*types.UserSettingsResponse, error) {
@@ -128,7 +128,7 @@ func (c *UserController) UpdateLanguage(s fuego.ContextWithBody[UpdateLanguageRe
 }
 
 type UpdateAutoUpdateRequest struct {
-	AutoUpdate bool `json:"auto_update"`
+	AutoUpdate bool `json:"auto_update" description:"Whether to automatically apply updates" example:"true"`
 }
 
 func (c *UserController) UpdateAutoUpdate(s fuego.ContextWithBody[UpdateAutoUpdateRequest]) (*types.UserSettingsResponse, error) {

--- a/api/internal/features/user/controller/update_username.go
+++ b/api/internal/features/user/controller/update_username.go
@@ -22,9 +22,10 @@ func (u *UserController) UpdateUserName(s fuego.ContextWithBody[types.UpdateUser
 
 	w, r := s.Response(), s.Request()
 
-	if !u.parseAndValidate(w, r, &req) {
+	if err := u.parseAndValidate(w, r, &req); err != nil {
 		return nil, fuego.BadRequestError{
-			Detail: "validation failed",
+			Detail: err.Error(),
+			Err:    err,
 		}
 	}
 

--- a/api/internal/features/user/types/user.go
+++ b/api/internal/features/user/types/user.go
@@ -11,11 +11,11 @@ type UserOrganizationsResponse struct {
 }
 
 type UpdateUserNameRequest struct {
-	Name string `json:"name"`
+	Name string `json:"name" validate:"required,min=3,max=50" description:"New username. Must be 3-50 characters with no spaces" example:"johndoe"`
 }
 
 type UpdateAvatarRequest struct {
-	AvatarData string `json:"avatarData"`
+	AvatarData string `json:"avatarData" validate:"required" description:"Base64-encoded image data URI. Must start with data:image/{jpeg,jpg,png,gif};base64," example:"data:image/png;base64,iVBORw0KGgo..."`
 }
 
 type AvatarResponse struct {

--- a/api/internal/middleware/rate_limiter.go
+++ b/api/internal/middleware/rate_limiter.go
@@ -28,8 +28,8 @@ type client struct {
 }
 
 type rateLimitResponse struct {
-	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 func StartCleanupTask() {
@@ -103,12 +103,15 @@ func RateLimiter(next http.Handler) http.Handler {
 		if !allowed {
 			clientsMtx.Unlock()
 			fmt.Printf("Rate limit exceeded for IP: %s\n", ip)
-			message := rateLimitResponse{
-				Status:  "Request Failed",
-				Message: "The API is at capacity, try again later.",
-			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-RateLimit-Limit", "10")
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusTooManyRequests)
-			json.NewEncoder(w).Encode(&message)
+			json.NewEncoder(w).Encode(&rateLimitResponse{
+				Code:    "rate_limited",
+				Message: "The API is at capacity, try again later.",
+			})
 			return
 		}
 
@@ -165,12 +168,15 @@ func NewRateLimiterWithConfig(rps float64, burst int) func(http.Handler) http.Ha
 
 			if !allowed {
 				rlMtx.Unlock()
-				msg := rateLimitResponse{
-					Status:  "Request Failed",
-					Message: "Too many requests, try again later.",
-				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", burst))
+				w.Header().Set("X-RateLimit-Remaining", "0")
+				w.Header().Set("Retry-After", "1")
 				w.WriteHeader(http.StatusTooManyRequests)
-				json.NewEncoder(w).Encode(&msg)
+				json.NewEncoder(w).Encode(&rateLimitResponse{
+					Code:    "rate_limited",
+					Message: "Too many requests, try again later.",
+				})
 				return
 			}
 

--- a/api/internal/middleware/recovery.go
+++ b/api/internal/middleware/recovery.go
@@ -10,8 +10,9 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 		defer func() {
 			if err := recover(); err != nil {
 				log.Printf("Panic recovered: %v", err)
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(`{"status":"error","message":"Internal server error"}`))
+				w.Write([]byte(`{"code":"internal_error","message":"Internal server error"}`))
 			}
 		}()
 

--- a/api/internal/middleware/request_id.go
+++ b/api/internal/middleware/request_id.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+const RequestIDHeader = "X-Request-ID"
+
+func RequestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.Header.Get(RequestIDHeader)
+		if requestID == "" {
+			requestID = generateRequestID()
+		}
+		w.Header().Set(RequestIDHeader, requestID)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func generateRequestID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/api/internal/openapi/postprocess.go
+++ b/api/internal/openapi/postprocess.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-fuego/fuego"
 )
 
 // specMarshalJSON is the JSON encoder for PostProcessSpec; override in tests to force errors.
@@ -79,6 +82,7 @@ func PostProcessSpec(specPath string) error {
 			addRequestExamples(op, schemas)
 			standardizeErrorResponses(op)
 			addSuccessExamples(op, method, schemas)
+			cleanTags(op)
 		}
 	}
 
@@ -89,6 +93,60 @@ func PostProcessSpec(specPath string) error {
 		return err
 	}
 	return os.WriteFile(specPath, encoded, 0o644)
+}
+
+var allowedTags = map[string]bool{
+	"Audit": true, "Auth": true, "Containers": true, "Deploy": true,
+	"Domains": true, "Extensions": true, "Feature Flags": true,
+	"File Manager": true, "GitHub Connector": true, "Health": true,
+	"Health Checks": true, "MCP": true, "Machines": true,
+	"Notifications": true, "Telemetry": true, "Trial": true,
+	"Update": true, "User": true, "Webhooks": true,
+}
+
+// CleanSpecTags strips auto-generated tags from the in-memory OpenAPI spec
+// so only explicitly allowed tags remain in the live Swagger UI.
+func CleanSpecTags(oa *fuego.OpenAPI) {
+	desc := oa.Description()
+	if desc == nil || desc.Paths == nil {
+		return
+	}
+	for _, pathItem := range desc.Paths.Map() {
+		for _, op := range []*openapi3.Operation{
+			pathItem.Get, pathItem.Post, pathItem.Put, pathItem.Patch,
+			pathItem.Delete, pathItem.Head, pathItem.Options, pathItem.Trace,
+		} {
+			if op == nil {
+				continue
+			}
+			var kept []string
+			for _, t := range op.Tags {
+				if allowedTags[t] {
+					kept = append(kept, t)
+				}
+			}
+			op.Tags = kept
+		}
+	}
+}
+
+func cleanTags(op map[string]any) {
+	rawTags, _ := op["tags"].([]any)
+	if len(rawTags) == 0 {
+		return
+	}
+	var kept []any
+	for _, t := range rawTags {
+		s, _ := t.(string)
+		if allowedTags[s] {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) == 0 {
+		delete(op, "tags")
+	} else {
+		op["tags"] = kept
+	}
 }
 
 func normalizeOperationID(op map[string]any, method, routePath string, seen map[string]int) {

--- a/api/internal/routes/deploy.go
+++ b/api/internal/routes/deploy.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
 	deploy "github.com/nixopus/nixopus/api/internal/features/deploy/controller"
 )
 
@@ -17,10 +18,10 @@ func (router *Router) RegisterDeployRoutes(deployGroup *fuego.Server, deployCont
 		fuego.OptionQuery("sort_by", "Sort field"),
 		fuego.OptionQuery("sort_direction", "Sort direction"),
 	)
-	deployApplicationGroup := fuego.Group(deployGroup, "/application")
+	deployApplicationGroup := fuego.Group(deployGroup, "/application", option.Tags("Deploy"))
 	router.RegisterDeployApplicationRoutes(deployApplicationGroup, deployController)
 
-	artifactGroup := fuego.Group(deployGroup, "/artifacts")
+	artifactGroup := fuego.Group(deployGroup, "/artifacts", option.Tags("Deploy"))
 	router.RegisterArtifactRoutes(artifactGroup, deployController)
 }
 
@@ -31,18 +32,21 @@ func (router *Router) RegisterDeployApplicationRoutes(applicationGroup *fuego.Se
 		"",
 		deployController.HandleDeploy,
 		fuego.OptionSummary("Deploy application"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Post(
 		applicationGroup,
 		"/template",
 		deployController.HandleTemplateDeploy,
 		fuego.OptionSummary("Deploy application from template"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Post(
 		applicationGroup,
 		"/project",
 		deployController.HandleCreateProject,
 		fuego.OptionSummary("Create project"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Post(
 		applicationGroup,
@@ -55,12 +59,14 @@ func (router *Router) RegisterDeployApplicationRoutes(applicationGroup *fuego.Se
 		"/project/duplicate",
 		deployController.HandleDuplicateProject,
 		fuego.OptionSummary("Duplicate project"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Post(
 		applicationGroup,
 		"/project/add-to-family",
 		deployController.HandleAddApplicationToFamily,
 		fuego.OptionSummary("Add project to family"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Get(
 		applicationGroup,
@@ -156,7 +162,7 @@ func (router *Router) RegisterDeployApplicationRoutes(applicationGroup *fuego.Se
 		fuego.OptionSummary("List application deployments"),
 		fuego.OptionQuery("id", "Application ID", fuego.ParamRequired()),
 		fuego.OptionQueryInt("page", "Page number"),
-		fuego.OptionQueryInt("limit", "Page size"),
+		fuego.OptionQueryInt("page_size", "Page size"),
 	)
 	fuego.Put(
 		applicationGroup,
@@ -170,6 +176,7 @@ func (router *Router) RegisterDeployApplicationRoutes(applicationGroup *fuego.Se
 		"/domains",
 		deployController.AddApplicationDomain,
 		fuego.OptionSummary("Add application domain"),
+		fuego.OptionDefaultStatusCode(201),
 		fuego.OptionQuery("id", "Application ID", fuego.ParamRequired()),
 	)
 	fuego.Delete(

--- a/api/internal/routes/domain.go
+++ b/api/internal/routes/domain.go
@@ -25,6 +25,7 @@ func (router *Router) RegisterDomainRoutes(domainGroup *fuego.Server, domainCont
 		"/custom",
 		domainController.HandleAddCustomDomain,
 		fuego.OptionSummary("Add custom domain"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Delete(
 		domainGroup,

--- a/api/internal/routes/github_connector.go
+++ b/api/internal/routes/github_connector.go
@@ -7,7 +7,7 @@ import (
 
 // RegisterGithubConnectorRoutes registers GitHub connector routes
 func (router *Router) RegisterGithubConnectorRoutes(githubGroup *fuego.Server, githubConnectorController *githubConnector.GithubConnectorController) {
-	fuego.Post(githubGroup, "", githubConnectorController.CreateGithubConnector, fuego.OptionSummary("Create GitHub connector"))
+	fuego.Post(githubGroup, "", githubConnectorController.CreateGithubConnector, fuego.OptionSummary("Create GitHub connector"), fuego.OptionDefaultStatusCode(201))
 	fuego.Put(githubGroup, "", githubConnectorController.UpdateGithubConnectorRequest, fuego.OptionSummary("Update GitHub connector"))
 	fuego.Delete(githubGroup, "", githubConnectorController.DeleteGithubConnector, fuego.OptionSummary("Delete GitHub connector"))
 	fuego.Get(githubGroup, "/all", githubConnectorController.GetGithubConnectors, fuego.OptionSummary("List GitHub connectors"))

--- a/api/internal/routes/healthcheck.go
+++ b/api/internal/routes/healthcheck.go
@@ -9,7 +9,7 @@ func (router *Router) RegisterHealthCheckRoutes(
 	group *fuego.Server,
 	controller *healthcheckController.HealthCheckController,
 ) {
-	fuego.Post(group, "", controller.CreateHealthCheck, fuego.OptionSummary("Create health check"))
+	fuego.Post(group, "", controller.CreateHealthCheck, fuego.OptionSummary("Create health check"), fuego.OptionDefaultStatusCode(201))
 	fuego.Get(
 		group,
 		"",

--- a/api/internal/routes/machine.go
+++ b/api/internal/routes/machine.go
@@ -141,7 +141,8 @@ func (router *Router) RegisterMachineRoutes(machineGroup *fuego.Server, machineC
 
 func (router *Router) RegisterMachineRegistrationRoutes(regGroup *fuego.Server, machineController *machine_controller.MachineController) {
 	fuego.Post(regGroup, "", machineController.CreateMachine,
-		fuego.OptionSummary("Register a BYOS machine"))
+		fuego.OptionSummary("Register a BYOS machine"),
+		fuego.OptionDefaultStatusCode(201))
 	fuego.Post(regGroup, "/{id}/verify", machineController.VerifyMachine,
 		fuego.OptionSummary("Verify SSH connection"))
 	fuego.Patch(regGroup, "/{id}/rename", machineController.RenameMachine,

--- a/api/internal/routes/mcp.go
+++ b/api/internal/routes/mcp.go
@@ -2,27 +2,28 @@ package routes
 
 import (
 	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
 	mcpController "github.com/nixopus/nixopus/api/internal/features/mcp/controller"
 )
 
 // RegisterMCPPublicRoutes registers MCP routes that don't require authentication (e.g. provider icons).
 func (router *Router) RegisterMCPPublicRoutes(publicServer *fuego.Server, controller *mcpController.MCPController) {
-	iconGroup := fuego.Group(publicServer, "/catalog")
+	iconGroup := fuego.Group(publicServer, "/catalog", option.Tags("MCP"))
 	fuego.Get(iconGroup, "/{provider_id}/icon", controller.GetProviderIcon, fuego.OptionSummary("Get provider icon"))
 }
 
 func (router *Router) RegisterMCPRoutes(mcpGroup *fuego.Server, controller *mcpController.MCPController) {
-	catalogGroup := fuego.Group(mcpGroup, "/catalog")
+	catalogGroup := fuego.Group(mcpGroup, "/catalog", option.Tags("MCP"))
 	fuego.Get(catalogGroup, "", controller.ListCatalog, fuego.OptionSummary("List MCP provider catalog"))
 
-	serversGroup := fuego.Group(mcpGroup, "/servers")
+	serversGroup := fuego.Group(mcpGroup, "/servers", option.Tags("MCP"))
 	fuego.Get(serversGroup, "", controller.ListServers, fuego.OptionSummary("List org MCP servers"))
-	fuego.Post(serversGroup, "", controller.AddServer, fuego.OptionSummary("Add MCP server"))
+	fuego.Post(serversGroup, "", controller.AddServer, fuego.OptionSummary("Add MCP server"), fuego.OptionDefaultStatusCode(201))
 	fuego.Put(serversGroup, "/{id}", controller.UpdateServer, fuego.OptionSummary("Update MCP server"))
 	fuego.Delete(serversGroup, "", controller.DeleteServer, fuego.OptionSummary("Delete MCP server"))
 	fuego.Post(serversGroup, "/test", controller.TestServer, fuego.OptionSummary("Test MCP server connection"))
 
-	internalGroup := fuego.Group(mcpGroup, "/internal")
+	internalGroup := fuego.Group(mcpGroup, "/internal", option.Tags("MCP"))
 	fuego.Get(internalGroup, "/servers", controller.ListServersInternal, fuego.OptionSummary("Agent: list enabled servers with credentials"))
 	fuego.Get(internalGroup, "/tools", controller.ListTools, fuego.OptionSummary("Agent: discover tools from all enabled MCP servers"))
 	fuego.Post(internalGroup, "/tools/call", controller.CallTool, fuego.OptionSummary("Agent: invoke a tool on an MCP server"))

--- a/api/internal/routes/notification.go
+++ b/api/internal/routes/notification.go
@@ -2,17 +2,19 @@ package routes
 
 import (
 	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
 	notificationController "github.com/nixopus/nixopus/api/internal/features/notification/controller"
 )
 
 // RegisterNotificationRoutes registers notification routes
 func (router *Router) RegisterNotificationRoutes(notificationGroup *fuego.Server, notificationController *notificationController.NotificationController) {
-	smtpGroup := fuego.Group(notificationGroup, "/smtp")
+	smtpGroup := fuego.Group(notificationGroup, "/smtp", option.Tags("Notifications"))
 	fuego.Post(
 		smtpGroup,
 		"",
 		notificationController.AddSmtp,
 		fuego.OptionSummary("Create SMTP config"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Get(
 		smtpGroup,
@@ -34,8 +36,8 @@ func (router *Router) RegisterNotificationRoutes(notificationGroup *fuego.Server
 		fuego.OptionSummary("Delete SMTP config"),
 	)
 
-	preferenceGroup := fuego.Group(notificationGroup, "/preferences")
-	fuego.Post(
+	preferenceGroup := fuego.Group(notificationGroup, "/preferences", option.Tags("Notifications"))
+	fuego.Patch(
 		preferenceGroup,
 		"",
 		notificationController.UpdatePreference,
@@ -48,12 +50,13 @@ func (router *Router) RegisterNotificationRoutes(notificationGroup *fuego.Server
 		fuego.OptionSummary("Get notification preferences"),
 	)
 
-	webhookGroup := fuego.Group(notificationGroup, "/webhook")
+	webhookGroup := fuego.Group(notificationGroup, "/webhook", option.Tags("Notifications"))
 	fuego.Post(
 		webhookGroup,
 		"",
 		notificationController.CreateWebhookConfig,
 		fuego.OptionSummary("Create webhook config"),
+		fuego.OptionDefaultStatusCode(201),
 	)
 	fuego.Get(
 		webhookGroup,

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
 	"github.com/joho/godotenv"
 	"github.com/nixopus/nixopus/api/internal/cache"
 	"github.com/nixopus/nixopus/api/internal/config"
@@ -111,8 +112,10 @@ func (router *Router) createServer(port string) *fuego.Server {
 			}),
 			fuego.WithOpenAPIGeneratorSchemaCustomizer(openapi.SchemaCustomizer),
 		),
+		fuego.WithoutAutoGroupTags(),
 		fuego.WithGlobalMiddlewares(
 			middleware.RecoveryMiddleware,
+			middleware.RequestIDMiddleware,
 			middleware.CorsMiddleware,
 			middleware.LoggingMiddleware,
 			api.VersionMiddleware,
@@ -221,15 +224,17 @@ func (router *Router) SetupRoutes() {
 			log.Printf("Warning: failed to post-process OpenAPI spec: %v", err)
 		}
 	}()
+
+	openapi.CleanSpecTags(server.OpenAPI)
 	server.Run()
 }
 
 // registerPublicRoutes registers routes that don't require authentication
 func (router *Router) registerPublicRoutes(server *fuego.Server, apiV1 api.Version, dispatcher *notification.Dispatcher, deployController *deploy.DeployController) {
-	healthGroup := fuego.Group(server, apiV1.Path+"/health")
+	healthGroup := fuego.Group(server, apiV1.Path+"/health", option.Tags("Health"))
 	router.RegisterHealthRoutes(healthGroup)
 
-	webhookGroup := fuego.Group(server, apiV1.Path+"/webhook")
+	webhookGroup := fuego.Group(server, apiV1.Path+"/webhook", option.Tags("Webhooks"))
 	fuego.Post(
 		webhookGroup,
 		"",
@@ -240,19 +245,19 @@ func (router *Router) registerPublicRoutes(server *fuego.Server, apiV1 api.Versi
 	router.RegisterWebSocketRoutes(server, deployController, router.schedulers.HealthCheck)
 
 	trailInternalController := machine_controller.NewTrailController(router.app.Store, router.app.Ctx, router.logger, router.cache)
-	trailInternalGroup := fuego.Group(server, apiV1.Path+"/trail")
+	trailInternalGroup := fuego.Group(server, apiV1.Path+"/trail", option.Tags("Trial"))
 	router.RegisterTrailInternalRoutes(trailInternalGroup, trailInternalController)
 
 	authController := router.createAuthController(dispatcher)
-	authGroup := fuego.Group(server, apiV1.Path+"/auth")
+	authGroup := fuego.Group(server, apiV1.Path+"/auth", option.Tags("Auth"))
 	router.RegisterAuthRoutes(authGroup, authController)
 
 	mcpPublicCtrl := mcpController.NewMCPController(router.app.Store, router.app.Ctx, router.logger)
-	mcpPublicGroup := fuego.Group(server, apiV1.Path+"/mcp")
+	mcpPublicGroup := fuego.Group(server, apiV1.Path+"/mcp", option.Tags("MCP"))
 	router.RegisterMCPPublicRoutes(mcpPublicGroup, mcpPublicCtrl)
 
 	telemetryCtrl := telemetry.NewTelemetryController(router.app.Store.DB, router.app.Ctx, router.logger)
-	telemetryGroup := fuego.Group(server, apiV1.Path+"/cli/telemetry")
+	telemetryGroup := fuego.Group(server, apiV1.Path+"/cli/telemetry", option.Tags("Telemetry"))
 	fuego.Use(telemetryGroup, middleware.NewRateLimiterWithConfig(0.01, 3))
 	router.RegisterTelemetryRoutes(telemetryGroup, telemetryCtrl)
 }
@@ -260,22 +265,22 @@ func (router *Router) registerPublicRoutes(server *fuego.Server, apiV1 api.Versi
 // registerProtectedRoutes registers routes that require authentication
 func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Version, dispatcher *notification.Dispatcher, deployController *deploy.DeployController) {
 	authController := router.createAuthController(dispatcher)
-	authProtectedGroup := fuego.Group(server, apiV1.Path+"/auth")
+	authProtectedGroup := fuego.Group(server, apiV1.Path+"/auth", option.Tags("Auth"))
 	router.applyMiddleware(authProtectedGroup, MiddlewareConfig{RBAC: false, Audit: false, ResourceName: "auth"})
 	router.RegisterAuthProtectedRoutes(authProtectedGroup, authController)
 
 	userController := user.NewUserController(router.app.Store, router.app.Ctx, router.logger, router.cache)
-	userGroup := fuego.Group(server, apiV1.Path+"/user")
+	userGroup := fuego.Group(server, apiV1.Path+"/user", option.Tags("User"))
 	router.applyMiddleware(userGroup, MiddlewareConfig{RBAC: false, Audit: false, ResourceName: "user"})
 	router.RegisterUserRoutes(userGroup, userController)
 
 	domainController := domain.NewDomainsController(router.app.Store, router.app.Ctx, router.logger, dispatcher)
-	domainGroup := fuego.Group(server, apiV1.Path+"/domain")
+	domainGroup := fuego.Group(server, apiV1.Path+"/domain", option.Tags("Domains"))
 	router.applyMiddleware(domainGroup, MiddlewareConfig{RBAC: true, FeatureFlag: "domain", Audit: true, ResourceName: "domain"})
 	router.RegisterDomainRoutes(domainGroup, domainController)
 
 	githubConnectorController := githubConnector.NewGithubConnectorController(router.app.Store, router.app.Ctx, router.logger, dispatcher)
-	githubConnectorGroup := fuego.Group(server, apiV1.Path+"/github-connector")
+	githubConnectorGroup := fuego.Group(server, apiV1.Path+"/github-connector", option.Tags("GitHub Connector"))
 	router.applyMiddleware(githubConnectorGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "github_connector",
@@ -285,7 +290,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterGithubConnectorRoutes(githubConnectorGroup, githubConnectorController)
 
 	notifController := notificationController.NewNotificationController(router.app.Store, router.app.Ctx, router.logger, dispatcher)
-	notificationGroup := fuego.Group(server, apiV1.Path+"/notification")
+	notificationGroup := fuego.Group(server, apiV1.Path+"/notification", option.Tags("Notifications"))
 	router.applyMiddleware(notificationGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "notifications",
@@ -295,7 +300,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterNotificationRoutes(notificationGroup, notifController)
 
 	fileManagerController := file_manager.NewFileManagerController(router.app.Store, router.app.Ctx, router.logger, dispatcher)
-	fileManagerGroup := fuego.Group(server, apiV1.Path+"/file-manager")
+	fileManagerGroup := fuego.Group(server, apiV1.Path+"/file-manager", option.Tags("File Manager"))
 	fuego.Use(fileManagerGroup, middleware.ServerIDMiddleware)
 	router.applyMiddleware(fileManagerGroup, MiddlewareConfig{
 		RBAC:         true,
@@ -305,7 +310,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	})
 	router.RegisterFileManagerRoutes(fileManagerGroup, fileManagerController)
 
-	deployGroup := fuego.Group(server, apiV1.Path+"/deploy")
+	deployGroup := fuego.Group(server, apiV1.Path+"/deploy", option.Tags("Deploy"))
 	router.applyMiddleware(deployGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "deploy",
@@ -315,18 +320,18 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterDeployRoutes(deployGroup, deployController)
 
 	auditController := audit.NewAuditController(router.app.Store.DB, router.app.Ctx, router.logger)
-	auditGroup := fuego.Group(server, apiV1.Path+"/audit")
+	auditGroup := fuego.Group(server, apiV1.Path+"/audit", option.Tags("Audit"))
 	router.applyMiddleware(auditGroup, MiddlewareConfig{RBAC: true, FeatureFlag: "audit", Audit: true, ResourceName: "audit"})
 	router.RegisterAuditRoutes(auditGroup, auditController)
 
 	updateService := update_service.NewUpdateService(router.app, &router.logger, router.app.Ctx)
 	updateController := update.NewUpdateController(updateService, &router.logger)
-	updateGroup := fuego.Group(server, apiV1.Path+"/update")
+	updateGroup := fuego.Group(server, apiV1.Path+"/update", option.Tags("Update"))
 	router.RegisterUpdateRoutes(updateGroup, updateController)
 
 	featureFlagController := router.createFeatureFlagController()
-	featureFlagReadGroup := fuego.Group(server, apiV1.Path+"/feature-flags")
-	featureFlagWriteGroup := fuego.Group(server, apiV1.Path+"/feature-flags")
+	featureFlagReadGroup := fuego.Group(server, apiV1.Path+"/feature-flags", option.Tags("Feature Flags"))
+	featureFlagWriteGroup := fuego.Group(server, apiV1.Path+"/feature-flags", option.Tags("Feature Flags"))
 	featureFlagMiddleware := MiddlewareConfig{RBAC: true, Audit: true, ResourceName: "feature_flags"}
 	router.applyMiddleware(featureFlagReadGroup, featureFlagMiddleware)
 	router.applyMiddleware(featureFlagWriteGroup, featureFlagMiddleware)
@@ -336,7 +341,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	if err != nil {
 		log.Fatalf("Failed to create container controller: %v", err)
 	}
-	containerGroup := fuego.Group(server, apiV1.Path+"/container")
+	containerGroup := fuego.Group(server, apiV1.Path+"/container", option.Tags("Containers"))
 	fuego.Use(containerGroup, middleware.ServerIDMiddleware)
 	router.applyMiddleware(containerGroup, MiddlewareConfig{
 		RBAC:         true,
@@ -347,7 +352,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterContainerRoutes(containerGroup, containerController)
 
 	healthCheckController := healthcheck.NewHealthCheckController(router.app.Store, router.app.Ctx, router.logger)
-	healthCheckGroup := fuego.Group(server, apiV1.Path+"/healthcheck")
+	healthCheckGroup := fuego.Group(server, apiV1.Path+"/healthcheck", option.Tags("Health Checks"))
 	router.applyMiddleware(healthCheckGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "deploy",
@@ -357,7 +362,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterHealthCheckRoutes(healthCheckGroup, healthCheckController)
 
 	extensionController := extension.NewExtensionsController(router.app.Store, router.app.Ctx, router.logger, config.AppConfig.Redis.URL)
-	extensionGroup := fuego.Group(server, apiV1.Path+"/extensions")
+	extensionGroup := fuego.Group(server, apiV1.Path+"/extensions", option.Tags("Extensions"))
 	router.applyMiddleware(extensionGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "extension",
@@ -369,7 +374,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	machineTimescaleStore, _ := machine_storage.NewTimescaleStore(router.app.Ctx, config.AppConfig.Timescale.URL)
 	machineController := machine_controller.NewMachineController(router.app.Store, router.app.Ctx, router.logger, machineTimescaleStore)
 
-	machinesGroup := fuego.Group(server, apiV1.Path+"/machines")
+	machinesGroup := fuego.Group(server, apiV1.Path+"/machines", option.Tags("Machines"))
 	router.applyMiddleware(machinesGroup, MiddlewareConfig{
 		RBAC:         true,
 		Audit:        true,
@@ -378,7 +383,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterMachinesRoutes(machinesGroup, machineController)
 	router.RegisterMachineRegistrationRoutes(machinesGroup, machineController)
 
-	machinesOpsGroup := fuego.Group(server, apiV1.Path+"/machines")
+	machinesOpsGroup := fuego.Group(server, apiV1.Path+"/machines", option.Tags("Machines"))
 	fuego.Use(machinesOpsGroup, middleware.ServerIDMiddleware)
 	router.applyMiddleware(machinesOpsGroup, MiddlewareConfig{
 		RBAC:         true,
@@ -387,7 +392,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	})
 	router.RegisterMachineRoutes(machinesOpsGroup, machineController)
 
-	machinesBillingGroup := fuego.Group(server, apiV1.Path+"/machines")
+	machinesBillingGroup := fuego.Group(server, apiV1.Path+"/machines", option.Tags("Machines"))
 	fuego.Use(machinesBillingGroup, middleware.ServerIDMiddleware)
 	router.applyMiddleware(machinesBillingGroup, MiddlewareConfig{
 		RBAC:         false,
@@ -397,7 +402,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterMachineBillingRoutes(machinesBillingGroup, machineController)
 
 	trailController := machine_controller.NewTrailController(router.app.Store, router.app.Ctx, router.logger, router.cache)
-	trailGroup := fuego.Group(server, apiV1.Path+"/machines/trial")
+	trailGroup := fuego.Group(server, apiV1.Path+"/machines/trial", option.Tags("Machines"))
 	router.applyMiddleware(trailGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "trail",
@@ -407,7 +412,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 	router.RegisterTrailRoutes(trailGroup, trailController)
 
 	mcpCtrl := mcpController.NewMCPController(router.app.Store, router.app.Ctx, router.logger)
-	mcpGroup := fuego.Group(server, apiV1.Path+"/mcp")
+	mcpGroup := fuego.Group(server, apiV1.Path+"/mcp", option.Tags("MCP"))
 	router.applyMiddleware(mcpGroup, MiddlewareConfig{
 		RBAC:         true,
 		FeatureFlag:  "mcp",

--- a/api/internal/routes/telemetry.go
+++ b/api/internal/routes/telemetry.go
@@ -6,5 +6,5 @@ import (
 )
 
 func (router *Router) RegisterTelemetryRoutes(group *fuego.Server, controller *telemetry.TelemetryController) {
-	fuego.Post(group, "", controller.HandleTrackInstall, fuego.OptionSummary("Track CLI installation event"))
+	fuego.Post(group, "", controller.HandleTrackInstall, fuego.OptionSummary("Track CLI installation event"), fuego.OptionDefaultStatusCode(201))
 }

--- a/api/internal/tests/deploy/create_application_test.go
+++ b/api/internal/tests/deploy/create_application_test.go
@@ -48,7 +48,7 @@ func TestCreateApplication(t *testing.T) {
 					"PORT": "3000",
 				},
 			},
-			expectedStatus: http.StatusOK, // API returns 200 not 201
+			expectedStatus: http.StatusCreated,
 			description:    "Should create application successfully with valid data",
 		},
 		{
@@ -127,7 +127,7 @@ func TestCreateApplication(t *testing.T) {
 				Branch:      "main",
 				Port:        3000,
 			},
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusCreated,
 			description:    "Empty domains list is accepted by the API",
 		},
 		{

--- a/api/internal/tests/healthcheck/healthcheck_test.go
+++ b/api/internal/tests/healthcheck/healthcheck_test.go
@@ -115,14 +115,14 @@ func TestCreateHealthcheck_ValidMinimal(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /healthcheck with application_id returns 200"),
+		Description("POST /healthcheck with application_id returns 201"),
 		Post(tests.GetHealthCheckURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{
 			"application_id": appID,
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 		Expect().Body().JSON().JQ(".status").Equal("success"),
 		Expect().Body().JSON().JQ(".data.id").NotEqual(nil),
 	)
@@ -141,7 +141,7 @@ func TestCreateHealthcheck_WithFullConfig(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /healthcheck with full config returns 200"),
+		Description("POST /healthcheck with full config returns 201"),
 		Post(tests.GetHealthCheckURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
@@ -154,7 +154,7 @@ func TestCreateHealthcheck_WithFullConfig(t *testing.T) {
 			"expected_status_codes": []int{200},
 			"failure_threshold":     3,
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 		Expect().Body().JSON().JQ(".status").Equal("success"),
 	)
 }
@@ -177,7 +177,7 @@ func TestCreateHealthcheck_DuplicateApplicationID(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -253,7 +253,7 @@ func TestUpdateHealthcheck_ValidFlow(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -331,7 +331,7 @@ func TestDeleteHealthcheck_ValidFlow(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -410,7 +410,7 @@ func TestToggleHealthcheck_ValidFlow(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -484,7 +484,7 @@ func TestGetHealthcheckResults_ValidAuth(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -515,7 +515,7 @@ func TestGetHealthcheckResults_WithPagination(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -587,7 +587,7 @@ func TestGetHealthcheckStats_ValidFlow(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"application_id": appID}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,

--- a/api/internal/tests/machine/helpers_test.go
+++ b/api/internal/tests/machine/helpers_test.go
@@ -36,7 +36,7 @@ func createMachineHelper(t *testing.T, auth *testutils.TestAuthResponse, name, h
 			Port: port,
 			User: user,
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 		Expect().Custom(func(hit Hit) error {
 			return json.Unmarshal(hit.Response().Body().MustBytes(), &created)
 		}),

--- a/api/internal/tests/notification/notification_test.go
+++ b/api/internal/tests/notification/notification_test.go
@@ -138,7 +138,7 @@ func TestCreateSMTPConfig_ValidData(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/smtp with all required fields returns 200"),
+		Description("POST /notification/smtp with all required fields returns 201"),
 		Post(tests.GetNotificationSMTPURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
@@ -151,7 +151,7 @@ func TestCreateSMTPConfig_ValidData(t *testing.T) {
 			"from_email":      "test@example.com",
 			"organization_id": orgID.String(),
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 		Expect().Body().JSON().JQ(".status").Equal("success"),
 	)
 }
@@ -184,7 +184,7 @@ func TestCreateSMTPConfig_DuplicateReturnsError(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(payload),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,
@@ -267,7 +267,7 @@ func TestUpdateSMTPConfig_ValidFlow(t *testing.T) {
 			"password":        "password123",
 			"organization_id": orgID.String(),
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	// Fetch to get ID
@@ -368,7 +368,7 @@ func TestDeleteSMTPConfig_ValidFlow(t *testing.T) {
 			"password":        "password123",
 			"organization_id": orgID.String(),
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	var smtpID string
@@ -425,8 +425,8 @@ func TestGetNotificationPreferences_ValidAuth(t *testing.T) {
 
 func TestUpdateNotificationPreferences_NoAuth(t *testing.T) {
 	Test(t,
-		Description("POST /notification/preferences without auth returns 401"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences without auth returns 401"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Body().JSON(map[string]interface{}{"category": "activity", "type": "deploy", "enabled": true}),
 		Expect().Status().Equal(http.StatusUnauthorized),
 	)
@@ -440,8 +440,8 @@ func TestUpdateNotificationPreferences_MissingCategory(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/preferences without category returns 400"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences without category returns 400"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"type": "deploy", "enabled": true}),
@@ -457,8 +457,8 @@ func TestUpdateNotificationPreferences_InvalidCategory(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/preferences with invalid category returns 400"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences with invalid category returns 400"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"category": "invalid_category", "type": "deploy", "enabled": true}),
@@ -474,8 +474,8 @@ func TestUpdateNotificationPreferences_MissingType(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/preferences without type returns 400"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences without type returns 400"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"category": "activity", "enabled": true}),
@@ -491,8 +491,8 @@ func TestUpdateNotificationPreferences_Activity(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/preferences activity category returns 200"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences activity category returns 200"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"category": "activity", "type": "deploy", "enabled": true}),
@@ -508,8 +508,8 @@ func TestUpdateNotificationPreferences_Security(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/preferences security category returns 200"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences security category returns 200"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"category": "security", "type": "login", "enabled": false}),
@@ -525,8 +525,8 @@ func TestUpdateNotificationPreferences_Update(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/preferences update category returns 200"),
-		Post(tests.GetNotificationPreferencesURL()),
+		Description("PATCH /notification/preferences update category returns 200"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"category": "update", "type": "release", "enabled": true}),
@@ -587,7 +587,7 @@ func TestCreateWebhookConfig_Slack(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/webhook with slack type returns 200"),
+		Description("POST /notification/webhook with slack type returns 201"),
 		Post(tests.GetNotificationWebhookBaseURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
@@ -595,7 +595,7 @@ func TestCreateWebhookConfig_Slack(t *testing.T) {
 			"type":        "slack",
 			"webhook_url": "https://hooks.slack.com/services/TEST/TEST/TEST",
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 		Expect().Body().JSON().JQ(".status").Equal("success"),
 	)
 }
@@ -608,7 +608,7 @@ func TestCreateWebhookConfig_Discord(t *testing.T) {
 	}
 
 	Test(t,
-		Description("POST /notification/webhook with discord type returns 200"),
+		Description("POST /notification/webhook with discord type returns 201"),
 		Post(tests.GetNotificationWebhookBaseURL()),
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
@@ -616,7 +616,7 @@ func TestCreateWebhookConfig_Discord(t *testing.T) {
 			"type":        "discord",
 			"webhook_url": "https://discord.com/api/webhooks/TEST/TEST",
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 		Expect().Body().JSON().JQ(".status").Equal("success"),
 	)
 }
@@ -722,7 +722,7 @@ func TestUpdateWebhookConfig_ValidFlow(t *testing.T) {
 			"type":        "slack",
 			"webhook_url": "https://hooks.slack.com/services/OLD/OLD/OLD",
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	newURL := "https://hooks.slack.com/services/NEW/NEW/NEW"
@@ -801,7 +801,7 @@ func TestDeleteWebhookConfig_ValidFlow(t *testing.T) {
 			"type":        "discord",
 			"webhook_url": "https://discord.com/api/webhooks/DELETE/ME",
 		}),
-		Expect().Status().Equal(http.StatusOK),
+		Expect().Status().Equal(http.StatusCreated),
 	)
 
 	Test(t,

--- a/api/internal/tests/notification/notification_test.go
+++ b/api/internal/tests/notification/notification_test.go
@@ -238,7 +238,7 @@ func TestUpdateSMTPConfig_NonExistentID(t *testing.T) {
 		Send().Body().JSON(map[string]interface{}{
 			"id": uuid.New().String(),
 		}),
-		Expect().Status().OneOf(int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
+		Expect().Status().OneOf(int64(http.StatusBadRequest), int64(http.StatusNotFound), int64(http.StatusInternalServerError)),
 	)
 }
 

--- a/api/internal/types/application.go
+++ b/api/internal/types/application.go
@@ -232,6 +232,110 @@ const (
 	DeploymentTypeRestart  = "restart"
 )
 
+// RoutingStrategy OpenAPI methods
+
+func (RoutingStrategy) OpenAPISchemaType() []string { return []string{"string"} }
+func (RoutingStrategy) OpenAPISchemaEnum() []any {
+	return []any{
+		string(RoutingStrategySingle),
+		string(RoutingStrategyRoundRobin),
+		string(RoutingStrategyPrimaryFailover),
+		string(RoutingStrategyPerServerDomain),
+	}
+}
+func (RoutingStrategy) Description() string {
+	return "Traffic routing strategy: single (one server), round_robin (distribute across servers), primary_failover (failover to backup), per_server_domain (unique domain per server)."
+}
+
+// Status OpenAPI methods
+
+func (Status) OpenAPISchemaType() []string { return []string{"string"} }
+func (Status) OpenAPISchemaEnum() []any {
+	return []any{
+		string(Draft),
+		string(Started),
+		string(Running),
+		string(Stopped),
+		string(Failed),
+		string(Cloning),
+		string(Building),
+		string(Deploying),
+		string(Deployed),
+		string(Cancelled),
+		string(PartialFailure),
+	}
+}
+func (Status) Description() string {
+	return "Application or deployment lifecycle status."
+}
+
+// Environment OpenAPI methods
+
+func (Environment) OpenAPISchemaType() []string { return []string{"string"} }
+func (Environment) Description() string {
+	return "Environment name. Must match pattern ^[a-z0-9]+(-[a-z0-9]+)*$ and be 1-50 chars. Common values: production, staging, development."
+}
+
+// ProxyServer OpenAPI methods
+
+func (ProxyServer) OpenAPISchemaType() []string { return []string{"string"} }
+func (ProxyServer) OpenAPISchemaEnum() []any {
+	return []any{
+		string(Nginx),
+		string(Caddy),
+	}
+}
+func (ProxyServer) Description() string {
+	return "Reverse proxy server used to route traffic to the application."
+}
+
+// BuildPack OpenAPI methods
+
+func (BuildPack) OpenAPISchemaType() []string { return []string{"string"} }
+func (BuildPack) OpenAPISchemaEnum() []any {
+	return []any{
+		string(DockerFile),
+		string(DockerCompose),
+		string(Static),
+	}
+}
+func (BuildPack) Description() string {
+	return "Build strategy for the application: dockerfile, docker-compose, or static site."
+}
+
+// Source OpenAPI methods
+
+func (Source) OpenAPISchemaType() []string { return []string{"string"} }
+func (Source) OpenAPISchemaEnum() []any {
+	return []any{
+		string(SourceGithub),
+		string(SourceS3),
+		string(SourceZip),
+		string(SourceStaging),
+		string(SourceTemplate),
+		string(SourcePublicGit),
+	}
+}
+func (Source) Description() string {
+	return "Origin of the application source code."
+}
+
+// DeploymentType OpenAPI methods
+
+func (DeploymentType) OpenAPISchemaType() []string { return []string{"string"} }
+func (DeploymentType) OpenAPISchemaEnum() []any {
+	return []any{
+		DeploymentTypeCreate,
+		DeploymentTypeUpdate,
+		DeploymentTypeReDeploy,
+		DeploymentTypeRollback,
+		DeploymentTypeRestart,
+	}
+}
+func (DeploymentType) Description() string {
+	return "Kind of deployment operation to perform."
+}
+
 type WebhookPayload struct {
 	Repository struct {
 		ID       uint64 `json:"id"`

--- a/api/internal/utils/response.go
+++ b/api/internal/utils/response.go
@@ -13,8 +13,9 @@ type jsonSuccessResponse struct {
 }
 
 type jsonErrorResponse struct {
-	Status string `json:"status"`
-	Error  string `json:"error,omitempty"`
+	Code    string            `json:"code"`
+	Message string            `json:"message"`
+	Details map[string]string `json:"details,omitempty"`
 }
 
 // SendJSONResponse writes a JSON response to the given http.ResponseWriter.
@@ -33,8 +34,8 @@ func SendJSONResponse(w http.ResponseWriter, status string, message string, data
 			log.Printf("Error marshaling response data: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(jsonErrorResponse{
-				Status: "error",
-				Error:  "failed to encode response data",
+				Code:    "internal_error",
+				Message: "failed to encode response data",
 			})
 			return
 		}
@@ -51,10 +52,31 @@ func SendErrorResponse(w http.ResponseWriter, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	response := jsonErrorResponse{
-		Status: "error",
-		Error:  message,
+		Code:    errorCodeFromStatus(statusCode),
+		Message: message,
 	}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Printf("Error encoding error response: %v", err)
+	}
+}
+
+func errorCodeFromStatus(statusCode int) string {
+	switch statusCode {
+	case 400:
+		return "invalid_request"
+	case 401:
+		return "unauthorized"
+	case 403:
+		return "forbidden"
+	case 404:
+		return "not_found"
+	case 409:
+		return "conflict"
+	case 422:
+		return "unprocessable_entity"
+	case 429:
+		return "rate_limited"
+	default:
+		return "internal_error"
 	}
 }

--- a/api/internal/utils/response_test.go
+++ b/api/internal/utils/response_test.go
@@ -37,7 +37,8 @@ func TestSendJSONResponse(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		var got map[string]any
 		require.NoError(t, json.NewDecoder(rr.Body).Decode(&got))
-		assert.Equal(t, "error", got["status"])
+		assert.Equal(t, "internal_error", got["code"])
+		assert.Equal(t, "failed to encode response data", got["message"])
 	})
 
 	t.Run("encode to writer fails", func(t *testing.T) {
@@ -62,8 +63,8 @@ func TestSendErrorResponse(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	var got map[string]any
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&got))
-	assert.Equal(t, "error", got["status"])
-	assert.Equal(t, "bad", got["error"])
+	assert.Equal(t, "invalid_request", got["code"])
+	assert.Equal(t, "bad", got["message"])
 }
 
 func TestSendErrorResponse_encodeFails(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Explicit API documentation**: Added `validate`, `description`, and `example` struct tags to all request types across every feature (deploy, auth, user, notifications, healthcheck, domains, github-connector, mcp, telemetry) so API callers and LLMs can understand validation rules without reading internal code
- **Unified error handling**: Standardized all error responses to a single `ErrorEnvelope` schema (`code`, `message`, `details`), fixed double-write bugs where handlers called both `SendErrorResponse` and returned Fuego errors, refactored `parseAndValidate` helpers to return errors directly
- **REST consistency fixes**: Added `X-Request-ID` middleware for request correlation, rate-limit headers (`X-RateLimit-Limit`, `Remaining`, `Retry-After`), proper `201` status codes for POST-create routes, corrected notification preference update from POST to PATCH
- **Clean Swagger UI**: Stripped 63 auto-generated path-segment tags from the in-memory OpenAPI spec, leaving only 18 explicit domain tags for proper sidebar grouping
- **OpenAPI post-processing**: Auto-generates examples, operationIds, parameter constraints, and standard error envelope references for all endpoints

## Changed files (37 files, +1481 / -1028)

| Area | Files | What changed |
|------|-------|-------------|
| Types & validation | 12 | Added struct tags, enum methods |
| Controllers | 8 | Fixed double-write, error returns |
| Routes | 9 | Tags, status codes, HTTP methods |
| Middleware | 3 | Request ID, rate-limit headers, recovery |
| OpenAPI | 1 | In-memory tag cleaning + post-processor |
| Utils | 2 | ErrorEnvelope schema, tests |
| Generated | 1 | `doc/openapi.json` |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Unit tests pass (`response_test.go` updated for new ErrorEnvelope)
- [x] Swagger UI at `/swagger/` shows 18 clean domain tags
- [x] Live spec at `/swagger/openapi.json` contains no junk auto-tags
- [x] All existing API callers unaffected (no business logic changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request IDs: every API response includes X-Request-ID.

* **Improvements**
  * Stronger input validation and clearer field descriptions/examples across many APIs.
  * Many create endpoints now return 201 Created by default.
  * Cleaner OpenAPI tagging and richer schema metadata for docs.
  * Standardized JSON error payloads (code/message); improved rate-limit and error responses.
  * Notification preferences endpoint changed from POST to PATCH.

* **Tests**
  * Tests updated to expect 201 and new error/response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->