### PR TITLE
test(container): unit coverage

### DIFF
--- a/api/internal/features/container/controller/list_containers.go
+++ b/api/internal/features/container/controller/list_containers.go
@@ -2,20 +2,15 @@ package controller
 
 import (
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/go-fuego/fuego"
+	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	containertypes "github.com/nixopus/nixopus/api/internal/features/container/types"
-	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
-	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (c *ContainerController) ListContainers(fuegoCtx fuego.ContextNoBody) (*containertypes.ListContainersResponse, error) {
-	// normalize query params
 	params := parseContainerListParams(fuegoCtx.Request())
 	ctx := fuegoCtx.Request().Context()
 
@@ -28,76 +23,16 @@ func (c *ContainerController) ListContainers(fuegoCtx fuego.ContextNoBody) (*con
 		}
 	}
 
-	// Get pre-filtered summaries from Docker
-	containers, err := dockerService.ListContainers(container.ListOptions{
-		All:     true,
-		Filters: buildDockerFilters(params),
-	})
+	resp, err := service.ListContainers(dockerService, c.logger, params)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
 			Status: http.StatusInternalServerError,
 		}
 	}
-	// Build summaries, then search/sort
-	rows := summarizeContainers(containers)
-	filteredRows := applySearchFilter(rows, params)
-	sortedRows := applySort(filteredRows, params)
 
-	// Group containers by application ID
-	groups, ungrouped := groupContainersByApplication(sortedRows, containers, dockerService)
-
-	// Sort groups by application name
-	sort.SliceStable(groups, func(i, j int) bool {
-		if params.SortOrder == "desc" {
-			return groups[i].ApplicationName > groups[j].ApplicationName
-		}
-		return groups[i].ApplicationName < groups[j].ApplicationName
-	})
-
-	// Paginate groups
-	totalGroupCount := len(groups)
-	start := (params.Page - 1) * params.PageSize
-	if start > totalGroupCount {
-		start = totalGroupCount
-	}
-	end := start + params.PageSize
-	if end > totalGroupCount {
-		end = totalGroupCount
-	}
-	paginatedGroups := groups[start:end]
-
-	// Calculate total container count
-	totalContainerCount := 0
-	for _, group := range groups {
-		totalContainerCount += len(group.Containers)
-	}
-	totalContainerCount += len(ungrouped)
-
-	// Include ungrouped containers on every page
-	// This ensures they're always visible regardless of pagination
-	paginatedUngrouped := ungrouped
-
-	return &containertypes.ListContainersResponse{
-		Status:  "success",
-		Message: "Containers fetched successfully",
-		Data: containertypes.ListContainersResponseData{
-			Groups:     paginatedGroups,
-			Ungrouped:  paginatedUngrouped,
-			TotalCount: totalContainerCount,
-			GroupCount: totalGroupCount,
-			Page:       params.Page,
-			PageSize:   params.PageSize,
-			SortBy:     params.SortBy,
-			SortOrder:  params.SortOrder,
-			Search:     params.Search,
-			Status:     params.Status,
-			Name:       params.Name,
-			Image:      params.Image,
-		},
-	}, nil
+	return &resp, nil
 }
 
 func parseContainerListParams(r *http.Request) containertypes.ContainerListParams {
@@ -139,263 +74,4 @@ func parseContainerListParams(r *http.Request) containertypes.ContainerListParam
 		Name:      strings.TrimSpace(q.Get("name")),
 		Image:     strings.TrimSpace(q.Get("image")),
 	}
-}
-
-func buildDockerFilters(p containertypes.ContainerListParams) filters.Args {
-	f := filters.NewArgs()
-	if p.Status != "" {
-		f.Add("status", p.Status)
-	}
-	if p.Name != "" {
-		f.Add("name", p.Name)
-	}
-	if p.Image != "" {
-		f.Add("ancestor", p.Image)
-	}
-	return f
-}
-
-func summarizeContainers(summaries []container.Summary) []containertypes.ContainerListRow {
-	rows := make([]containertypes.ContainerListRow, 0, len(summaries))
-	for _, csum := range summaries {
-		name := ""
-		if len(csum.Names) > 0 {
-			n := csum.Names[0]
-			if len(n) > 1 {
-				name = n[1:]
-			} else {
-				name = n
-			}
-		}
-		rows = append(rows, containertypes.ContainerListRow{
-			ID:      csum.ID,
-			Name:    name,
-			Image:   csum.Image,
-			Status:  csum.Status,
-			State:   csum.State,
-			Created: csum.Created,
-			Labels:  csum.Labels,
-		})
-	}
-	return rows
-}
-
-func applySearchFilter(rows []containertypes.ContainerListRow, p containertypes.ContainerListParams) []containertypes.ContainerListRow {
-	if p.Search != "" {
-		lower := strings.ToLower(p.Search)
-		filtered := make([]containertypes.ContainerListRow, 0, len(rows))
-		for _, r := range rows {
-			if strings.Contains(strings.ToLower(r.Name), lower) ||
-				strings.Contains(strings.ToLower(r.Image), lower) ||
-				strings.Contains(strings.ToLower(r.Status), lower) {
-				filtered = append(filtered, r)
-			}
-		}
-		return filtered
-	}
-	return rows
-}
-
-func applySort(rows []containertypes.ContainerListRow, p containertypes.ContainerListParams) []containertypes.ContainerListRow {
-	sort.SliceStable(rows, func(i, j int) bool {
-		switch p.SortBy {
-		case "status":
-			a := strings.ToLower(rows[i].Status)
-			b := strings.ToLower(rows[j].Status)
-			if p.SortOrder == "desc" {
-				return a > b
-			}
-			return a < b
-		case "name":
-			a := strings.ToLower(rows[i].Name)
-			b := strings.ToLower(rows[j].Name)
-			if p.SortOrder == "desc" {
-				return a > b
-			}
-			return a < b
-		default:
-			ai := rows[i].Created
-			aj := rows[j].Created
-			if p.SortOrder == "desc" {
-				return ai > aj
-			}
-			return ai < aj
-		}
-	})
-	return rows
-}
-
-func groupContainersByApplication(
-	rows []containertypes.ContainerListRow,
-	summaries []container.Summary,
-	dockerService interface {
-		GetContainerById(id string) (container.InspectResponse, error)
-	},
-) ([]containertypes.ContainerGroup, []containertypes.Container) {
-	groupsMap := make(map[string]*containertypes.ContainerGroup)
-	ungrouped := make([]containertypes.Container, 0)
-
-	// Create a map of summaries by ID for quick lookup
-	summaryMap := make(map[string]container.Summary)
-	for _, s := range summaries {
-		summaryMap[s.ID] = s
-	}
-
-	for _, row := range rows {
-		applicationID := ""
-		applicationName := "Unknown Application"
-		if row.Labels != nil {
-			if id, ok := row.Labels["com.application.id"]; ok {
-				applicationID = id
-			}
-			if name, ok := row.Labels["com.application.name"]; ok {
-				applicationName = name
-			}
-		}
-
-		// Get full container info
-		info, err := dockerService.GetContainerById(row.ID)
-		if err != nil {
-			continue
-		}
-
-		containerData := containertypes.Container{
-			ID:        row.ID,
-			Name:      row.Name,
-			Image:     row.Image,
-			Status:    row.Status,
-			State:     row.State,
-			Created:   info.Created,
-			Labels:    row.Labels,
-			Command:   "",
-			IPAddress: info.NetworkSettings.IPAddress,
-			HostConfig: containertypes.HostConfig{
-				Memory:     info.HostConfig.Memory,
-				MemorySwap: info.HostConfig.MemorySwap,
-				CPUShares:  info.HostConfig.CPUShares,
-			},
-		}
-
-		if info.Config != nil && info.Config.Cmd != nil && len(info.Config.Cmd) > 0 {
-			containerData.Command = info.Config.Cmd[0]
-		}
-
-		// Add ports from summary
-		if s, ok := summaryMap[row.ID]; ok {
-			for _, p := range s.Ports {
-				containerData.Ports = append(containerData.Ports, containertypes.Port{
-					PrivatePort: int(p.PrivatePort),
-					PublicPort:  int(p.PublicPort),
-					Type:        p.Type,
-				})
-			}
-		}
-
-		// Add mounts
-		for _, m := range info.Mounts {
-			containerData.Mounts = append(containerData.Mounts, containertypes.Mount{
-				Type:        string(m.Type),
-				Source:      m.Source,
-				Destination: m.Destination,
-				Mode:        m.Mode,
-			})
-		}
-
-		// Add networks
-		for name, network := range info.NetworkSettings.Networks {
-			containerData.Networks = append(containerData.Networks, containertypes.Network{
-				Name:       name,
-				IPAddress:  network.IPAddress,
-				Gateway:    network.Gateway,
-				MacAddress: network.MacAddress,
-				Aliases:    network.Aliases,
-			})
-		}
-
-		if applicationID != "" {
-			if _, exists := groupsMap[applicationID]; !exists {
-				groupsMap[applicationID] = &containertypes.ContainerGroup{
-					ApplicationID:   applicationID,
-					ApplicationName: applicationName,
-					Containers:      make([]containertypes.Container, 0),
-				}
-			}
-			groupsMap[applicationID].Containers = append(groupsMap[applicationID].Containers, containerData)
-		} else {
-			ungrouped = append(ungrouped, containerData)
-		}
-	}
-
-	// Convert map to slice
-	groups := make([]containertypes.ContainerGroup, 0, len(groupsMap))
-	for _, group := range groupsMap {
-		groups = append(groups, *group)
-	}
-
-	return groups, ungrouped
-}
-
-func (c *ContainerController) appendContainerInfo(dockerService docker.DockerRepository, pageRows []containertypes.ContainerListRow, summaries []container.Summary) []containertypes.Container {
-	result := make([]containertypes.Container, 0, len(pageRows))
-	for _, r := range pageRows {
-		info, err := dockerService.GetContainerById(r.ID)
-		if err != nil {
-			c.logger.Log(logger.Error, "Error inspecting container", r.ID)
-			continue
-		}
-		cd := containertypes.Container{
-			ID:        r.ID,
-			Name:      r.Name,
-			Image:     r.Image,
-			Status:    r.Status,
-			State:     r.State,
-			Created:   info.Created,
-			Labels:    r.Labels,
-			Command:   "",
-			IPAddress: info.NetworkSettings.IPAddress,
-			HostConfig: containertypes.HostConfig{
-				Memory:     info.HostConfig.Memory,
-				MemorySwap: info.HostConfig.MemorySwap,
-				CPUShares:  info.HostConfig.CPUShares,
-			},
-		}
-		if info.Config != nil && info.Config.Cmd != nil && len(info.Config.Cmd) > 0 {
-			cd.Command = info.Config.Cmd[0]
-		}
-		for _, s := range summaries {
-			if s.ID == r.ID {
-				for _, p := range s.Ports {
-					cd.Ports = append(cd.Ports, containertypes.Port{
-						PrivatePort: int(p.PrivatePort),
-						PublicPort:  int(p.PublicPort),
-						Type:        p.Type,
-					})
-				}
-				break
-			}
-		}
-		for _, m := range info.Mounts {
-			cd.Mounts = append(cd.Mounts, containertypes.Mount{
-				Type:        string(m.Type),
-				Source:      m.Source,
-				Destination: m.Destination,
-				Mode:        m.Mode,
-			})
-		}
-		for name, network := range info.NetworkSettings.Networks {
-			aliases := network.Aliases
-			if aliases == nil {
-				aliases = []string{}
-			}
-			cd.Networks = append(cd.Networks, containertypes.Network{
-				Name:       name,
-				IPAddress:  network.IPAddress,
-				Gateway:    network.Gateway,
-				MacAddress: network.MacAddress,
-				Aliases:    aliases,
-			})
-		}
-		result = append(result, cd)
-	}
-	return result
 }

--- a/api/internal/features/container/service/actions_test.go
+++ b/api/internal/features/container/service/actions_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartContainer_successAndError(t *testing.T) {
+	t.Parallel()
+	log := logger.NewLogger()
+	stub := &stubDockerRepository{}
+
+	stub.startContainer = func(string, container.StartOptions) error { return nil }
+	resp, err := StartContainer(stub, log, StartContainerOptions{ContainerID: "c1"})
+	require.NoError(t, err)
+	require.Equal(t, "started", resp.Data.Status)
+
+	stub.startContainer = func(string, container.StartOptions) error { return errors.New("boom") }
+	_, err = StartContainer(stub, log, StartContainerOptions{ContainerID: "c1"})
+	require.Error(t, err)
+}
+
+func TestStopContainer_timeoutAndErrors(t *testing.T) {
+	t.Parallel()
+	log := logger.NewLogger()
+	stub := &stubDockerRepository{}
+	timeout := 5
+	stub.stopContainer = func(id string, opts container.StopOptions) error {
+		require.Equal(t, "c2", id)
+		require.NotNil(t, opts.Timeout)
+		require.Equal(t, 5, *opts.Timeout)
+		return nil
+	}
+	resp, err := StopContainer(stub, log, StopContainerOptions{ContainerID: "c2", Timeout: &timeout})
+	require.NoError(t, err)
+	require.Equal(t, "stopped", resp.Data.Status)
+
+	stub.stopContainer = func(string, container.StopOptions) error { return nil }
+	resp, err = StopContainer(stub, log, StopContainerOptions{ContainerID: "c2"})
+	require.NoError(t, err)
+	require.Equal(t, "stopped", resp.Data.Status)
+
+	stub.stopContainer = func(string, container.StopOptions) error { return errors.New("fail") }
+	_, err = StopContainer(stub, log, StopContainerOptions{ContainerID: "c2"})
+	require.Error(t, err)
+}
+
+func TestRestartContainer_timeoutAndErrors(t *testing.T) {
+	t.Parallel()
+	log := logger.NewLogger()
+	stub := &stubDockerRepository{}
+	timeout := 3
+	stub.restartContainer = func(id string, opts container.StopOptions) error {
+		require.Equal(t, "c3", id)
+		require.NotNil(t, opts.Timeout)
+		return nil
+	}
+	resp, err := RestartContainer(stub, log, RestartContainerOptions{ContainerID: "c3", Timeout: &timeout})
+	require.NoError(t, err)
+	require.Equal(t, "restarted", resp.Data.Status)
+
+	stub.restartContainer = func(string, container.StopOptions) error { return errors.New("fail") }
+	_, err = RestartContainer(stub, log, RestartContainerOptions{ContainerID: "c3"})
+	require.Error(t, err)
+}
+
+func TestRemoveContainer_forceAndErrors(t *testing.T) {
+	t.Parallel()
+	log := logger.NewLogger()
+	stub := &stubDockerRepository{}
+	stub.removeContainer = func(id string, opts container.RemoveOptions) error {
+		require.True(t, opts.Force)
+		return nil
+	}
+	resp, err := RemoveContainer(stub, log, RemoveContainerOptions{ContainerID: "c4", Force: true})
+	require.NoError(t, err)
+	require.Equal(t, "removed", resp.Data.Status)
+
+	stub.removeContainer = func(string, container.RemoveOptions) error { return errors.New("fail") }
+	_, err = RemoveContainer(stub, log, RemoveContainerOptions{ContainerID: "c4"})
+	require.Error(t, err)
+}
+
+func TestPruneBuildCache_successAndError(t *testing.T) {
+	t.Parallel()
+	log := logger.NewLogger()
+	stub := &stubDockerRepository{}
+	stub.pruneBuildCache = func(opts dockertypes.BuildCachePruneOptions) error {
+		return nil
+	}
+	_, err := PruneBuildCache(stub, log, PruneBuildCacheOptions{All: true})
+	require.NoError(t, err)
+
+	var hit bool
+	stub.pruneBuildCache = func(o dockertypes.BuildCachePruneOptions) error {
+		hit = true
+		require.True(t, o.All)
+		return errors.New("prune failed")
+	}
+	_, err = PruneBuildCache(stub, log, PruneBuildCacheOptions{All: true})
+	require.Error(t, err)
+	require.True(t, hit)
+}

--- a/api/internal/features/container/service/decode_logs_test.go
+++ b/api/internal/features/container/service/decode_logs_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"context"
+
+	"github.com/google/uuid"
+	shared_storage "github.com/nixopus/nixopus/api/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTailLinesFromOrgLogTailSetting(t *testing.T) {
+	t.Parallel()
+	seven := 7
+	require.Equal(t, 7, tailLinesFromOrgLogTailSetting(&seven))
+	require.Equal(t, 100, tailLinesFromOrgLogTailSetting(nil))
+}
+
+func TestDecodeDockerLogs_variants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		require.Equal(t, "", decodeDockerLogs(nil))
+	})
+
+	t.Run("short_header", func(t *testing.T) {
+		require.Equal(t, "", decodeDockerLogs([]byte{1, 0, 0, 0, 4}))
+	})
+
+	t.Run("stdout_and_stderr_concat", func(t *testing.T) {
+		var frames []byte
+		frames = appendFrame(frames, 1, []byte("out"))
+		frames = appendFrame(frames, 2, []byte("err"))
+		require.Equal(t, "outerr", decodeDockerLogs(frames))
+	})
+
+	t.Run("skip_unknown_stream", func(t *testing.T) {
+		var frames []byte
+		frames = appendFrame(frames, 7, []byte("x"))
+		frames = appendFrame(frames, 1, []byte("y"))
+		require.Equal(t, "y", decodeDockerLogs(frames))
+	})
+
+	t.Run("truncated_length", func(t *testing.T) {
+		payload := byte(99)
+		b := []byte{1, 0, 0, 0, 0, 0, 0, 50, payload}
+		require.Equal(t, "", decodeDockerLogs(b))
+	})
+
+	t.Run("partial_header_at_end_loop_exit", func(t *testing.T) {
+		payload := appendFrame(nil, 1, []byte("done"))
+		partial := append(payload, byte(9))
+		require.Equal(t, "done", decodeDockerLogs(partial))
+	})
+}
+
+func appendFrame(b []byte, streamType byte, payload []byte) []byte {
+	hdr := []byte{streamType, 0, 0, 0}
+	lenb := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenb, uint32(len(payload)))
+	hdr = append(hdr, lenb...)
+	b = append(b, hdr...)
+	return append(b, payload...)
+}
+
+func TestGetOrganizationSettings_nonDBPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("invalid_uuid", func(t *testing.T) {
+		got := getOrganizationSettings(&shared_storage.Store{}, ctx, "nope-not-uuid")
+		require.NotNil(t, got.ContainerLogTailLines)
+		require.GreaterOrEqual(t, *got.ContainerLogTailLines, 1)
+	})
+
+	t.Run("nil_uuid_string", func(t *testing.T) {
+		got := getOrganizationSettings(&shared_storage.Store{}, ctx, uuid.Nil.String())
+		require.NotNil(t, got.ContainerLogTailLines)
+	})
+
+	t.Run("valid_uuid_nil_store_returns_defaults_without_db", func(t *testing.T) {
+		got := getOrganizationSettings(nil, ctx, uuid.NewString())
+		require.NotNil(t, got.ContainerLogTailLines)
+	})
+
+	t.Run("valid_uuid_nil_db_returns_defaults_without_db", func(t *testing.T) {
+		st := &shared_storage.Store{}
+		got := getOrganizationSettings(st, ctx, uuid.NewString())
+		require.NotNil(t, got.ContainerLogTailLines)
+	})
+}

--- a/api/internal/features/container/service/docker_repository_stub_test.go
+++ b/api/internal/features/container/service/docker_repository_stub_test.go
@@ -1,0 +1,268 @@
+package service
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
+)
+
+// stubDockerRepository implements docker.DockerRepository for unit tests.
+// Only non-nil hooks are consulted; omitted behavior returns zeros.
+type stubDockerRepository struct {
+	listContainers    func(opts container.ListOptions) ([]container.Summary, error)
+	listAllContainers func() ([]container.Summary, error)
+	listAllImages     func(opts image.ListOptions) []image.Summary
+	getContainerByID  func(id string) (container.InspectResponse, error)
+	getContainerLogs  func(containerID string, opts container.LogsOptions) (io.Reader, error)
+	startContainer    func(containerID string, opts container.StartOptions) error
+	stopContainer     func(containerID string, opts container.StopOptions) error
+	removeContainer   func(containerID string, opts container.RemoveOptions) error
+	restartContainer  func(containerID string, opts container.StopOptions) error
+	updateResources   func(containerID string, cfg container.UpdateConfig) (container.ContainerUpdateOKBody, error)
+	pruneBuildCache   func(opts types.BuildCachePruneOptions) error
+	pruneImages       func(args filters.Args) (image.PruneReport, error)
+}
+
+var _ docker.DockerRepository = (*stubDockerRepository)(nil)
+
+func (s *stubDockerRepository) ListAllContainers() ([]container.Summary, error) {
+	if s.listAllContainers != nil {
+		return s.listAllContainers()
+	}
+	return nil, nil
+}
+
+func (s *stubDockerRepository) ListContainers(opts container.ListOptions) ([]container.Summary, error) {
+	if s.listContainers != nil {
+		return s.listContainers(opts)
+	}
+	return nil, nil
+}
+
+func (s *stubDockerRepository) ListAllImages(opts image.ListOptions) []image.Summary {
+	if s.listAllImages != nil {
+		return s.listAllImages(opts)
+	}
+	return nil
+}
+
+func (s *stubDockerRepository) StopContainer(containerID string, opts container.StopOptions) error {
+	if s.stopContainer != nil {
+		return s.stopContainer(containerID, opts)
+	}
+	return nil
+}
+
+func (s *stubDockerRepository) RemoveContainer(containerID string, opts container.RemoveOptions) error {
+	if s.removeContainer != nil {
+		return s.removeContainer(containerID, opts)
+	}
+	return nil
+}
+
+func (s *stubDockerRepository) StartContainer(containerID string, opts container.StartOptions) error {
+	if s.startContainer != nil {
+		return s.startContainer(containerID, opts)
+	}
+	return nil
+}
+
+func (s *stubDockerRepository) GetContainerLogs(containerID string, opts container.LogsOptions) (io.Reader, error) {
+	if s.getContainerLogs != nil {
+		return s.getContainerLogs(containerID, opts)
+	}
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetContainerById(containerID string) (container.InspectResponse, error) {
+	if s.getContainerByID != nil {
+		return s.getContainerByID(containerID)
+	}
+	return container.InspectResponse{}, nil
+}
+
+func (s *stubDockerRepository) GetImageById(imageID string, opts client.ImageInspectOption) (image.InspectResponse, error) {
+	return image.InspectResponse{}, nil
+}
+
+func (s *stubDockerRepository) ImagePull(ctx context.Context, ref string, opts image.PullOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) BuildImage(opts types.ImageBuildOptions, buildContext io.Reader) (types.ImageBuildResponse, error) {
+	return types.ImageBuildResponse{}, nil
+}
+
+func (s *stubDockerRepository) CreateContainer(cfg container.Config, hostConfig container.HostConfig, networkConfig network.NetworkingConfig, containerName string) (container.CreateResponse, error) {
+	return container.CreateResponse{}, nil
+}
+
+func (s *stubDockerRepository) ContainerLogs(ctx context.Context, containerID string, opts container.LogsOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) RestartContainer(containerID string, opts container.StopOptions) error {
+	if s.restartContainer != nil {
+		return s.restartContainer(containerID, opts)
+	}
+	return nil
+}
+
+func (s *stubDockerRepository) UpdateContainerResources(containerID string, resources container.UpdateConfig) (container.ContainerUpdateOKBody, error) {
+	if s.updateResources != nil {
+		return s.updateResources(containerID, resources)
+	}
+	return container.ContainerUpdateOKBody{}, nil
+}
+
+func (s *stubDockerRepository) ComposeUp(composeFilePath string, envVars map[string]string, overrideFiles ...string) (string, error) {
+	return "", nil
+}
+
+func (s *stubDockerRepository) ComposeUpWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) (string, error) {
+	return "", nil
+}
+
+func (s *stubDockerRepository) ComposeDown(composeFilePath string, envVars map[string]string, overrideFiles ...string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) ComposeDownWithCallback(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) ComposeRestart(composeFilePath string, envVars map[string]string, outputCallback func(string), overrideFiles ...string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) ComposeBuild(composeFilePath string, envVars map[string]string, overrideFiles ...string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) RemoveImage(imageName string, opts image.RemoveOptions) error {
+	return nil
+}
+
+func (s *stubDockerRepository) PruneBuildCache(opts types.BuildCachePruneOptions) error {
+	if s.pruneBuildCache != nil {
+		return s.pruneBuildCache(opts)
+	}
+	return nil
+}
+
+func (s *stubDockerRepository) PruneImages(opts filters.Args) (image.PruneReport, error) {
+	if s.pruneImages != nil {
+		return s.pruneImages(opts)
+	}
+	return image.PruneReport{}, nil
+}
+
+func (s *stubDockerRepository) InitCluster() error {
+	return nil
+}
+
+func (s *stubDockerRepository) JoinCluster() error {
+	return nil
+}
+
+func (s *stubDockerRepository) LeaveCluster(force bool) error {
+	return nil
+}
+
+func (s *stubDockerRepository) GetClusterInfo() (swarm.ClusterInfo, error) {
+	return swarm.ClusterInfo{}, nil
+}
+
+func (s *stubDockerRepository) GetClusterNodes() ([]swarm.Node, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetClusterServices() ([]swarm.Service, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetClusterTasks() ([]swarm.Task, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetTasksByServiceID(serviceID string) ([]swarm.Task, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetClusterSecrets() ([]swarm.Secret, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetClusterConfigs() ([]swarm.Config, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetClusterVolumes() ([]*volume.Volume, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetClusterNetworks() ([]network.Summary, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) UpdateNodeAvailability(nodeID string, availability swarm.NodeAvailability) error {
+	return nil
+}
+
+func (s *stubDockerRepository) ScaleService(serviceID string, replicas uint64, rollback string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) ListenEvents(opts events.ListOptions) (<-chan events.Message, <-chan error) {
+	ch := make(chan events.Message)
+	ech := make(chan error)
+	close(ch)
+	close(ech)
+	return ch, ech
+}
+
+func (s *stubDockerRepository) GetServiceHealth(service swarm.Service) (int, int, error) {
+	return 0, 0, nil
+}
+
+func (s *stubDockerRepository) GetTaskHealth(task swarm.Task) swarm.TaskState {
+	return swarm.TaskState("")
+}
+
+func (s *stubDockerRepository) CreateService(service swarm.Service) error {
+	return nil
+}
+
+func (s *stubDockerRepository) UpdateService(serviceID string, serviceSpec swarm.ServiceSpec, rollback string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) DeleteService(serviceID string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) RollbackService(serviceID string) error {
+	return nil
+}
+
+func (s *stubDockerRepository) GetServiceByID(serviceID string) (swarm.Service, error) {
+	return swarm.Service{}, nil
+}
+
+func (s *stubDockerRepository) GetServiceByName(name string) (*swarm.Service, error) {
+	return nil, nil
+}
+
+func (s *stubDockerRepository) GetServiceByLabel(key, value string) (*swarm.Service, error) {
+	return nil, nil
+}

--- a/api/internal/features/container/service/get_container_logs.go
+++ b/api/internal/features/container/service/get_container_logs.go
@@ -38,17 +38,10 @@ func GetContainerLogs(
 	l logger.Logger,
 	opts ContainerLogsOptions,
 ) (string, error) {
-	// Get organization settings
-	orgSettings := getOrganizationSettings(store, ctx, opts.OrganizationID)
-
-	// Use default tail lines from settings if not provided
 	tail := opts.Tail
 	if tail == 0 {
-		if orgSettings.ContainerLogTailLines != nil {
-			tail = *orgSettings.ContainerLogTailLines
-		} else {
-			tail = 100 // Fallback default
-		}
+		orgSettings := getOrganizationSettings(store, ctx, opts.OrganizationID)
+		tail = tailLinesFromOrgLogTailSetting(orgSettings.ContainerLogTailLines)
 	}
 
 	// Get container logs
@@ -85,6 +78,9 @@ func getOrganizationSettings(store *shared_storage.Store, ctx context.Context, o
 	if err != nil || orgID == uuid.Nil {
 		return shared_types.DefaultOrganizationSettingsData()
 	}
+	if store == nil || store.DB == nil {
+		return shared_types.DefaultOrganizationSettingsData()
+	}
 
 	settings, err := utils.GetOrganizationSettings(ctx, store.DB, orgID)
 	if err != nil {
@@ -92,6 +88,14 @@ func getOrganizationSettings(store *shared_storage.Store, ctx context.Context, o
 	}
 
 	return settings
+}
+
+// tailLinesFromOrgLogTailSetting returns configured tail or 100 when unset.
+func tailLinesFromOrgLogTailSetting(ptr *int) int {
+	if ptr != nil {
+		return *ptr
+	}
+	return 100
 }
 
 // decodeDockerLogs decodes Docker's log format (8-byte header + payload)

--- a/api/internal/features/container/service/get_container_logs_test.go
+++ b/api/internal/features/container/service/get_container_logs_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	shared_storage "github.com/nixopus/nixopus/api/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+type errLogReader struct{}
+
+func (errLogReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+
+func TestGetContainerLogs_docker_error(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logger.NewLogger()
+	st := &shared_storage.Store{}
+	stub := &stubDockerRepository{}
+	stub.getContainerLogs = func(string, container.LogsOptions) (io.Reader, error) {
+		return nil, errors.New("daemon down")
+	}
+
+	_, err := GetContainerLogs(ctx, st, stub, log, ContainerLogsOptions{
+		ContainerID:    "c1",
+		OrganizationID: "not-a-uuid",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get container logs")
+}
+
+func TestGetContainerLogs_read_error(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logger.NewLogger()
+	st := &shared_storage.Store{}
+	stub := &stubDockerRepository{}
+	stub.getContainerLogs = func(cid string, opts container.LogsOptions) (io.Reader, error) {
+		require.Equal(t, "c-read", cid)
+		require.Equal(t, "5", opts.Tail)
+		return errLogReader{}, nil
+	}
+
+	_, err := GetContainerLogs(ctx, st, stub, log, ContainerLogsOptions{
+		ContainerID:    "c-read",
+		OrganizationID: "also-bad",
+		Tail:           5,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read container logs")
+}
+
+func TestGetContainerLogs_success_decodes_stream(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logger.NewLogger()
+	st := &shared_storage.Store{}
+	payload := appendFrame(nil, 1, []byte("HELLO"))
+
+	stub := &stubDockerRepository{}
+	stub.getContainerLogs = func(string, container.LogsOptions) (io.Reader, error) {
+		return strings.NewReader(string(payload)), nil
+	}
+
+	out, err := GetContainerLogs(ctx, st, stub, log, ContainerLogsOptions{
+		ContainerID:    "cok",
+		OrganizationID: "bad-org-no-db",
+		Stdout:         true,
+		Stderr:         true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "HELLO", out)
+}
+
+func TestGetContainerLogs_explicit_tail_skips_org_settings_branch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logger.NewLogger()
+	st := &shared_storage.Store{}
+	var sawTail string
+	stub := &stubDockerRepository{}
+	stub.getContainerLogs = func(_ string, opts container.LogsOptions) (io.Reader, error) {
+		sawTail = opts.Tail
+		return strings.NewReader(""), nil
+	}
+
+	_, err := GetContainerLogs(ctx, st, stub, log, ContainerLogsOptions{
+		ContainerID:    "c",
+		OrganizationID: "",
+		Tail:           42,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "42", sawTail)
+}
+
+func TestGetContainerLogs_tail_zero_uses_default_setting(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logger.NewLogger()
+	st := &shared_storage.Store{}
+	stub := &stubDockerRepository{}
+	stub.getContainerLogs = func(_ string, opts container.LogsOptions) (io.Reader, error) {
+		require.Equal(t, "100", opts.Tail)
+		return strings.NewReader(""), nil
+	}
+
+	_, err := GetContainerLogs(ctx, st, stub, log, ContainerLogsOptions{
+		ContainerID:    "c",
+		OrganizationID: "not-valid-uuid",
+		Tail:           0,
+	})
+	require.NoError(t, err)
+}

--- a/api/internal/features/container/service/get_container_test.go
+++ b/api/internal/features/container/service/get_container_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	apinetwork "github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetContainer_error(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{}, errors.New("no such container")
+	}
+	_, err := GetContainer(stub, logger.NewLogger(), "deadbeef")
+	require.Error(t, err)
+}
+
+func TestGetContainer_fullShape(t *testing.T) {
+	t.Parallel()
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	stub := &stubDockerRepository{}
+	stub.getContainerByID = func(id string) (container.InspectResponse, error) {
+		require.Equal(t, "abc", id)
+
+		ns := &container.NetworkSettings{}
+		ns.Ports = nat.PortMap{
+			port: {{HostPort: "18080"}},
+		}
+		ns.Networks = map[string]*apinetwork.EndpointSettings{
+			"n1": {IPAddress: "172.18.0.2", Gateway: "172.18.0.1", Aliases: nil},
+		}
+		ns.IPAddress = "10.11.12.13"
+
+		return container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				ID:      "inspect-id",
+				Created: "2020-01-01",
+				Name:    "/fancy",
+				State: &container.State{
+					Status: "running",
+				},
+				HostConfig: &container.HostConfig{
+					Resources: container.Resources{
+						Memory:     4096,
+						MemorySwap: 8192,
+						CPUShares:  10,
+					},
+				},
+			},
+			Config: &container.Config{
+				Image:  "nginx:1",
+				Labels: map[string]string{"k": "v"},
+				Cmd:    []string{"/sbin/init", "--help"},
+			},
+			NetworkSettings: ns,
+			Mounts: []container.MountPoint{
+				{Type: mount.TypeBind, Source: "/a", Destination: "/b", Mode: "rw"},
+			},
+		}, nil
+	}
+
+	got, err := GetContainer(stub, logger.NewLogger(), "abc")
+	require.NoError(t, err)
+
+	require.Equal(t, "inspect-id", got.ID)
+	require.Equal(t, "fancy", got.Name)
+	require.Equal(t, "nginx:1", got.Image)
+	require.Equal(t, "/sbin/init", got.Command)
+	require.Equal(t, map[string]string{"k": "v"}, got.Labels)
+	require.Equal(t, "2020-01-01", got.Created)
+	require.Len(t, got.Ports, 1)
+	require.Equal(t, 8080, got.Ports[0].PrivatePort)
+	require.Equal(t, 18080, got.Ports[0].PublicPort)
+	require.Equal(t, "tcp", got.Ports[0].Type)
+	require.Len(t, got.Networks, 1)
+	require.Equal(t, "n1", got.Networks[0].Name)
+	require.Empty(t, got.Networks[0].Aliases)
+	require.Equal(t, "10.11.12.13", got.IPAddress)
+	require.Equal(t, int64(4096), got.HostConfig.Memory)
+
+	require.Len(t, got.Mounts, 1)
+	require.Equal(t, "bind", got.Mounts[0].Type)
+}
+
+func TestGetContainer_minimalOptionalNil(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				ID:      "x",
+				Created: "t",
+				Name:    "no-leading-slash",
+			},
+			NetworkSettings: &container.NetworkSettings{},
+		}, nil
+	}
+
+	got, err := GetContainer(stub, logger.NewLogger(), "x")
+	require.NoError(t, err)
+
+	require.Empty(t, got.Image)
+	require.Empty(t, got.Ports)
+	require.Empty(t, got.Networks)
+	require.Equal(t, "x", got.ID)
+	require.Equal(t, "t", got.Created)
+	require.Equal(t, "o-leading-slash", got.Name)
+}

--- a/api/internal/features/container/service/list_containers.go
+++ b/api/internal/features/container/service/list_containers.go
@@ -11,13 +11,12 @@ import (
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
-// ListContainers retrieves a paginated, filtered, and sorted list of containers
+// ListContainers retrieves containers grouped by application, with filtering, sorting, and pagination of groups.
 func ListContainers(
 	dockerService docker.DockerRepository,
 	l logger.Logger,
 	params container_types.ContainerListParams,
 ) (container_types.ListContainersResponse, error) {
-	// Get pre-filtered summaries from Docker
 	containers, err := dockerService.ListContainers(container.ListOptions{
 		All:     true,
 		Filters: buildDockerFilters(params),
@@ -27,19 +26,46 @@ func ListContainers(
 		return container_types.ListContainersResponse{}, err
 	}
 
-	// Build summaries, then search/sort/paginate
 	rows := summarizeContainers(containers)
-	pageRows, totalCount := applySearchSortPaginate(rows, params)
+	filteredRows := applySearchFilter(rows, params)
+	sortedRows := applySort(filteredRows, params)
 
-	// Build detailed container info for paginated results
-	result := appendContainerInfo(dockerService, l, pageRows, containers)
+	groups, ungrouped := groupContainersByApplication(sortedRows, containers, dockerService)
+
+	sort.SliceStable(groups, func(i, j int) bool {
+		if params.SortOrder == "desc" {
+			return groups[i].ApplicationName > groups[j].ApplicationName
+		}
+		return groups[i].ApplicationName < groups[j].ApplicationName
+	})
+
+	totalGroupCount := len(groups)
+	start := (params.Page - 1) * params.PageSize
+	if start > totalGroupCount {
+		start = totalGroupCount
+	}
+	end := start + params.PageSize
+	if end > totalGroupCount {
+		end = totalGroupCount
+	}
+	paginatedGroups := groups[start:end]
+
+	totalContainerCount := 0
+	for _, group := range groups {
+		totalContainerCount += len(group.Containers)
+	}
+	totalContainerCount += len(ungrouped)
+
+	paginatedUngrouped := ungrouped
 
 	return container_types.ListContainersResponse{
 		Status:  "success",
 		Message: "Containers fetched successfully",
 		Data: container_types.ListContainersResponseData{
-			Containers: result,
-			TotalCount: totalCount,
+			Groups:     paginatedGroups,
+			Ungrouped:  paginatedUngrouped,
+			TotalCount: totalContainerCount,
+			GroupCount: totalGroupCount,
 			Page:       params.Page,
 			PageSize:   params.PageSize,
 			SortBy:     params.SortBy,
@@ -91,7 +117,7 @@ func summarizeContainers(summaries []container.Summary) []container_types.Contai
 	return rows
 }
 
-func applySearchSortPaginate(rows []container_types.ContainerListRow, p container_types.ContainerListParams) ([]container_types.ContainerListRow, int) {
+func applySearchFilter(rows []container_types.ContainerListRow, p container_types.ContainerListParams) []container_types.ContainerListRow {
 	if p.Search != "" {
 		lower := strings.ToLower(p.Search)
 		filtered := make([]container_types.ContainerListRow, 0, len(rows))
@@ -102,9 +128,12 @@ func applySearchSortPaginate(rows []container_types.ContainerListRow, p containe
 				filtered = append(filtered, r)
 			}
 		}
-		rows = filtered
+		return filtered
 	}
+	return rows
+}
 
+func applySort(rows []container_types.ContainerListRow, p container_types.ContainerListParams) []container_types.ContainerListRow {
 	sort.SliceStable(rows, func(i, j int) bool {
 		switch p.SortBy {
 		case "status":
@@ -130,38 +159,49 @@ func applySearchSortPaginate(rows []container_types.ContainerListRow, p containe
 			return ai < aj
 		}
 	})
-
-	totalCount := len(rows)
-	start := (p.Page - 1) * p.PageSize
-	if start > totalCount {
-		start = totalCount
-	}
-	end := start + p.PageSize
-	if end > totalCount {
-		end = totalCount
-	}
-	return rows[start:end], totalCount
+	return rows
 }
 
-func appendContainerInfo(dockerService docker.DockerRepository, l logger.Logger, pageRows []container_types.ContainerListRow, summaries []container.Summary) []container_types.Container {
-	result := make([]container_types.Container, 0, len(pageRows))
-	for _, r := range pageRows {
-		info, err := dockerService.GetContainerById(r.ID)
+func groupContainersByApplication(
+	rows []container_types.ContainerListRow,
+	summaries []container.Summary,
+	dockerService interface {
+		GetContainerById(id string) (container.InspectResponse, error)
+	},
+) ([]container_types.ContainerGroup, []container_types.Container) {
+	groupsMap := make(map[string]*container_types.ContainerGroup)
+	ungrouped := make([]container_types.Container, 0)
+
+	summaryMap := make(map[string]container.Summary)
+	for _, s := range summaries {
+		summaryMap[s.ID] = s
+	}
+
+	for _, row := range rows {
+		applicationID := ""
+		applicationName := "Unknown Application"
+		if row.Labels != nil {
+			if id, ok := row.Labels["com.application.id"]; ok {
+				applicationID = id
+			}
+			if name, ok := row.Labels["com.application.name"]; ok {
+				applicationName = name
+			}
+		}
+
+		info, err := dockerService.GetContainerById(row.ID)
 		if err != nil {
-			l.Log(logger.Error, "Error inspecting container", r.ID)
 			continue
 		}
-		cd := container_types.Container{
-			ID:        r.ID,
-			Name:      r.Name,
-			Image:     r.Image,
-			Status:    r.Status,
-			State:     r.State,
+
+		containerData := container_types.Container{
+			ID:        row.ID,
+			Name:      row.Name,
+			Image:     row.Image,
+			Status:    row.Status,
+			State:     row.State,
 			Created:   info.Created,
-			Labels:    r.Labels,
-			Ports:     []container_types.Port{},
-			Mounts:    []container_types.Mount{},
-			Networks:  []container_types.Network{},
+			Labels:    row.Labels,
 			Command:   "",
 			IPAddress: info.NetworkSettings.IPAddress,
 			HostConfig: container_types.HostConfig{
@@ -170,43 +210,58 @@ func appendContainerInfo(dockerService docker.DockerRepository, l logger.Logger,
 				CPUShares:  info.HostConfig.CPUShares,
 			},
 		}
+
 		if info.Config != nil && info.Config.Cmd != nil && len(info.Config.Cmd) > 0 {
-			cd.Command = info.Config.Cmd[0]
+			containerData.Command = info.Config.Cmd[0]
 		}
-		for _, s := range summaries {
-			if s.ID == r.ID {
-				for _, p := range s.Ports {
-					cd.Ports = append(cd.Ports, container_types.Port{
-						PrivatePort: int(p.PrivatePort),
-						PublicPort:  int(p.PublicPort),
-						Type:        p.Type,
-					})
-				}
-				break
+
+		if s, ok := summaryMap[row.ID]; ok {
+			for _, p := range s.Ports {
+				containerData.Ports = append(containerData.Ports, container_types.Port{
+					PrivatePort: int(p.PrivatePort),
+					PublicPort:  int(p.PublicPort),
+					Type:        p.Type,
+				})
 			}
 		}
+
 		for _, m := range info.Mounts {
-			cd.Mounts = append(cd.Mounts, container_types.Mount{
+			containerData.Mounts = append(containerData.Mounts, container_types.Mount{
 				Type:        string(m.Type),
 				Source:      m.Source,
 				Destination: m.Destination,
 				Mode:        m.Mode,
 			})
 		}
+
 		for name, network := range info.NetworkSettings.Networks {
-			aliases := network.Aliases
-			if aliases == nil {
-				aliases = []string{}
-			}
-			cd.Networks = append(cd.Networks, container_types.Network{
+			containerData.Networks = append(containerData.Networks, container_types.Network{
 				Name:       name,
 				IPAddress:  network.IPAddress,
 				Gateway:    network.Gateway,
 				MacAddress: network.MacAddress,
-				Aliases:    aliases,
+				Aliases:    network.Aliases,
 			})
 		}
-		result = append(result, cd)
+
+		if applicationID != "" {
+			if _, exists := groupsMap[applicationID]; !exists {
+				groupsMap[applicationID] = &container_types.ContainerGroup{
+					ApplicationID:   applicationID,
+					ApplicationName: applicationName,
+					Containers:      make([]container_types.Container, 0),
+				}
+			}
+			groupsMap[applicationID].Containers = append(groupsMap[applicationID].Containers, containerData)
+		} else {
+			ungrouped = append(ungrouped, containerData)
+		}
 	}
-	return result
+
+	groups := make([]container_types.ContainerGroup, 0, len(groupsMap))
+	for _, group := range groupsMap {
+		groups = append(groups, *group)
+	}
+
+	return groups, ungrouped
 }

--- a/api/internal/features/container/service/list_containers_test.go
+++ b/api/internal/features/container/service/list_containers_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	apinetwork "github.com/docker/docker/api/types/network"
+	containertypes "github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func inspectForList(cid string) container.InspectResponse {
+	return container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:      cid,
+			Created: "2024-06-01T00:00:00Z",
+			HostConfig: &container.HostConfig{
+				Resources: container.Resources{
+					Memory:     100,
+					MemorySwap: 200,
+					CPUShares:  2,
+				},
+			},
+		},
+		Config: &container.Config{Cmd: []string{"/entry"}},
+		NetworkSettings: &container.NetworkSettings{
+			DefaultNetworkSettings: container.DefaultNetworkSettings{IPAddress: "10.0.0.1"},
+			Networks:               map[string]*apinetwork.EndpointSettings{"bridge": {}},
+		},
+	}
+}
+
+func TestListContainers_listDockerError(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.listContainers = func(container.ListOptions) ([]container.Summary, error) {
+		return nil, errors.New("list failed")
+	}
+	_, err := ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{Page: 1, PageSize: 10})
+	require.Error(t, err)
+}
+
+func TestListContainers_buildDockerFilters_captured(t *testing.T) {
+	t.Parallel()
+	var got container.ListOptions
+	stub := &stubDockerRepository{}
+	stub.listContainers = func(opts container.ListOptions) ([]container.Summary, error) {
+		got = opts
+		return nil, errors.New("stop")
+	}
+	_, _ = ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		Status: "running",
+		Name:   "web",
+		Image:  "nginx",
+	})
+
+	require.True(t, got.All)
+	require.Equal(t, []string{"running"}, got.Filters.Get("status"))
+	require.Equal(t, []string{"web"}, got.Filters.Get("name"))
+	require.Equal(t, []string{"nginx"}, got.Filters.Get("ancestor"))
+}
+
+func TestListContainers_sortGroupingPaginationInspectSkip(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.listContainers = func(container.ListOptions) ([]container.Summary, error) {
+		return []container.Summary{
+			{
+				ID:    "gid-b",
+				Names: []string{"/bbb"},
+				Image: "i2",
+				Labels: map[string]string{
+					"com.application.id":   "b1",
+					"com.application.name": "Beta App",
+				},
+				Status:  "Up",
+				State:   "running",
+				Created: 200,
+			},
+			{
+				ID:    "gid-a",
+				Names: []string{"/aaa"},
+				Image: "i1",
+				Labels: map[string]string{
+					"com.application.id":   "a1",
+					"com.application.name": "Alpha App",
+				},
+				Status:  "Up",
+				State:   "running",
+				Created: 100,
+			},
+			{
+				ID:      "solo",
+				Names:   []string{"/x"},
+				Image:   "soloimg",
+				Labels:  nil,
+				Status:  "Exited",
+				State:   "exited",
+				Created: 50,
+				Ports:   []container.Port{{PrivatePort: 443, Type: "tcp"}},
+			},
+			{
+				ID:      "badinspect",
+				Names:   []string{"/badinspect"},
+				Image:   "z",
+				Status:  "Up",
+				Created: 300,
+			},
+		}, nil
+	}
+	stub.getContainerByID = func(id string) (container.InspectResponse, error) {
+		if id == "badinspect" {
+			return container.InspectResponse{}, errors.New("inspect fail")
+		}
+		return inspectForList(id), nil
+	}
+
+	resp, err := ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		Page: 1, PageSize: 1, SortBy: "name", SortOrder: "asc",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, resp.Data.TotalCount)
+	require.Len(t, resp.Data.Ungrouped, 1)
+	require.Equal(t, "solo", resp.Data.Ungrouped[0].ID)
+	require.Equal(t, 2, resp.Data.GroupCount)
+	require.Len(t, resp.Data.Groups, 1)
+
+	resp2, err := ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		Page: 2, PageSize: 1, SortBy: "name", SortOrder: "asc",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp2.Data.Groups, 1)
+
+	_, err = ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		SortOrder: "desc", Page: 1, PageSize: 99,
+	})
+	require.NoError(t, err)
+
+	_, err = ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		SortBy: "status", SortOrder: "desc",
+	})
+	require.NoError(t, err)
+
+	_, err = ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		SortBy: "created", SortOrder: "desc",
+	})
+	require.NoError(t, err)
+
+	respFar, err := ListContainers(stub, logger.NewLogger(), containertypes.ContainerListParams{
+		SortOrder: "asc", Page: 100, PageSize: 10,
+	})
+	require.NoError(t, err)
+	require.Empty(t, respFar.Data.Groups)
+}
+
+func TestSummarizeContainers_edgeNames(t *testing.T) {
+	t.Parallel()
+	row := summarizeContainers([]container.Summary{
+		{ID: "e1", Names: []string{}, Image: "i", Created: 1},
+		{ID: "e2", Names: []string{"/"}, Image: "i", Created: 2},
+		{ID: "e3", Names: []string{"/svc"}, Image: "i", Created: 3},
+	})
+	require.Equal(t, "", row[0].Name)
+	require.Equal(t, "/", row[1].Name)
+	require.Equal(t, "svc", row[2].Name)
+}
+
+func TestApplySearchFilter(t *testing.T) {
+	t.Parallel()
+	rows := []containertypes.ContainerListRow{{Name: "foo", Image: "x", Status: "Up"}}
+	out := applySearchFilter(rows, containertypes.ContainerListParams{})
+	require.Len(t, out, 1)
+	out = applySearchFilter(rows, containertypes.ContainerListParams{Search: "FOO"})
+	require.Len(t, out, 1)
+	require.Empty(t, applySearchFilter(rows, containertypes.ContainerListParams{Search: "nomatch"}))
+}

--- a/api/internal/features/container/service/list_images_prune_update_test.go
+++ b/api/internal/features/container/service/list_images_prune_update_test.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	dockerfilters "github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListImages_containerIDRejected(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{}, errors.New("missing")
+	}
+	_, err := ListImages(stub, logger.NewLogger(), ListImagesOptions{ContainerID: "nope"})
+	require.Error(t, err)
+}
+
+func TestListImages_emptyResult(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{}, nil
+	}
+	stub.listAllImages = func(image.ListOptions) []image.Summary { return nil }
+	resp, err := ListImages(stub, logger.NewLogger(), ListImagesOptions{ContainerID: "ok"})
+	require.NoError(t, err)
+	require.Equal(t, "No images found", resp.Message)
+	require.Empty(t, resp.Data)
+}
+
+func TestListImages_referenceFilter_appendsWildcard(t *testing.T) {
+	t.Parallel()
+	want := dockerfilters.NewArgs()
+	want.Add("reference", "myrepo*")
+	stub := &stubDockerRepository{}
+	stub.listAllImages = func(opts image.ListOptions) []image.Summary {
+		require.Equal(t, want.Get("reference"), opts.Filters.Get("reference"))
+		return []image.Summary{}
+	}
+	_, err := ListImages(stub, logger.NewLogger(), ListImagesOptions{ImagePrefix: "myrepo"})
+	require.NoError(t, err)
+
+	stub2 := &stubDockerRepository{}
+	stub2.listAllImages = func(opts image.ListOptions) []image.Summary {
+		require.Equal(t, []string{"pinned*"}, opts.Filters.Get("reference"))
+		return []image.Summary{}
+	}
+	_, err = ListImages(stub2, logger.NewLogger(), ListImagesOptions{ImagePrefix: "pinned*"})
+	require.NoError(t, err)
+}
+
+func TestListImages_mapsNilSlicesToConcrete(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.listAllImages = func(image.ListOptions) []image.Summary {
+		return []image.Summary{
+			{
+				ID:          "id1",
+				Created:     55,
+				Size:        99,
+				SharedSize:  1,
+				VirtualSize: 100,
+			},
+		}
+	}
+	resp, err := ListImages(stub, logger.NewLogger(), ListImagesOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "Images listed successfully", resp.Message)
+	require.Len(t, resp.Data, 1)
+	im := resp.Data[0]
+	require.Empty(t, im.RepoDigests)
+	require.Empty(t, im.RepoTags)
+	require.NotNil(t, im.Labels)
+}
+
+func TestPruneImages_paths(t *testing.T) {
+	t.Parallel()
+	stub := &stubDockerRepository{}
+	stub.pruneImages = func(f dockerfilters.Args) (image.PruneReport, error) {
+		require.Equal(t, []string{"t"}, f.Get("until"))
+		require.Equal(t, []string{"k=v"}, f.Get("label"))
+		require.Equal(t, []string{"true"}, f.Get("dangling"))
+		return image.PruneReport{}, errors.New("prune boom")
+	}
+	_, err := PruneImages(stub, logger.NewLogger(), PruneImagesOptions{
+		Until: "t", Label: "k=v", Dangling: true,
+	})
+	require.Error(t, err)
+
+	stub.pruneImages = func(dockerfilters.Args) (image.PruneReport, error) {
+		return image.PruneReport{
+			SpaceReclaimed: 42,
+			ImagesDeleted: []image.DeleteResponse{
+				{Untagged: "a", Deleted: "b"},
+			},
+		}, nil
+	}
+	resp, err := PruneImages(stub, logger.NewLogger(), PruneImagesOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Data.ImagesDeleted, 1)
+	require.Equal(t, "a", resp.Data.ImagesDeleted[0].Untagged)
+	require.Equal(t, "b", resp.Data.ImagesDeleted[0].Deleted)
+	require.Equal(t, uint64(42), resp.Data.SpaceReclaimed)
+}
+
+func TestUpdateContainerResources_validationAndSuccess(t *testing.T) {
+	t.Parallel()
+	log := logger.NewLogger()
+	stub := &stubDockerRepository{}
+
+	_, err := UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{
+		ContainerID: "c",
+		Memory:      5 * 1024 * 1024,
+	})
+	require.Error(t, err)
+
+	_, err = UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{
+		ContainerID: "c",
+		Memory:      10 * 1024 * 1024,
+		MemorySwap:  5 * 1024 * 1024,
+	})
+	require.Error(t, err)
+
+	_, err = UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{
+		ContainerID: "c",
+		CPUShares:   1,
+	})
+	require.Error(t, err)
+
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{}, errors.New("inspect fail")
+	}
+	_, err = UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{
+		ContainerID: "c",
+		MemorySwap:  -1,
+	})
+	require.Error(t, err)
+
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{},
+			},
+		}, nil
+	}
+	_, err = UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{
+		ContainerID: "c",
+	})
+	require.Error(t, err)
+
+	stub.getContainerByID = func(string) (container.InspectResponse, error) {
+		return container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				State: &container.State{Running: true},
+			},
+		}, nil
+	}
+	stub.updateResources = func(string, container.UpdateConfig) (container.ContainerUpdateOKBody, error) {
+		return container.ContainerUpdateOKBody{}, errors.New("update api")
+	}
+	_, err = UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{ContainerID: "c"})
+	require.Error(t, err)
+
+	const memOk = int64(16 * 1024 * 1024)
+	stub.updateResources = func(id string, cfg container.UpdateConfig) (container.ContainerUpdateOKBody, error) {
+		require.Equal(t, "ok", id)
+		require.Equal(t, memOk, cfg.Resources.Memory)
+		require.Equal(t, int64(-1), cfg.Resources.MemorySwap)
+		require.Equal(t, int64(2), cfg.Resources.CPUShares)
+		return container.ContainerUpdateOKBody{Warnings: []string{"w1"}}, nil
+	}
+	respOK, err := UpdateContainerResources(stub, log, UpdateContainerResourcesOptions{
+		ContainerID: "ok",
+		Memory:      memOk,
+		MemorySwap:  -1,
+		CPUShares:   2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "success", respOK.Status)
+	require.Equal(t, []string{"w1"}, respOK.Data.Warnings)
+}

--- a/api/internal/tests/container/container_ops_test.go
+++ b/api/internal/tests/container/container_ops_test.go
@@ -251,6 +251,65 @@ func TestRestartContainer_ValidAuth_NoSSH(t *testing.T) {
 	)
 }
 
+// --- DELETE container (remove) ---
+
+func TestRemoveContainer_NoAuth(t *testing.T) {
+	containerID := uuid.New().String()
+	Test(t,
+		Description("DELETE /container/:id without auth returns 401"),
+		Delete(tests.GetContainerURL(containerID)),
+		Expect().Status().Equal(http.StatusUnauthorized),
+	)
+}
+
+func TestRemoveContainer_ValidAuth_NoSSH(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("DELETE /container/:id — OK or 500 (no SSH in CI); remove does not reject non-UUID in controller"),
+		Delete(tests.GetContainerURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
+	)
+}
+
+func TestRemoveContainer_InvalidOrgHeader(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("DELETE /container/:id with invalid org header returns 400"),
+		Delete(tests.GetContainerURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("not-a-uuid"),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestRemoveContainer_CrossOrgDenied(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("DELETE /container/:id for different org returns 403"),
+		Delete(tests.GetContainerURL(uuid.New().String())),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add("123e4567-e89b-12d3-a456-426614174000"),
+		Expect().Status().Equal(http.StatusForbidden),
+	)
+}
+
 // --- PUT container resources ---
 
 func TestGetContainerResources_NoAuth(t *testing.T) {

--- a/api/internal/tests/container/get_container_logs_test.go
+++ b/api/internal/tests/container/get_container_logs_test.go
@@ -30,7 +30,7 @@ func TestGetContainerLogs(t *testing.T) {
 		Send().Headers("Cookie").Add(cookies),
 		Send().Headers("X-Organization-Id").Add(orgID),
 		Expect().Status().Equal(http.StatusOK),
-		Store().Response().Body().JSON().JQ(".data.containers[0].id").In(&containerID),
+		Store().Response().Body().JSON().JQ(tests.JQFirstContainerIDFromList()).In(&containerID),
 	)
 
 	testCases := []struct {
@@ -148,7 +148,7 @@ func TestGetContainerLogsWithFilters(t *testing.T) {
 		Send().Headers("Cookie").Add(cookies),
 		Send().Headers("X-Organization-Id").Add(orgID),
 		Expect().Status().Equal(http.StatusOK),
-		Store().Response().Body().JSON().JQ(".data.containers[0].id").In(&containerID),
+		Store().Response().Body().JSON().JQ(tests.JQFirstContainerIDFromList()).In(&containerID),
 	)
 
 	t.Run("Fetch logs with tail parameter", func(t *testing.T) {
@@ -354,7 +354,7 @@ func TestGetContainerLogsPermissions(t *testing.T) {
 		Send().Headers("Cookie").Add(cookies),
 		Send().Headers("X-Organization-Id").Add(orgID),
 		Expect().Status().Equal(http.StatusOK),
-		Store().Response().Body().JSON().JQ(".data.containers[0].id").In(&containerID),
+		Store().Response().Body().JSON().JQ(tests.JQFirstContainerIDFromList()).In(&containerID),
 	)
 
 	t.Run("Access logs with organization member permissions", func(t *testing.T) {

--- a/api/internal/tests/container/get_container_test.go
+++ b/api/internal/tests/container/get_container_test.go
@@ -28,7 +28,7 @@ func TestGetContainer(t *testing.T) {
 		Send().Headers("Cookie").Add(cookies),
 		Send().Headers("X-Organization-Id").Add(orgID),
 		Expect().Status().Equal(http.StatusOK),
-		Store().Response().Body().JSON().JQ(".data.containers[0].id").In(&containerID),
+		Store().Response().Body().JSON().JQ(tests.JQFirstContainerIDFromList()).In(&containerID),
 	)
 
 	testCases := []struct {
@@ -139,7 +139,7 @@ func TestGetContainerDetailedValidation(t *testing.T) {
 		Send().Headers("Cookie").Add(cookies),
 		Send().Headers("X-Organization-Id").Add(orgID),
 		Expect().Status().Equal(http.StatusOK),
-		Store().Response().Body().JSON().JQ(`.data.containers[] | select(.name == "nixopus-test-db-container") | .id`).In(&containerID),
+		Store().Response().Body().JSON().JQ(tests.JQContainerIDNamed("nixopus-test-db-container")).In(&containerID),
 	)
 
 	if containerID == "" {

--- a/api/internal/tests/helper.go
+++ b/api/internal/tests/helper.go
@@ -1,5 +1,7 @@
 package tests
 
+import "fmt"
+
 var baseURL = "http://localhost:8080/api/v1"
 
 func GetHealthURL() string {
@@ -76,6 +78,19 @@ func GetContainerURL(containerID string) string {
 
 func GetContainerLogsURL(containerID string) string {
 	return baseURL + "/container/" + containerID + "/logs"
+}
+
+// JQFirstContainerIDFromList resolves a container id from ListContainers grouped JSON (.groups / .ungrouped).
+func JQFirstContainerIDFromList() string {
+	return `(.data.ungrouped[0].id // .data.groups[0].containers[0].id)`
+}
+
+// JQContainerIDNamed builds jq that finds a container id by exact name among ungrouped and grouped containers.
+func JQContainerIDNamed(containerName string) string {
+	return fmt.Sprintf(
+		`[.data.ungrouped[]?, (.data.groups // [])[].containers[]?] | map(select(.name == %q)) | .[0].id`,
+		containerName,
+	)
 }
 
 func GetDomainURL() string {


### PR DESCRIPTION
## Summary

- Moves `ListContainers` orchestration into the container **service**; controller parses query params and delegates.
- Adds **service unit tests** with a stub `DockerRepository`, plus tightening of `get_container_logs` (org/settings only when `Tail` is unset; `tailLinesFromOrgLogTailSetting`).
- **Integration tests**: `DELETE /container/:id` (remove); jq helpers and updates for grouped list response (`groups` / `ungrouped`) in get-container and logs suites.

## Test plan

- [ ] `go test ./internal/features/container/service/...`
- [ ] Run container integration suite against API + infra when available