### PR TITLE
test(notification): unit coverage

### DIFF
--- a/api/internal/features/notification/channel/agent_test.go
+++ b/api/internal/features/notification/channel/agent_test.go
@@ -1,0 +1,300 @@
+package channel
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newTokenServer returns a test server that serves a valid token response.
+// If delay > 0 it sleeps before responding, giving concurrent goroutines time
+// to pile up waiting for the write lock inside getToken().
+func newTokenServer(t *testing.T, accessToken string, expiresIn int, delay time.Duration) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		_ = json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: accessToken,
+			TokenType:   "Bearer",
+			ExpiresIn:   expiresIn,
+		})
+	}))
+}
+
+func newWebhookServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+}
+
+func baseMsg() Message {
+	return Message{
+		Body: "hello agent",
+		Metadata: map[string]string{
+			"event_type":      "test.event",
+			"organization_id": "org-1",
+			"user_id":         "user-1",
+			"extra_key":       "extra_val",
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constructor + Type
+// ---------------------------------------------------------------------------
+
+func TestNewAgentChannel_ReturnsNonNil(t *testing.T) {
+	ch := NewAgentChannel("https://wh.example.com", "https://token.example.com", "cid", "csecret")
+	require.NotNil(t, ch)
+	assert.NotNil(t, ch.httpClient)
+}
+
+func TestAgentChannel_Type(t *testing.T) {
+	ch := NewAgentChannel("", "", "", "")
+	assert.Equal(t, "agent", ch.Type())
+}
+
+// ---------------------------------------------------------------------------
+// Send — token acquisition failures
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_Send_TokenServer_Non200(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer tokenSrv.Close()
+
+	webhookSrv := newWebhookServer(t, http.StatusOK)
+	defer webhookSrv.Close()
+
+	ch := NewAgentChannel(webhookSrv.URL, tokenSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent channel token acquisition failed")
+	assert.Contains(t, err.Error(), "token endpoint returned status 403")
+}
+
+func TestAgentChannel_Send_TokenServer_InvalidJSON(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer tokenSrv.Close()
+
+	ch := NewAgentChannel("http://wh.example.com", tokenSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent channel token acquisition failed")
+	assert.Contains(t, err.Error(), "failed to decode token response")
+}
+
+func TestAgentChannel_Send_TokenServer_HTTPError(t *testing.T) {
+	// Point to a server that is already closed → connection refused.
+	closedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	closedSrv.Close()
+
+	ch := NewAgentChannel("http://wh.example.com", closedSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent channel token acquisition failed")
+}
+
+// ---------------------------------------------------------------------------
+// Send — webhook failures (token succeeds)
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_Send_Webhook_HTTPError(t *testing.T) {
+	tokenSrv := newTokenServer(t, "tok", 3600, 0)
+	defer tokenSrv.Close()
+
+	// Closed webhook server → connection refused.
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	webhookSrv.Close()
+
+	ch := NewAgentChannel(webhookSrv.URL, tokenSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent channel webhook POST failed")
+}
+
+func TestAgentChannel_Send_Webhook_Non2xx(t *testing.T) {
+	tokenSrv := newTokenServer(t, "tok", 3600, 0)
+	defer tokenSrv.Close()
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request body", http.StatusBadRequest)
+	}))
+	defer webhookSrv.Close()
+
+	ch := NewAgentChannel(webhookSrv.URL, tokenSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent channel webhook returned status 400")
+}
+
+// ---------------------------------------------------------------------------
+// Send — success
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_Send_Success(t *testing.T) {
+	tokenSrv := newTokenServer(t, "mytoken", 3600, 0)
+	defer tokenSrv.Close()
+
+	var receivedAuth string
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookSrv.Close()
+
+	ch := NewAgentChannel(webhookSrv.URL, tokenSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer mytoken", receivedAuth)
+}
+
+// ---------------------------------------------------------------------------
+// getToken — cached token path (RLock fast path)
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_getToken_CacheHit(t *testing.T) {
+	ch := NewAgentChannel("http://wh.example.com", "http://token.example.com", "cid", "csecret")
+	// Seed the cache directly (same package).
+	ch.cachedToken = "pre-cached"
+	ch.tokenExpiry = time.Now().Add(time.Hour)
+
+	token, err := ch.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, "pre-cached", token)
+}
+
+// ---------------------------------------------------------------------------
+// getToken — short-lived token (covers the skew < expiresIn/2 branch)
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_getToken_ShortLivedToken(t *testing.T) {
+	// ExpiresIn = 5 seconds → 5s < 2*5min, so skew = ExpiresIn/2 = 2.5s
+	tokenSrv := newTokenServer(t, "short-token", 5, 0)
+	defer tokenSrv.Close()
+
+	ch := NewAgentChannel("http://wh.example.com", tokenSrv.URL, "cid", "csecret")
+	token, err := ch.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, "short-token", token)
+	// Expiry should be within the next 5 seconds (skew = 2.5s → expiry ≤ now+2.5s)
+	assert.True(t, ch.tokenExpiry.Before(time.Now().Add(5*time.Second)))
+}
+
+// ---------------------------------------------------------------------------
+// getToken — http.NewRequest creation error (invalid token URL)
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_getToken_TokenRequestCreationError(t *testing.T) {
+	// "://invalid" is not a valid URL — http.NewRequest will fail.
+	ch := NewAgentChannel("http://wh.example.com", "://invalid-token-url", "cid", "csecret")
+
+	_, err := ch.getToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create token request")
+}
+
+// ---------------------------------------------------------------------------
+// Send — http.NewRequestWithContext creation error (invalid webhook URL)
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_Send_WebhookRequestCreationError(t *testing.T) {
+	// Token server is valid; webhook URL is invalid so request creation fails.
+	tokenSrv := newTokenServer(t, "tok", 3600, 0)
+	defer tokenSrv.Close()
+
+	ch := NewAgentChannel("://invalid-webhook", tokenSrv.URL, "cid", "csecret")
+
+	err := ch.Send(context.Background(), baseMsg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent channel request creation failed")
+}
+
+// ---------------------------------------------------------------------------
+// getToken — double-checked lock (lines 120-122)
+//
+// Strategy:
+//  1. The test holds ch.mu.RLock() — multiple readers can still acquire RLock,
+//     but any goroutine trying Lock() will block until ALL readers release.
+//  2. N goroutines are released; they each call RLock (succeeds), see cache
+//     miss, call RUnlock, then call Lock() — all N block here.
+//  3. After a brief sleep (goroutines are now queued at Lock), the test
+//     releases its RLock.
+//  4. The first goroutine gets the write Lock, fetches the token (slow server),
+//     sets cachedToken, then releases Lock.
+//  5. Each subsequent goroutine gets Lock one-by-one and hits the double-check
+//     at lines 120-122 where cachedToken is already populated.
+// ---------------------------------------------------------------------------
+
+func TestAgentChannel_getToken_DoubleCheckLock(t *testing.T) {
+	prev := runtime.GOMAXPROCS(4)
+	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+
+	// Token server with a deliberate delay so the first lock-holder keeps the
+	// write lock long enough for other goroutines to queue behind it.
+	tokenSrv := newTokenServer(t, "lock-token", 3600, 20*time.Millisecond)
+	defer tokenSrv.Close()
+
+	ch := NewAgentChannel("http://wh.example.com", tokenSrv.URL, "cid", "csecret")
+
+	const N = 5
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	tokens := make([]string, N)
+	errs := make([]error, N)
+
+	// Hold a read lock: goroutines can pass RLock (cache miss) but will then
+	// block at Lock() until we release this reader lock.
+	ch.mu.RLock()
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			tok, err := ch.getToken()
+			tokens[idx] = tok
+			errs[idx] = err
+		}(i)
+	}
+
+	close(start)
+	// Pure mutex operations take nanoseconds; 5ms is extremely generous.
+	time.Sleep(5 * time.Millisecond)
+
+	// Release the read lock — goroutines can now compete for the write lock.
+	ch.mu.RUnlock()
+
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d failed", i)
+		assert.Equal(t, "lock-token", tokens[i])
+	}
+	assert.Equal(t, "lock-token", ch.cachedToken)
+}

--- a/api/internal/features/notification/channel/discord_test.go
+++ b/api/internal/features/notification/channel/discord_test.go
@@ -1,0 +1,118 @@
+package channel
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDiscordChannel_ReturnsNonNil(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewDiscordChannel(db, context.Background())
+	require.NotNil(t, ch)
+}
+
+func TestDiscordChannel_Type(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewDiscordChannel(db, context.Background())
+	assert.Equal(t, "discord", ch.Type())
+}
+
+func TestDiscordChannel_Send_MissingOrgID(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewDiscordChannel(db, context.Background())
+
+	err := ch.Send(context.Background(), Message{Body: "hi"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization_id required")
+}
+
+func TestDiscordChannel_Send_WebhookLookupError(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewDiscordChannel(db, context.Background())
+
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": uuid.New().String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active discord webhook")
+}
+
+func TestDiscordChannel_Send_HTTPError(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	closed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closed.Close()
+	insertActiveWebhook(t, db, "discord", closed.URL, orgID)
+
+	ch := NewDiscordChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send discord notification")
+}
+
+func TestDiscordChannel_Send_Non2xx(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	insertActiveWebhook(t, db, "discord", srv.URL, orgID)
+
+	ch := NewDiscordChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "discord webhook returned status 500")
+}
+
+func TestDiscordChannel_Send_Success_StatusOK(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	var receivedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 512)
+		n, _ := r.Body.Read(buf)
+		receivedBody = string(buf[:n])
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	insertActiveWebhook(t, db, "discord", srv.URL, orgID)
+
+	ch := NewDiscordChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "server alert",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, receivedBody, "server alert")
+}
+
+func TestDiscordChannel_Send_Success_StatusNoContent(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	insertActiveWebhook(t, db, "discord", srv.URL, orgID)
+
+	ch := NewDiscordChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+}

--- a/api/internal/features/notification/channel/email_test.go
+++ b/api/internal/features/notification/channel/email_test.go
@@ -1,0 +1,336 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Constructor + Type
+// ---------------------------------------------------------------------------
+
+func TestNewEmailChannel_ReturnsNonNil(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewEmailChannel(db, context.Background())
+	require.NotNil(t, ch)
+}
+
+func TestEmailChannel_Type(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewEmailChannel(db, context.Background())
+	assert.Equal(t, "email", ch.Type())
+}
+
+// ---------------------------------------------------------------------------
+// Send — early validation errors
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_Send_MissingOrgID(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewEmailChannel(db, context.Background())
+
+	err := ch.Send(context.Background(), Message{
+		To:   "user@example.com",
+		Body: "hello",
+		// no Metadata
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization_id required")
+}
+
+func TestEmailChannel_Send_GetSmtpError(t *testing.T) {
+	// Use a DB with no smtp_configs table so the lookup fails.
+	db := newChannelTestDB(t)
+	// Drop the smtp_configs table to force an error.
+	_, err := db.ExecContext(context.Background(), "DROP TABLE smtp_configs")
+	require.NoError(t, err)
+
+	ch := NewEmailChannel(db, context.Background())
+	err = ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Body:     "hello",
+		Metadata: map[string]string{"organization_id": uuid.New().String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve SMTP config")
+}
+
+func TestEmailChannel_Send_EmptyRecipient(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	// Use the bad-SMTP address as host; we won't reach dial because recipient is empty.
+	insertActiveSMTP(t, db, "127.0.0.1", 9, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:       "",
+		Body:     "hello",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recipient address is required")
+}
+
+// ---------------------------------------------------------------------------
+// Send — template rendering branches
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_Send_TemplateName_ParseError(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	insertActiveSMTP(t, db, "127.0.0.1", 9, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:           "user@example.com",
+		Body:         "hello",
+		TemplateName: "nonexistent_template.html",
+		Metadata:     map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template render failed")
+}
+
+// TestEmailChannel_Send_TemplateName_ExecuteError covers the tmpl.Execute error
+// path by using a template that references an undefined sub-template.
+func TestEmailChannel_Send_TemplateName_ExecuteError(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	insertActiveSMTP(t, db, "127.0.0.1", 9, orgID)
+
+	// Build a temp directory tree that mirrors what renderTemplate expects:
+	//   <root>/internal/features/notification/templates/<name>
+	root := t.TempDir()
+	tmplDir := filepath.Join(root, "internal", "features", "notification", "templates")
+	require.NoError(t, os.MkdirAll(tmplDir, 0o755))
+
+	// Template that calls an undefined sub-template → Execute will error.
+	tmplName := "bad_execute.html"
+	content := `{{template "undefined_subtmpl" .}}`
+	require.NoError(t, os.WriteFile(filepath.Join(tmplDir, tmplName), []byte(content), 0o644))
+
+	// Change working directory so os.Getwd() returns root.
+	t.Chdir(root)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:           "user@example.com",
+		Body:         "hello",
+		TemplateName: tmplName,
+		Metadata:     map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template render failed")
+}
+
+// ---------------------------------------------------------------------------
+// Send — content-type branches
+// ---------------------------------------------------------------------------
+
+// HTMLBody set + no TemplateName → html content-type, body = HTMLBody.
+func TestEmailChannel_Send_HTMLBody_NoTemplateName(t *testing.T) {
+	smtpAddr, results := startFakeSMTPServer(t)
+
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	parts := strings.SplitN(smtpAddr, ":", 2)
+	port, _ := strconv.Atoi(parts[1])
+	insertActiveSMTP(t, db, parts[0], port, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		HTMLBody: "<b>hello</b>",
+		Subject:  "Test",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+	select {
+	case res := <-results:
+		assert.True(t, res.Received)
+		assert.Contains(t, res.Body, "text/html")
+	default:
+		t.Fatal("fake SMTP server did not receive a message")
+	}
+}
+
+// TemplateName set → rendered html body (uses a real temp template file).
+func TestEmailChannel_Send_TemplateName_Success(t *testing.T) {
+	root := t.TempDir()
+	tmplDir := filepath.Join(root, "internal", "features", "notification", "templates")
+	require.NoError(t, os.MkdirAll(tmplDir, 0o755))
+	tmplName := "welcome.html"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmplDir, tmplName),
+		[]byte(`<h1>Hello {{.Name}}</h1>`),
+		0o644,
+	))
+	t.Chdir(root)
+
+	smtpAddr, results := startFakeSMTPServer(t)
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	parts := strings.SplitN(smtpAddr, ":", 2)
+	port, _ := strconv.Atoi(parts[1])
+	insertActiveSMTP(t, db, parts[0], port, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:           "user@example.com",
+		TemplateName: tmplName,
+		TemplateData: map[string]interface{}{"Name": "Alice"},
+		Subject:      "Welcome",
+		Metadata:     map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+	select {
+	case res := <-results:
+		assert.True(t, res.Received)
+		assert.Contains(t, res.Body, "text/html")
+	default:
+		t.Fatal("fake SMTP server did not receive a message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Send — subject default branch
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_Send_DefaultSubject(t *testing.T) {
+	smtpAddr, results := startFakeSMTPServer(t)
+
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	parts := strings.SplitN(smtpAddr, ":", 2)
+	port, _ := strconv.Atoi(parts[1])
+	insertActiveSMTP(t, db, parts[0], port, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Body:     "plain body",
+		Subject:  "", // triggers default
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+	select {
+	case res := <-results:
+		assert.True(t, res.Received)
+		assert.Contains(t, res.Body, "Notification from Nixopus")
+	default:
+		t.Fatal("fake SMTP server did not receive a message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Send — SMTP dial failure
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_Send_SMTPDialFail(t *testing.T) {
+	badAddr := startBadSMTPServer(t)
+
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	parts := strings.SplitN(badAddr, ":", 2)
+	port, _ := strconv.Atoi(parts[1])
+	insertActiveSMTP(t, db, parts[0], port, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Body:     "hello",
+		Subject:  "Test",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "smtp send failed")
+}
+
+// ---------------------------------------------------------------------------
+// Send — plain text success (no template, no HTMLBody, subject provided)
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_Send_PlainText_Success(t *testing.T) {
+	smtpAddr, results := startFakeSMTPServer(t)
+
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	parts := strings.SplitN(smtpAddr, ":", 2)
+	port, _ := strconv.Atoi(parts[1])
+	insertActiveSMTP(t, db, parts[0], port, orgID)
+
+	ch := NewEmailChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		To:       "recipient@example.com",
+		Body:     "plain text body",
+		Subject:  "Hello",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+	select {
+	case res := <-results:
+		assert.True(t, res.Received)
+		assert.Contains(t, res.Body, "text/plain")
+	default:
+		t.Fatal("fake SMTP server did not receive a message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getSmtpByOrg — error path (no row in smtp_configs)
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_getSmtpByOrg_NoRow(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewEmailChannel(db, context.Background())
+
+	cfg, err := ch.getSmtpByOrg("no-such-org")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active SMTP config for org no-such-org")
+	assert.Nil(t, cfg)
+}
+
+// ---------------------------------------------------------------------------
+// renderTemplate — parse error (non-existent template file)
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_renderTemplate_ParseError(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewEmailChannel(db, context.Background())
+
+	_, err := ch.renderTemplate("definitely_does_not_exist.html", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template parse error")
+}
+
+// ---------------------------------------------------------------------------
+// renderTemplate — success
+// ---------------------------------------------------------------------------
+
+func TestEmailChannel_renderTemplate_Success(t *testing.T) {
+	root := t.TempDir()
+	tmplDir := filepath.Join(root, "internal", "features", "notification", "templates")
+	require.NoError(t, os.MkdirAll(tmplDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmplDir, "greet.html"),
+		[]byte(`Hello {{.Name}}!`),
+		0o644,
+	))
+	t.Chdir(root)
+
+	db := newChannelTestDB(t)
+	ch := NewEmailChannel(db, context.Background())
+
+	out, err := ch.renderTemplate("greet.html", map[string]interface{}{"Name": "Bob"})
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("Hello %s!", "Bob"), out)
+}

--- a/api/internal/features/notification/channel/helpers_test.go
+++ b/api/internal/features/notification/channel/helpers_test.go
@@ -1,0 +1,197 @@
+package channel
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	_ "modernc.org/sqlite"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory SQLite DB helpers
+// ---------------------------------------------------------------------------
+
+// newChannelTestDB opens a fresh in-memory SQLite database and creates all
+// tables used by the channel adapters (smtp_configs, webhook_configs).
+func newChannelTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", fmt.Sprintf("file:channeltest_%s?mode=memory&cache=shared", uuid.New().String()))
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	_, err = db.NewCreateTable().
+		Model((*shared_types.SMTPConfigs)(nil)).
+		IfNotExists().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewCreateTable().
+		Model((*shared_types.WebhookConfig)(nil)).
+		IfNotExists().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	return db
+}
+
+// insertActiveSMTP inserts an active SMTP config for the given org and returns it.
+func insertActiveSMTP(t *testing.T, db *bun.DB, host string, port int, orgID uuid.UUID) *shared_types.SMTPConfigs {
+	t.Helper()
+	cfg := &shared_types.SMTPConfigs{
+		ID:             uuid.New(),
+		Host:           host,
+		Port:           port,
+		Username:       "testuser",
+		Password:       "testpass",
+		FromEmail:      "from@example.com",
+		FromName:       "Test",
+		Security:       "none",
+		IsActive:       true,
+		UserID:         uuid.New(),
+		OrganizationID: orgID,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	_, err := db.NewInsert().Model(cfg).Exec(context.Background())
+	require.NoError(t, err)
+	return cfg
+}
+
+// insertActiveWebhook inserts an active webhook config for the given org and type.
+func insertActiveWebhook(t *testing.T, db *bun.DB, webhookType, webhookURL string, orgID uuid.UUID) {
+	t.Helper()
+	cfg := &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           webhookType,
+		WebhookURL:     webhookURL,
+		ChannelID:      webhookType + ":" + orgID.String(),
+		IsActive:       true,
+		UserID:         uuid.New(),
+		OrganizationID: orgID,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	_, err := db.NewInsert().Model(cfg).Exec(context.Background())
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Minimal fake SMTP server
+// ---------------------------------------------------------------------------
+
+// smtpResult collects the outcome of a single fake SMTP transaction.
+type smtpResult struct {
+	Received bool
+	Body     string
+}
+
+// startFakeSMTPServer starts a minimal SMTP listener on a random localhost port
+// that accepts one transaction then closes. It advertises AUTH PLAIN so that
+// smtp.PlainAuth works without TLS (localhost is exempt from the TLS requirement).
+// Returns the address ("host:port") and a channel that receives the body text.
+func startFakeSMTPServer(t *testing.T) (addr string, results chan smtpResult) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	results = make(chan smtpResult, 1)
+
+	go func() {
+		defer l.Close()
+		conn, err := l.Accept()
+		if err != nil {
+			results <- smtpResult{}
+			return
+		}
+		defer conn.Close()
+
+		rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+		write := func(s string) {
+			_, _ = rw.WriteString(s)
+			_ = rw.Flush()
+		}
+
+		write("220 smtp.test ESMTP\r\n")
+
+		var msgBuf strings.Builder
+		inData := false
+
+		for {
+			line, err := rw.ReadString('\n')
+			if err != nil {
+				break
+			}
+			line = strings.TrimRight(line, "\r\n")
+
+			if inData {
+				if line == "." {
+					inData = false
+					write("250 OK: message queued\r\n")
+					results <- smtpResult{Received: true, Body: msgBuf.String()}
+					continue
+				}
+				// un-dot-stuff
+				if strings.HasPrefix(line, ".") {
+					line = line[1:]
+				}
+				msgBuf.WriteString(line + "\n")
+				continue
+			}
+
+			upper := strings.ToUpper(line)
+			switch {
+			case strings.HasPrefix(upper, "EHLO"), strings.HasPrefix(upper, "HELO"):
+				write("250-smtp.test Hello\r\n250-AUTH PLAIN LOGIN\r\n250 SIZE 10240000\r\n")
+			case strings.HasPrefix(upper, "AUTH"):
+				write("235 Authentication successful\r\n")
+			case strings.HasPrefix(upper, "MAIL FROM"):
+				write("250 OK\r\n")
+			case strings.HasPrefix(upper, "RCPT TO"):
+				write("250 OK\r\n")
+			case upper == "DATA":
+				write("354 Start mail input; end with <CRLF>.<CRLF>\r\n")
+				inData = true
+			case upper == "QUIT":
+				write("221 Bye\r\n")
+				return
+			default:
+				write("500 Unknown command\r\n")
+			}
+		}
+	}()
+
+	t.Cleanup(func() { l.Close() })
+	return l.Addr().String(), results
+}
+
+// startBadSMTPServer starts a server that accepts a connection but immediately
+// sends garbage, causing smtp.SendMail to fail during the protocol handshake.
+func startBadSMTPServer(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		defer l.Close()
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("garbage not smtp\r\n"))
+		conn.Close()
+	}()
+	t.Cleanup(func() { l.Close() })
+	return l.Addr().String()
+}

--- a/api/internal/features/notification/channel/slack_test.go
+++ b/api/internal/features/notification/channel/slack_test.go
@@ -1,0 +1,120 @@
+package channel
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSlackChannel_ReturnsNonNil(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewSlackChannel(db, context.Background())
+	require.NotNil(t, ch)
+}
+
+func TestSlackChannel_Type(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewSlackChannel(db, context.Background())
+	assert.Equal(t, "slack", ch.Type())
+}
+
+func TestSlackChannel_Send_MissingOrgID(t *testing.T) {
+	db := newChannelTestDB(t)
+	ch := NewSlackChannel(db, context.Background())
+
+	err := ch.Send(context.Background(), Message{Body: "hi"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization_id required")
+}
+
+func TestSlackChannel_Send_WebhookLookupError(t *testing.T) {
+	db := newChannelTestDB(t)
+	// No webhook row inserted → getWebhookURL returns an error.
+	ch := NewSlackChannel(db, context.Background())
+
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": uuid.New().String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active slack webhook")
+}
+
+func TestSlackChannel_Send_HTTPError(t *testing.T) {
+	// Insert a webhook that points to a closed server.
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	closed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closed.Close()
+	insertActiveWebhook(t, db, "slack", closed.URL, orgID)
+
+	ch := NewSlackChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send slack notification")
+}
+
+func TestSlackChannel_Send_Non2xx(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	insertActiveWebhook(t, db, "slack", srv.URL, orgID)
+
+	ch := NewSlackChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slack webhook returned status 400")
+}
+
+func TestSlackChannel_Send_Success_StatusOK(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	var receivedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 512)
+		n, _ := r.Body.Read(buf)
+		receivedBody = string(buf[:n])
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	insertActiveWebhook(t, db, "slack", srv.URL, orgID)
+
+	ch := NewSlackChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "deploy complete",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, receivedBody, "deploy complete")
+}
+
+func TestSlackChannel_Send_Success_StatusNoContent(t *testing.T) {
+	db := newChannelTestDB(t)
+	orgID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	insertActiveWebhook(t, db, "slack", srv.URL, orgID)
+
+	ch := NewSlackChannel(db, context.Background())
+	err := ch.Send(context.Background(), Message{
+		Body:     "hi",
+		Metadata: map[string]string{"organization_id": orgID.String()},
+	})
+	require.NoError(t, err)
+}

--- a/api/internal/features/notification/channel/system_email_test.go
+++ b/api/internal/features/notification/channel/system_email_test.go
@@ -1,0 +1,202 @@
+package channel
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Constructor + Type
+// ---------------------------------------------------------------------------
+
+func TestNewSystemEmailChannel_ReturnsNonNil(t *testing.T) {
+	ch := NewSystemEmailChannel("key", "from@example.com")
+	require.NotNil(t, ch)
+	assert.NotNil(t, ch.client)
+}
+
+func TestSystemEmailChannel_Type(t *testing.T) {
+	ch := NewSystemEmailChannel("key", "from@example.com")
+	assert.Equal(t, "system_email", ch.Type())
+}
+
+// ---------------------------------------------------------------------------
+// Send — early validation errors
+// ---------------------------------------------------------------------------
+
+func TestSystemEmailChannel_Send_NoAPIKey(t *testing.T) {
+	ch := NewSystemEmailChannel("", "from@example.com")
+
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Metadata: map[string]string{"resend_template_id": "tmpl_123"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RESEND_API_KEY not configured")
+}
+
+func TestSystemEmailChannel_Send_NoTemplateID_Key(t *testing.T) {
+	ch := NewSystemEmailChannel("api-key", "from@example.com")
+
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Metadata: map[string]string{}, // resend_template_id missing
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resend_template_id not set")
+}
+
+func TestSystemEmailChannel_Send_EmptyTemplateID_Value(t *testing.T) {
+	ch := NewSystemEmailChannel("api-key", "from@example.com")
+
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Metadata: map[string]string{"resend_template_id": ""},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resend_template_id not set")
+}
+
+func TestSystemEmailChannel_Send_EmptyRecipient(t *testing.T) {
+	ch := NewSystemEmailChannel("api-key", "from@example.com")
+
+	err := ch.Send(context.Background(), Message{
+		To:       "",
+		Metadata: map[string]string{"resend_template_id": "tmpl_123"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recipient address is required")
+}
+
+// ---------------------------------------------------------------------------
+// Send — HTTP errors
+// ---------------------------------------------------------------------------
+
+func TestSystemEmailChannel_Send_HTTPError(t *testing.T) {
+	closed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closed.Close()
+
+	ch := NewSystemEmailChannel("api-key", "from@example.com")
+	// Point the client to a closed server by replacing the default client.
+	ch.client = closed.Client()
+
+	// Use a custom transport that always fails.
+	ch.client.Transport = &failTransport{}
+
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Metadata: map[string]string{"resend_template_id": "tmpl_123"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resend API request failed")
+}
+
+func TestSystemEmailChannel_Send_4xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid_api_key"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	ch := NewSystemEmailChannel("bad-key", "from@example.com")
+	ch.client = srv.Client()
+	// Redirect the Resend API calls to our test server.
+	ch.client.Transport = &rewriteTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Metadata: map[string]string{"resend_template_id": "tmpl_123"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resend API error (HTTP 401)")
+}
+
+// ---------------------------------------------------------------------------
+// Send — success paths
+// ---------------------------------------------------------------------------
+
+func TestSystemEmailChannel_Send_Success_NoTemplateData(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		assert.Equal(t, "Bearer api-key", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ch := NewSystemEmailChannel("api-key", "from@example.com")
+	ch.client = srv.Client()
+	ch.client.Transport = &rewriteTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	err := ch.Send(context.Background(), Message{
+		To:       "user@example.com",
+		Metadata: map[string]string{"resend_template_id": "tmpl_123"},
+		// no TemplateData → variables NOT included in payload
+	})
+	require.NoError(t, err)
+	tmpl := captured["template"].(map[string]interface{})
+	assert.Equal(t, "tmpl_123", tmpl["id"])
+	_, hasVars := tmpl["variables"]
+	assert.False(t, hasVars)
+}
+
+func TestSystemEmailChannel_Send_Success_WithTemplateData(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ch := NewSystemEmailChannel("api-key", "from@example.com")
+	ch.client = srv.Client()
+	ch.client.Transport = &rewriteTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	err := ch.Send(context.Background(), Message{
+		To:           "user@example.com",
+		Metadata:     map[string]string{"resend_template_id": "tmpl_456"},
+		TemplateData: map[string]interface{}{"Name": "Alice", "Action": "login"},
+	})
+	require.NoError(t, err)
+	tmpl := captured["template"].(map[string]interface{})
+	assert.Equal(t, "tmpl_456", tmpl["id"])
+	assert.NotNil(t, tmpl["variables"])
+}
+
+// ---------------------------------------------------------------------------
+// Test transport helpers
+// ---------------------------------------------------------------------------
+
+// failTransport always returns an error, simulating a network failure.
+type failTransport struct{}
+
+func (f *failTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, assert.AnError
+}
+
+// rewriteTransport rewrites requests destined for "https://api.resend.com" to
+// the given target (our httptest server URL) so we can intercept them.
+type rewriteTransport struct {
+	target string
+	inner  http.RoundTripper
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := req.Clone(req.Context())
+	req2.URL.Host = req.URL.Host // preserve path/query
+	// Replace the scheme+host with our test server.
+	import_req, _ := http.NewRequestWithContext(req.Context(), req.Method, rt.target+req.URL.Path, req.Body)
+	if import_req != nil {
+		import_req.Header = req.Header
+		return rt.inner.RoundTrip(import_req)
+	}
+	return rt.inner.RoundTrip(req)
+}

--- a/api/internal/features/notification/dispatcher.go
+++ b/api/internal/features/notification/dispatcher.go
@@ -221,16 +221,16 @@ func (d *Dispatcher) buildPlainTextBody(event shared_types.NotificationEvent) st
 }
 
 func (d *Dispatcher) resolveUserEmail(userID string) (string, error) {
-	var user shared_types.User
+	var email string
 	err := d.db.NewSelect().
-		Model(&user).
 		Column("email").
+		TableExpr("user").
 		Where("id = ?", userID).
-		Scan(d.ctx)
+		Scan(d.ctx, &email)
 	if err != nil {
 		return "", fmt.Errorf("user not found: %w", err)
 	}
-	return user.Email, nil
+	return email, nil
 }
 
 func (d *Dispatcher) isAgentEnabledForOrg(orgIDStr string) bool {

--- a/api/internal/features/notification/dispatcher_test.go
+++ b/api/internal/features/notification/dispatcher_test.go
@@ -1,0 +1,478 @@
+package notification
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/notification/channel"
+	"github.com/nixopus/nixopus/api/internal/features/notification/tasks"
+	"github.com/nixopus/nixopus/api/internal/queue"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	_ "modernc.org/sqlite"
+)
+
+type stubChannel struct {
+	typeName string
+	sendErr  error
+	lastMsg  channel.Message
+}
+
+func (s *stubChannel) Type() string { return s.typeName }
+
+func (s *stubChannel) Send(ctx context.Context, msg channel.Message) error {
+	_ = ctx
+	s.lastMsg = msg
+	return s.sendErr
+}
+
+func dispatcherTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=shared&_busy_timeout=5000")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+	for _, m := range []any{
+		(*shared_types.NotificationPreferences)(nil),
+		(*shared_types.PreferenceItem)(nil),
+	} {
+		_, err = db.NewCreateTable().Model(m).IfNotExists().Exec(ctx)
+		require.NoError(t, err)
+	}
+	_, err = db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS "user" (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
+	email TEXT NOT NULL,
+	email_verified INTEGER NOT NULL DEFAULT 0,
+	is_onboarded INTEGER NOT NULL DEFAULT 0,
+	created_at DATETIME NOT NULL,
+	updated_at DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS organization_settings (
+	id TEXT PRIMARY KEY,
+	organization_id TEXT NOT NULL UNIQUE,
+	settings TEXT NOT NULL,
+	created_at DATETIME NOT NULL,
+	updated_at DATETIME NOT NULL
+);
+`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		CREATE UNIQUE INDEX IF NOT EXISTS notification_preferences_one_per_user
+		ON notification_preferences (user_id)
+	`)
+	require.NoError(t, err)
+	return db
+}
+
+func insertUser(t *testing.T, db *bun.DB, id uuid.UUID, email string) {
+	t.Helper()
+	now := time.Now()
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO "user" (id, name, email, email_verified, is_onboarded, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id.String(), "Test", email, 1, 0, now, now)
+	require.NoError(t, err)
+}
+
+func insertOrgSettingsAI(t *testing.T, db *bun.DB, orgID uuid.UUID, aiEnabled bool) {
+	t.Helper()
+	data := shared_types.DefaultOrganizationSettingsData()
+	data.AIIncidentsEnabled = &aiEnabled
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	now := time.Now()
+	_, err = db.ExecContext(context.Background(),
+		`INSERT INTO organization_settings (id, organization_id, settings, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		uuid.New().String(), orgID.String(), string(raw), now, now)
+	require.NoError(t, err)
+}
+
+func insertPrefEnabled(t *testing.T, db *bun.DB, userID uuid.UUID, category, typ string, enabled bool) {
+	t.Helper()
+	ctx := context.Background()
+	prefID := uuid.New()
+	now := time.Now()
+	_, err := db.NewInsert().Model(&shared_types.NotificationPreferences{
+		ID:        prefID,
+		UserID:    userID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&shared_types.PreferenceItem{
+		ID:           uuid.New(),
+		PreferenceID: prefID,
+		Category:     category,
+		Type:         typ,
+		Enabled:      enabled,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func fullChannelMap() map[string]channel.Channel {
+	return map[string]channel.Channel{
+		"email":        &stubChannel{typeName: "email"},
+		"slack":        &stubChannel{typeName: "slack"},
+		"discord":      &stubChannel{typeName: "discord"},
+		"agent":        &stubChannel{typeName: "agent"},
+		"system_email": &stubChannel{typeName: "system_email"},
+	}
+}
+
+func testQueue(t *testing.T) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	opt, err := redis.ParseURL("redis://" + mr.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { _ = rdb.Close() })
+	queue.Init(rdb)
+	t.Cleanup(func() { _ = queue.Close() })
+}
+
+func TestNewDispatcher(t *testing.T) {
+	db := dispatcherTestDB(t)
+	d := NewDispatcher(db, context.Background(), logger.NewLogger(), map[string]channel.Channel{})
+	require.NotNil(t, d)
+}
+
+func TestDispatcher_buildMessage(t *testing.T) {
+	ctx := context.Background()
+	db := dispatcherTestDB(t)
+	d := &Dispatcher{db: db, ctx: ctx, logger: logger.NewLogger()}
+	uid := uuid.New().String()
+	org := uuid.New().String()
+
+	t.Run("email_with_template", func(t *testing.T) {
+		ev := shared_types.NotificationEvent{
+			Type:           shared_types.EventLoginAlert,
+			UserID:         uid,
+			OrganizationID: org,
+			Data:           map[string]interface{}{"ip": "1.2.3.4"},
+		}
+		msg := d.buildMessage(ev, "email", "u@x.com")
+		assert.Equal(t, "u@x.com", msg.To)
+		assert.NotEmpty(t, msg.Subject)
+		assert.NotEmpty(t, msg.TemplateName)
+	})
+
+	t.Run("email_without_template", func(t *testing.T) {
+		ev := shared_types.NotificationEvent{
+			Type:           shared_types.EventDeploySuccess,
+			UserID:         uid,
+			OrganizationID: org,
+		}
+		msg := d.buildMessage(ev, "email", "u@x.com")
+		assert.Contains(t, msg.Body, "deploy.success")
+	})
+
+	t.Run("system_email_trial", func(t *testing.T) {
+		ev := shared_types.NotificationEvent{
+			Type:           shared_types.EventTrialExpired,
+			UserID:         uid,
+			OrganizationID: org,
+			Data:           map[string]interface{}{"k": "v"},
+		}
+		msg := d.buildMessage(ev, "system_email", "u@x.com")
+		assert.Equal(t, "trial-expired", msg.Metadata["resend_template_id"])
+	})
+
+	t.Run("slack_plain", func(t *testing.T) {
+		ev := shared_types.NotificationEvent{
+			Type:           shared_types.EventUserAddedToOrg,
+			UserID:         uid,
+			OrganizationID: org,
+			Data: map[string]interface{}{
+				"UserName": "A", "UserEmail": "a@b.com", "OrganizationName": "Org",
+			},
+		}
+		msg := d.buildMessage(ev, "slack", "")
+		assert.Contains(t, msg.Body, "New user")
+	})
+
+	t.Run("agent_metadata_strings", func(t *testing.T) {
+		ev := shared_types.NotificationEvent{
+			Type:           shared_types.EventDeployFailed,
+			UserID:         uid,
+			OrganizationID: org,
+			Data: map[string]interface{}{
+				"trace_id": "abc",
+				"skip":     42,
+				"empty":    "",
+			},
+		}
+		msg := d.buildMessage(ev, "agent", "")
+		assert.Equal(t, "abc", msg.Metadata["trace_id"])
+		_, hasSkip := msg.Metadata["skip"]
+		assert.False(t, hasSkip)
+	})
+}
+
+func TestDispatcher_buildPlainTextBody(t *testing.T) {
+	d := &Dispatcher{ctx: context.Background(), logger: logger.NewLogger()}
+	data := func(kv ...string) map[string]interface{} {
+		m := map[string]interface{}{}
+		for i := 0; i+1 < len(kv); i += 2 {
+			m[kv[i]] = kv[i+1]
+		}
+		return m
+	}
+	t.Run("user_added", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventUserAddedToOrg,
+			Data: data("UserName", "N", "UserEmail", "e@e.com", "OrganizationName", "O"),
+		})
+		assert.Contains(t, body, "N")
+	})
+	t.Run("user_removed", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventUserRemovedFromOrg,
+			Data: data("UserName", "N", "UserEmail", "e@e.com", "OrganizationName", "O"),
+		})
+		assert.Contains(t, body, "removed")
+	})
+	t.Run("deploy_success", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventDeploySuccess,
+			Data: data("app_name", "app1"),
+		})
+		assert.Contains(t, body, "app1")
+	})
+	t.Run("deploy_failed", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventDeployFailed,
+			Data: data("app_name", "app1"),
+		})
+		assert.Contains(t, body, "failed")
+	})
+	t.Run("build_failed", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventBuildFailed,
+			Data: data("app_name", "app1", "error_message", "boom"),
+		})
+		assert.Contains(t, body, "boom")
+	})
+	t.Run("health_critical", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventHealthCheckCritical,
+			Data: data("app_id", "a", "endpoint", "/h", "consecutive_fails", "3"),
+		})
+		assert.Contains(t, body, "critical")
+	})
+	t.Run("default", func(t *testing.T) {
+		body := d.buildPlainTextBody(shared_types.NotificationEvent{
+			Type: shared_types.EventContainerCrashed,
+		})
+		assert.Contains(t, body, "container.crashed")
+	})
+}
+
+func TestGetDataStr(t *testing.T) {
+	assert.Equal(t, "", getDataStr(nil, "k"))
+	assert.Equal(t, "", getDataStr(map[string]interface{}{"k": 1}, "k"))
+	assert.Equal(t, "x", getDataStr(map[string]interface{}{"k": "x"}, "k"))
+}
+
+func TestDispatcher_resolveUserEmail(t *testing.T) {
+	db := dispatcherTestDB(t)
+	ctx := context.Background()
+	uid := uuid.New()
+	insertUser(t, db, uid, "want@example.com")
+	d := NewDispatcher(db, ctx, logger.NewLogger(), nil)
+
+	email, err := d.resolveUserEmail(uid.String())
+	require.NoError(t, err)
+	assert.Equal(t, "want@example.com", email)
+
+	_, err = d.resolveUserEmail(uuid.New().String())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+func TestDispatcher_isAgentEnabledForOrg(t *testing.T) {
+	db := dispatcherTestDB(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	insertOrgSettingsAI(t, db, orgID, true)
+	d := NewDispatcher(db, ctx, logger.NewLogger(), nil)
+
+	assert.False(t, d.isAgentEnabledForOrg("not-a-uuid"))
+	assert.False(t, d.isAgentEnabledForOrg(uuid.New().String()))
+	assert.True(t, d.isAgentEnabledForOrg(orgID.String()))
+}
+
+func TestDispatcher_SendDirect(t *testing.T) {
+	db := dispatcherTestDB(t)
+	ctx := context.Background()
+	uid := uuid.New()
+	insertUser(t, db, uid, "direct@example.com")
+	emailCh := &stubChannel{typeName: "email"}
+	d := NewDispatcher(db, ctx, logger.NewLogger(), map[string]channel.Channel{"email": emailCh})
+
+	t.Run("unsupported_channel", func(t *testing.T) {
+		resp := d.SendDirect(SendNotificationRequest{Channel: "sms", Message: "m"}, uid.String(), "org")
+		require.False(t, resp.Success)
+		assert.Contains(t, resp.Error, "unsupported")
+	})
+
+	t.Run("email_resolve_recipient_error", func(t *testing.T) {
+		resp := d.SendDirect(SendNotificationRequest{Channel: "email", Message: "m"}, uuid.New().String(), "org")
+		require.False(t, resp.Success)
+		assert.Contains(t, resp.Error, "failed to resolve recipient")
+	})
+
+	t.Run("email_uses_db_when_to_empty", func(t *testing.T) {
+		resp := d.SendDirect(SendNotificationRequest{Channel: "email", Message: "hello"}, uid.String(), "org-1")
+		require.True(t, resp.Success)
+		assert.Equal(t, "direct@example.com", emailCh.lastMsg.To)
+	})
+
+	t.Run("default_subject", func(t *testing.T) {
+		_ = d.SendDirect(SendNotificationRequest{Channel: "email", To: "x@y.com", Message: "b"}, uid.String(), "org")
+		assert.Equal(t, "Notification from Nixopus", emailCh.lastMsg.Subject)
+	})
+
+	t.Run("send_error", func(t *testing.T) {
+		errCh := &stubChannel{typeName: "email", sendErr: errors.New("send failed")}
+		dd := NewDispatcher(db, ctx, logger.NewLogger(), map[string]channel.Channel{"email": errCh})
+		resp := dd.SendDirect(SendNotificationRequest{Channel: "email", To: "a@b.com", Message: "x"}, uid.String(), "org")
+		require.False(t, resp.Success)
+		assert.Contains(t, resp.Error, "send failed")
+	})
+}
+
+func TestDispatcher_Emit(t *testing.T) {
+	testQueue(t)
+	db := dispatcherTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	orgID := uuid.New()
+	insertUser(t, db, userID, "emit@example.com")
+	insertPrefEnabled(t, db, userID, "activity", "team-updates", true)
+	d := NewDispatcher(db, ctx, logger.NewLogger(), fullChannelMap())
+	d.SetupQueue()
+	require.NotNil(t, tasks.NotificationQueue)
+	require.NotNil(t, tasks.TaskSendNotification)
+
+	prevQ, prevT := tasks.NotificationQueue, tasks.TaskSendNotification
+	t.Cleanup(func() { tasks.NotificationQueue, tasks.TaskSendNotification = prevQ, prevT })
+
+	t.Run("skip_preference_password_reset", func(t *testing.T) {
+		err := d.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventPasswordReset,
+			UserID:         userID.String(),
+			OrganizationID: orgID.String(),
+			Channels:       []string{"email"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("preference_suppressed", func(t *testing.T) {
+		u := uuid.New()
+		insertUser(t, db, u, "suppress@example.com")
+		insertPrefEnabled(t, db, u, "security", "login-alerts", false)
+		err := d.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventLoginAlert,
+			UserID:         u.String(),
+			OrganizationID: orgID.String(),
+			Channels:       []string{"email"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("preference_check_error_still_suppressed", func(t *testing.T) {
+		bad := NewDispatcher(db, ctx, logger.NewLogger(), fullChannelMap())
+		err := bad.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventLoginAlert,
+			UserID:         "not-a-uuid",
+			OrganizationID: orgID.String(),
+			Channels:       []string{"email"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("unknown_event_uses_default_channels", func(t *testing.T) {
+		err := d.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventContainerCrashed,
+			UserID:         userID.String(),
+			OrganizationID: orgID.String(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("unregistered_channel_skipped", func(t *testing.T) {
+		err := d.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventPasswordReset,
+			UserID:         userID.String(),
+			OrganizationID: orgID.String(),
+			Channels:       []string{"unknown_x"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("agent_skipped_when_disabled", func(t *testing.T) {
+		err := d.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventDeployFailed,
+			UserID:         userID.String(),
+			OrganizationID: orgID.String(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("agent_enqueued_when_enabled", func(t *testing.T) {
+		orgAI := uuid.New()
+		insertOrgSettingsAI(t, db, orgAI, true)
+		err := d.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventDeployFailed,
+			UserID:         userID.String(),
+			OrganizationID: orgAI.String(),
+			Channels:       []string{"agent"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("enqueue_error", func(t *testing.T) {
+		tasks.NotificationQueue, tasks.TaskSendNotification = nil, nil
+		t.Cleanup(func() { tasks.NotificationQueue, tasks.TaskSendNotification = prevQ, prevT })
+		dd := NewDispatcher(db, ctx, logger.NewLogger(), map[string]channel.Channel{
+			"email": &stubChannel{typeName: "email"},
+		})
+		err := dd.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventPasswordReset,
+			UserID:         userID.String(),
+			OrganizationID: orgID.String(),
+			Channels:       []string{"email"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("resolve_email_failure_continues", func(t *testing.T) {
+		emptyUserDB := dispatcherTestDB(t)
+		dd := NewDispatcher(emptyUserDB, context.Background(), logger.NewLogger(), fullChannelMap())
+		tasks.NotificationQueue, tasks.TaskSendNotification = prevQ, prevT
+		dd.SetupQueue()
+		err := dd.Emit(shared_types.NotificationEvent{
+			Type:           shared_types.EventPasswordReset,
+			UserID:         uuid.New().String(),
+			OrganizationID: orgID.String(),
+			Channels:       []string{"email"},
+		})
+		require.NoError(t, err)
+	})
+}

--- a/api/internal/features/notification/event_test.go
+++ b/api/internal/features/notification/event_test.go
@@ -1,0 +1,32 @@
+package notification
+
+import (
+	"testing"
+
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultChannelsForEvent(t *testing.T) {
+	tests := []struct {
+		event shared_types.EventType
+		want  []string
+	}{
+		{shared_types.EventLoginAlert, []string{"email"}},
+		{shared_types.EventPasswordReset, []string{"email"}},
+		{shared_types.EventVerificationEmail, []string{"email"}},
+		{shared_types.EventUserAddedToOrg, []string{"email", "slack", "discord"}},
+		{shared_types.EventUserRemovedFromOrg, []string{"email", "slack", "discord"}},
+		{shared_types.EventDeploySuccess, []string{"slack", "discord"}},
+		{shared_types.EventDeployFailed, []string{"slack", "discord", "agent"}},
+		{shared_types.EventBuildFailed, []string{"email", "slack", "discord", "agent"}},
+		{shared_types.EventHealthCheckCritical, []string{"email", "slack", "discord", "agent"}},
+		{shared_types.EventTrialExpired, []string{"system_email"}},
+		{shared_types.EventContainerCrashed, []string{"email"}},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.event), func(t *testing.T) {
+			assert.Equal(t, tt.want, defaultChannelsForEvent(tt.event))
+		})
+	}
+}

--- a/api/internal/features/notification/helpers/preferences/check_user_preference_test.go
+++ b/api/internal/features/notification/helpers/preferences/check_user_preference_test.go
@@ -1,0 +1,218 @@
+package preferences
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	_ "modernc.org/sqlite"
+)
+
+// newTestDB opens a fresh in-memory SQLite DB and creates the two tables used
+// by CheckUserNotificationPreferences. Returns the DB; caller should defer Close.
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=shared&_busy_timeout=5000")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	_, err = db.NewCreateTable().
+		Model((*shared_types.NotificationPreferences)(nil)).
+		IfNotExists().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewCreateTable().
+		Model((*shared_types.PreferenceItem)(nil)).
+		IfNotExists().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	return db
+}
+
+// insertPreference inserts a NotificationPreferences row and returns its ID.
+func insertPreference(t *testing.T, db *bun.DB, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	prefID := uuid.New()
+	now := time.Now()
+	pref := &shared_types.NotificationPreferences{
+		ID:        prefID,
+		UserID:    userID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	_, err := db.NewInsert().Model(pref).Exec(context.Background())
+	require.NoError(t, err)
+	return prefID
+}
+
+// insertPreferenceItem inserts a PreferenceItem row for the given preferenceID.
+func insertPreferenceItem(t *testing.T, db *bun.DB, prefID uuid.UUID, category, typ string, enabled bool) {
+	t.Helper()
+	now := time.Now()
+	item := &shared_types.PreferenceItem{
+		ID:           uuid.New(),
+		PreferenceID: prefID,
+		Category:     category,
+		Type:         typ,
+		Enabled:      enabled,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	_, err := db.NewInsert().Model(item).Exec(context.Background())
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// NewPreferenceManager
+// ---------------------------------------------------------------------------
+
+func TestNewPreferenceManager_ReturnsNonNil(t *testing.T) {
+	db := newTestDB(t)
+	m := NewPreferenceManager(db, context.Background())
+	require.NotNil(t, m)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — invalid userID
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_InvalidUserID(t *testing.T) {
+	db := newTestDB(t)
+	m := NewPreferenceManager(db, context.Background())
+
+	ok, err := m.CheckUserNotificationPreferences("not-a-uuid", "security", "login-alerts")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid user ID")
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — preferences query: sql.ErrNoRows
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_NoPreferencesRow_ReturnsFalseNil(t *testing.T) {
+	db := newTestDB(t)
+	m := NewPreferenceManager(db, context.Background())
+
+	// No row inserted for this user → sql.ErrNoRows on the first select.
+	ok, err := m.CheckUserNotificationPreferences(uuid.New().String(), "security", "login-alerts")
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — preferences query: non-ErrNoRows DB error
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_PreferencesQueryError(t *testing.T) {
+	// Open a DB without creating any tables so the first select fails with
+	// "no such table: notification_preferences" (not sql.ErrNoRows).
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	m := NewPreferenceManager(db, context.Background())
+
+	ok, err := m.CheckUserNotificationPreferences(uuid.New().String(), "security", "login-alerts")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch user preferences")
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — preference item query: sql.ErrNoRows
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_NoPreferenceItem_ReturnsFalseNil(t *testing.T) {
+	db := newTestDB(t)
+	userID := uuid.New()
+	// Preference row exists but no item for this category/type.
+	insertPreference(t, db, userID)
+	m := NewPreferenceManager(db, context.Background())
+
+	ok, err := m.CheckUserNotificationPreferences(userID.String(), "security", "login-alerts")
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — preference item query: non-ErrNoRows error
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_PreferenceItemQueryError(t *testing.T) {
+	// Create only the notification_preferences table; omit preference_item so
+	// the second select fails with "no such table: preference_item".
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.NewCreateTable().
+		Model((*shared_types.NotificationPreferences)(nil)).
+		IfNotExists().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	userID := uuid.New()
+	insertPreference(t, db, userID)
+
+	m := NewPreferenceManager(db, ctx)
+
+	ok, err := m.CheckUserNotificationPreferences(userID.String(), "security", "login-alerts")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch preference item")
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — success: enabled = true
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_EnabledTrue(t *testing.T) {
+	db := newTestDB(t)
+	userID := uuid.New()
+	prefID := insertPreference(t, db, userID)
+	insertPreferenceItem(t, db, prefID, "security", "login-alerts", true)
+	m := NewPreferenceManager(db, context.Background())
+
+	ok, err := m.CheckUserNotificationPreferences(userID.String(), "security", "login-alerts")
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// CheckUserNotificationPreferences — success: enabled = false
+// ---------------------------------------------------------------------------
+
+func TestCheckUserNotificationPreferences_EnabledFalse(t *testing.T) {
+	db := newTestDB(t)
+	userID := uuid.New()
+	prefID := insertPreference(t, db, userID)
+	insertPreferenceItem(t, db, prefID, "update", "newsletter", false)
+	m := NewPreferenceManager(db, context.Background())
+
+	ok, err := m.CheckUserNotificationPreferences(userID.String(), "update", "newsletter")
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/api/internal/features/notification/service/mock_test.go
+++ b/api/internal/features/notification/service/mock_test.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/notification"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+)
+
+// mockNotificationRepo is a hand-written test double for storage.NotificationRepository.
+// Each method delegates to an optional func field; nil fields return benign zero values.
+type mockNotificationRepo struct {
+	addSmtp              func(config *shared_types.SMTPConfigs) error
+	updateSmtp           func(config *notification.UpdateSMTPConfigRequest) error
+	deleteSmtp           func(ID string) error
+	getSmtp              func(ID string) (*shared_types.SMTPConfigs, error)
+	getOrganizationsSmtp func(organizationID string) ([]shared_types.SMTPConfigs, error)
+	updatePreference     func(ctx context.Context, req notification.UpdatePreferenceRequest, userID uuid.UUID) error
+	getPreferences       func(ctx context.Context, userID uuid.UUID) (*notification.GetPreferencesResponse, error)
+	createWebhookConfig  func(ctx context.Context, config *shared_types.WebhookConfig) error
+	updateWebhookConfig  func(ctx context.Context, config *shared_types.WebhookConfig) error
+	deleteWebhookConfig  func(ctx context.Context, webhookType string, organizationID uuid.UUID) error
+	getWebhookConfig     func(ctx context.Context, webhookType string, organizationID uuid.UUID) (*shared_types.WebhookConfig, error)
+}
+
+func (m *mockNotificationRepo) AddSmtp(config *shared_types.SMTPConfigs) error {
+	if m.addSmtp != nil {
+		return m.addSmtp(config)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) UpdateSmtp(config *notification.UpdateSMTPConfigRequest) error {
+	if m.updateSmtp != nil {
+		return m.updateSmtp(config)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) DeleteSmtp(ID string) error {
+	if m.deleteSmtp != nil {
+		return m.deleteSmtp(ID)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) GetSmtp(ID string) (*shared_types.SMTPConfigs, error) {
+	if m.getSmtp != nil {
+		return m.getSmtp(ID)
+	}
+	return nil, nil
+}
+
+func (m *mockNotificationRepo) GetOrganizationsSmtp(organizationID string) ([]shared_types.SMTPConfigs, error) {
+	if m.getOrganizationsSmtp != nil {
+		return m.getOrganizationsSmtp(organizationID)
+	}
+	return nil, nil
+}
+
+func (m *mockNotificationRepo) UpdatePreference(ctx context.Context, req notification.UpdatePreferenceRequest, userID uuid.UUID) error {
+	if m.updatePreference != nil {
+		return m.updatePreference(ctx, req, userID)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) GetPreferences(ctx context.Context, userID uuid.UUID) (*notification.GetPreferencesResponse, error) {
+	if m.getPreferences != nil {
+		return m.getPreferences(ctx, userID)
+	}
+	return &notification.GetPreferencesResponse{}, nil
+}
+
+func (m *mockNotificationRepo) CreateWebhookConfig(ctx context.Context, config *shared_types.WebhookConfig) error {
+	if m.createWebhookConfig != nil {
+		return m.createWebhookConfig(ctx, config)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) UpdateWebhookConfig(ctx context.Context, config *shared_types.WebhookConfig) error {
+	if m.updateWebhookConfig != nil {
+		return m.updateWebhookConfig(ctx, config)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) DeleteWebhookConfig(ctx context.Context, webhookType string, organizationID uuid.UUID) error {
+	if m.deleteWebhookConfig != nil {
+		return m.deleteWebhookConfig(ctx, webhookType, organizationID)
+	}
+	return nil
+}
+
+func (m *mockNotificationRepo) GetWebhookConfig(ctx context.Context, webhookType string, organizationID uuid.UUID) (*shared_types.WebhookConfig, error) {
+	if m.getWebhookConfig != nil {
+		return m.getWebhookConfig(ctx, webhookType, organizationID)
+	}
+	return &shared_types.WebhookConfig{}, nil
+}
+
+// newTestService creates a NotificationService wired with the provided mock and sane defaults.
+func newTestService(repo *mockNotificationRepo) *NotificationService {
+	l := logger.NewLogger()
+	return &NotificationService{
+		storage: repo,
+		Ctx:     context.Background(),
+		logger:  l,
+	}
+}

--- a/api/internal/features/notification/service/service_test.go
+++ b/api/internal/features/notification/service/service_test.go
@@ -1,0 +1,625 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/notification"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NewNotificationService
+// ---------------------------------------------------------------------------
+
+func TestNewNotificationService_ReturnsWiredService(t *testing.T) {
+	repo := &mockNotificationRepo{}
+	l := logger.NewLogger()
+	ctx := context.Background()
+
+	svc := NewNotificationService(nil, ctx, l, repo)
+
+	require.NotNil(t, svc)
+	assert.Equal(t, ctx, svc.Ctx)
+}
+
+// ---------------------------------------------------------------------------
+// GetPreferences
+// ---------------------------------------------------------------------------
+
+func TestGetPreferences_Success(t *testing.T) {
+	userID := uuid.New()
+	expected := &notification.GetPreferencesResponse{
+		Activity: []notification.PreferenceType{{ID: "team-updates"}},
+	}
+	repo := &mockNotificationRepo{
+		getPreferences: func(ctx context.Context, id uuid.UUID) (*notification.GetPreferencesResponse, error) {
+			assert.Equal(t, userID, id)
+			return expected, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.GetPreferences(userID)
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestGetPreferences_StorageError(t *testing.T) {
+	storageErr := errors.New("db unavailable")
+	repo := &mockNotificationRepo{
+		getPreferences: func(_ context.Context, _ uuid.UUID) (*notification.GetPreferencesResponse, error) {
+			return nil, storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.GetPreferences(uuid.New())
+
+	assert.ErrorIs(t, err, storageErr)
+}
+
+// ---------------------------------------------------------------------------
+// AddSmtp
+// ---------------------------------------------------------------------------
+
+func TestAddSmtp_ExistingConfig_ReturnsAlreadyExistsError(t *testing.T) {
+	existing := &shared_types.SMTPConfigs{ID: uuid.New()}
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return existing, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.AddSmtp(notification.CreateSMTPConfigRequest{
+		Host: "smtp.example.com", Port: 587, Username: "user@example.com", Password: "pass",
+		OrganizationID: uuid.New(),
+	}, uuid.New())
+
+	assert.ErrorIs(t, err, notification.ErrSmtpAlreadyExists)
+}
+
+func TestAddSmtp_GetSmtpErrorIgnored_ProceedsToAdd(t *testing.T) {
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, errors.New("lookup failed")
+		},
+		addSmtp: func(_ *shared_types.SMTPConfigs) error {
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.AddSmtp(notification.CreateSMTPConfigRequest{
+		Host: "smtp.example.com", Port: 587, Username: "user@example.com", Password: "pass",
+		OrganizationID: uuid.New(),
+	}, uuid.New())
+
+	require.NoError(t, err)
+}
+
+func TestAddSmtp_Success(t *testing.T) {
+	userID := uuid.New()
+	var capturedConfig *shared_types.SMTPConfigs
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, nil
+		},
+		addSmtp: func(c *shared_types.SMTPConfigs) error {
+			capturedConfig = c
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.AddSmtp(notification.CreateSMTPConfigRequest{
+		Host: "smtp.example.com", Port: 587, Username: "user@example.com", Password: "pass",
+		FromName: "Nixopus", FromEmail: "noreply@example.com",
+		OrganizationID: uuid.New(),
+	}, userID)
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedConfig)
+	assert.Equal(t, userID, capturedConfig.UserID)
+}
+
+func TestAddSmtp_StorageAddError(t *testing.T) {
+	storageErr := errors.New("insert failed")
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, nil
+		},
+		addSmtp: func(_ *shared_types.SMTPConfigs) error {
+			return storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.AddSmtp(notification.CreateSMTPConfigRequest{
+		Host: "smtp.example.com", Port: 587, Username: "user@example.com", Password: "pass",
+		OrganizationID: uuid.New(),
+	}, uuid.New())
+
+	assert.ErrorIs(t, err, storageErr)
+}
+
+// ---------------------------------------------------------------------------
+// DeleteSmtp
+// ---------------------------------------------------------------------------
+
+func TestDeleteSmtp_Success(t *testing.T) {
+	const smtpID = "some-id"
+	var called string
+	repo := &mockNotificationRepo{
+		deleteSmtp: func(id string) error {
+			called = id
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.DeleteSmtp(smtpID)
+
+	require.NoError(t, err)
+	assert.Equal(t, smtpID, called)
+}
+
+func TestDeleteSmtp_StorageError(t *testing.T) {
+	storageErr := errors.New("delete failed")
+	repo := &mockNotificationRepo{
+		deleteSmtp: func(_ string) error { return storageErr },
+	}
+	svc := newTestService(repo)
+
+	err := svc.DeleteSmtp("id")
+
+	assert.ErrorIs(t, err, storageErr)
+}
+
+// ---------------------------------------------------------------------------
+// GetSmtp
+// ---------------------------------------------------------------------------
+
+func TestGetSmtp_GetSmtpReturnsError(t *testing.T) {
+	storageErr := errors.New("query failed")
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.GetSmtp("user-id", "org-id")
+
+	assert.ErrorIs(t, err, storageErr)
+}
+
+func TestGetSmtp_GetSmtpReturnsConfig_EarlyReturn(t *testing.T) {
+	expected := &shared_types.SMTPConfigs{ID: uuid.New(), Host: "smtp.example.com"}
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return expected, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.GetSmtp("user-id", "org-id")
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestGetSmtp_FallsBackToOrgSmtp_OrgError_ReturnsSMTPConfigNotFound(t *testing.T) {
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, nil
+		},
+		getOrganizationsSmtp: func(_ string) ([]shared_types.SMTPConfigs, error) {
+			return nil, errors.New("org lookup failed")
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.GetSmtp("user-id", "org-id")
+
+	assert.ErrorIs(t, err, notification.ErrSMTPConfigNotFound)
+}
+
+func TestGetSmtp_FallsBackToOrgSmtp_EmptySlice_ReturnsSMTPConfigNotFound(t *testing.T) {
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, nil
+		},
+		getOrganizationsSmtp: func(_ string) ([]shared_types.SMTPConfigs, error) {
+			return []shared_types.SMTPConfigs{}, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.GetSmtp("user-id", "org-id")
+
+	assert.ErrorIs(t, err, notification.ErrSMTPConfigNotFound)
+}
+
+func TestGetSmtp_FallsBackToOrgSmtp_ReturnsFirstConfig(t *testing.T) {
+	first := shared_types.SMTPConfigs{ID: uuid.New(), Host: "org-smtp.example.com"}
+	second := shared_types.SMTPConfigs{ID: uuid.New(), Host: "second.example.com"}
+	repo := &mockNotificationRepo{
+		getSmtp: func(_ string) (*shared_types.SMTPConfigs, error) {
+			return nil, nil
+		},
+		getOrganizationsSmtp: func(_ string) ([]shared_types.SMTPConfigs, error) {
+			return []shared_types.SMTPConfigs{first, second}, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.GetSmtp("user-id", "org-id")
+
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, got.ID)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateSmtp
+// ---------------------------------------------------------------------------
+
+func TestUpdateSmtp_NilStorage_ReturnsError(t *testing.T) {
+	l := logger.NewLogger()
+	svc := &NotificationService{
+		storage: nil,
+		Ctx:     context.Background(),
+		logger:  l,
+	}
+
+	err := svc.UpdateSmtp(notification.UpdateSMTPConfigRequest{ID: uuid.New()})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage layer not initialized")
+}
+
+func TestUpdateSmtp_HostNil_Success(t *testing.T) {
+	repo := &mockNotificationRepo{
+		updateSmtp: func(_ *notification.UpdateSMTPConfigRequest) error { return nil },
+	}
+	svc := newTestService(repo)
+
+	err := svc.UpdateSmtp(notification.UpdateSMTPConfigRequest{ID: uuid.New()})
+
+	require.NoError(t, err)
+}
+
+func TestUpdateSmtp_HostSet_Success(t *testing.T) {
+	host := "new-smtp.example.com"
+	repo := &mockNotificationRepo{
+		updateSmtp: func(c *notification.UpdateSMTPConfigRequest) error {
+			assert.Equal(t, host, *c.Host)
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.UpdateSmtp(notification.UpdateSMTPConfigRequest{ID: uuid.New(), Host: &host})
+
+	require.NoError(t, err)
+}
+
+func TestUpdateSmtp_StorageError_WrapsError(t *testing.T) {
+	storageErr := errors.New("update failed")
+	repo := &mockNotificationRepo{
+		updateSmtp: func(_ *notification.UpdateSMTPConfigRequest) error { return storageErr },
+	}
+	svc := newTestService(repo)
+
+	err := svc.UpdateSmtp(notification.UpdateSMTPConfigRequest{ID: uuid.New()})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "failed to update SMTP configuration")
+}
+
+// ---------------------------------------------------------------------------
+// UpdatePreference
+// ---------------------------------------------------------------------------
+
+func TestUpdatePreference_EmptyCategory_ReturnsError(t *testing.T) {
+	svc := newTestService(&mockNotificationRepo{})
+
+	err := svc.UpdatePreference(notification.UpdatePreferenceRequest{
+		Category: "", Type: "login-alerts", Enabled: true,
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "category cannot be empty")
+}
+
+func TestUpdatePreference_EmptyType_ReturnsError(t *testing.T) {
+	svc := newTestService(&mockNotificationRepo{})
+
+	err := svc.UpdatePreference(notification.UpdatePreferenceRequest{
+		Category: "security", Type: "", Enabled: true,
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "type cannot be empty")
+}
+
+func TestUpdatePreference_NilUserID_ReturnsError(t *testing.T) {
+	svc := newTestService(&mockNotificationRepo{})
+
+	err := svc.UpdatePreference(notification.UpdatePreferenceRequest{
+		Category: "security", Type: "login-alerts", Enabled: true,
+	}, uuid.Nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "userID cannot be empty")
+}
+
+func TestUpdatePreference_StorageError_WrapsError(t *testing.T) {
+	storageErr := errors.New("update failed")
+	repo := &mockNotificationRepo{
+		updatePreference: func(_ context.Context, _ notification.UpdatePreferenceRequest, _ uuid.UUID) error {
+			return storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.UpdatePreference(notification.UpdatePreferenceRequest{
+		Category: "security", Type: "login-alerts", Enabled: true,
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "failed to update preference")
+}
+
+func TestUpdatePreference_Success(t *testing.T) {
+	userID := uuid.New()
+	var capturedReq notification.UpdatePreferenceRequest
+	var capturedUserID uuid.UUID
+	repo := &mockNotificationRepo{
+		updatePreference: func(_ context.Context, req notification.UpdatePreferenceRequest, id uuid.UUID) error {
+			capturedReq = req
+			capturedUserID = id
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.UpdatePreference(notification.UpdatePreferenceRequest{
+		Category: "activity", Type: "team-updates", Enabled: false,
+	}, userID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "activity", capturedReq.Category)
+	assert.Equal(t, userID, capturedUserID)
+}
+
+// ---------------------------------------------------------------------------
+// CreateWebhookConfig
+// ---------------------------------------------------------------------------
+
+func TestCreateWebhookConfig_Success(t *testing.T) {
+	userID := uuid.New()
+	orgID := uuid.New()
+	var capturedConfig *shared_types.WebhookConfig
+	repo := &mockNotificationRepo{
+		createWebhookConfig: func(_ context.Context, c *shared_types.WebhookConfig) error {
+			capturedConfig = c
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.CreateWebhookConfig(context.Background(), &notification.CreateWebhookConfigRequest{
+		Type: "slack", WebhookURL: "https://hooks.slack.com/test",
+	}, userID, orgID)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "slack", got.Type)
+	assert.Equal(t, "https://hooks.slack.com/test", got.WebhookURL)
+	assert.True(t, got.IsActive)
+	assert.Equal(t, fmt.Sprintf("slack:%s", orgID.String()), got.ChannelID)
+	assert.Equal(t, userID, got.UserID)
+	assert.Equal(t, orgID, got.OrganizationID)
+	assert.NotEqual(t, uuid.Nil, got.ID)
+	assert.Equal(t, capturedConfig, got)
+}
+
+func TestCreateWebhookConfig_StorageError(t *testing.T) {
+	storageErr := errors.New("insert failed")
+	repo := &mockNotificationRepo{
+		createWebhookConfig: func(_ context.Context, _ *shared_types.WebhookConfig) error {
+			return storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.CreateWebhookConfig(context.Background(), &notification.CreateWebhookConfigRequest{
+		Type: "slack", WebhookURL: "https://hooks.slack.com/test",
+	}, uuid.New(), uuid.New())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "failed to create webhook config")
+}
+
+// ---------------------------------------------------------------------------
+// UpdateWebhookConfig
+// ---------------------------------------------------------------------------
+
+func TestUpdateWebhookConfig_GetError(t *testing.T) {
+	storageErr := errors.New("not found")
+	repo := &mockNotificationRepo{
+		getWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) (*shared_types.WebhookConfig, error) {
+			return nil, storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.UpdateWebhookConfig(context.Background(), &notification.UpdateWebhookConfigRequest{
+		Type: "slack",
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "webhook config not found")
+}
+
+func TestUpdateWebhookConfig_UpdatesURLAndIsActive(t *testing.T) {
+	existing := &shared_types.WebhookConfig{ID: uuid.New(), Type: "slack", IsActive: false}
+	newURL := "https://hooks.slack.com/new"
+	active := true
+	repo := &mockNotificationRepo{
+		getWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) (*shared_types.WebhookConfig, error) {
+			return existing, nil
+		},
+		updateWebhookConfig: func(_ context.Context, c *shared_types.WebhookConfig) error {
+			assert.Equal(t, newURL, c.WebhookURL)
+			assert.True(t, c.IsActive)
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.UpdateWebhookConfig(context.Background(), &notification.UpdateWebhookConfigRequest{
+		Type: "slack", WebhookURL: &newURL, IsActive: &active,
+	}, uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, newURL, got.WebhookURL)
+	assert.True(t, got.IsActive)
+}
+
+func TestUpdateWebhookConfig_NilOptionalFields_NoChange(t *testing.T) {
+	existing := &shared_types.WebhookConfig{
+		ID: uuid.New(), Type: "discord", WebhookURL: "https://discord.com/original", IsActive: true,
+	}
+	repo := &mockNotificationRepo{
+		getWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) (*shared_types.WebhookConfig, error) {
+			return existing, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.UpdateWebhookConfig(context.Background(), &notification.UpdateWebhookConfigRequest{
+		Type: "discord",
+	}, uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://discord.com/original", got.WebhookURL)
+	assert.True(t, got.IsActive)
+}
+
+func TestUpdateWebhookConfig_UpdateStorageError(t *testing.T) {
+	storageErr := errors.New("update failed")
+	repo := &mockNotificationRepo{
+		getWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) (*shared_types.WebhookConfig, error) {
+			return &shared_types.WebhookConfig{ID: uuid.New()}, nil
+		},
+		updateWebhookConfig: func(_ context.Context, _ *shared_types.WebhookConfig) error {
+			return storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.UpdateWebhookConfig(context.Background(), &notification.UpdateWebhookConfigRequest{
+		Type: "slack",
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "failed to update webhook config")
+}
+
+// ---------------------------------------------------------------------------
+// DeleteWebhookConfig
+// ---------------------------------------------------------------------------
+
+func TestDeleteWebhookConfig_Success(t *testing.T) {
+	orgID := uuid.New()
+	var capturedType string
+	var capturedOrgID uuid.UUID
+	repo := &mockNotificationRepo{
+		deleteWebhookConfig: func(_ context.Context, wt string, o uuid.UUID) error {
+			capturedType = wt
+			capturedOrgID = o
+			return nil
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.DeleteWebhookConfig(context.Background(), &notification.DeleteWebhookConfigRequest{
+		Type: "slack",
+	}, orgID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "slack", capturedType)
+	assert.Equal(t, orgID, capturedOrgID)
+}
+
+func TestDeleteWebhookConfig_StorageError(t *testing.T) {
+	storageErr := errors.New("delete failed")
+	repo := &mockNotificationRepo{
+		deleteWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) error {
+			return storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	err := svc.DeleteWebhookConfig(context.Background(), &notification.DeleteWebhookConfigRequest{
+		Type: "slack",
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "failed to delete webhook config")
+}
+
+// ---------------------------------------------------------------------------
+// GetWebhookConfig
+// ---------------------------------------------------------------------------
+
+func TestGetWebhookConfig_Success(t *testing.T) {
+	expected := &shared_types.WebhookConfig{ID: uuid.New(), Type: "discord"}
+	repo := &mockNotificationRepo{
+		getWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) (*shared_types.WebhookConfig, error) {
+			return expected, nil
+		},
+	}
+	svc := newTestService(repo)
+
+	got, err := svc.GetWebhookConfig(context.Background(), &notification.GetWebhookConfigRequest{
+		Type: "discord",
+	}, uuid.New())
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestGetWebhookConfig_StorageError(t *testing.T) {
+	storageErr := errors.New("query failed")
+	repo := &mockNotificationRepo{
+		getWebhookConfig: func(_ context.Context, _ string, _ uuid.UUID) (*shared_types.WebhookConfig, error) {
+			return nil, storageErr
+		},
+	}
+	svc := newTestService(repo)
+
+	_, err := svc.GetWebhookConfig(context.Background(), &notification.GetWebhookConfigRequest{
+		Type: "discord",
+	}, uuid.New())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	assert.Contains(t, err.Error(), "webhook config not found")
+}

--- a/api/internal/features/notification/storage/init.go
+++ b/api/internal/features/notification/storage/init.go
@@ -14,6 +14,16 @@ import (
 	"golang.org/x/net/context"
 )
 
+// bunTxCommitHook is set by tests to simulate Commit failures (same package).
+var bunTxCommitHook func(tx *bun.Tx) error
+
+func commitNotificationBunTx(tx bun.Tx) error {
+	if bunTxCommitHook != nil {
+		return bunTxCommitHook(&tx)
+	}
+	return tx.Commit()
+}
+
 type NotificationStorage struct {
 	DB  *bun.DB
 	Ctx context.Context
@@ -75,19 +85,15 @@ func (s NotificationStorage) UpdateSmtp(config *notification.UpdateSMTPConfigReq
 // It takes an ID as a parameter, deletes the corresponding SMTP configuration
 // from the database, and returns an error if the database operation fails.
 func (s NotificationStorage) DeleteSmtp(ID string) error {
-	var config shared_types.SMTPConfigs
-	result, err := s.DB.NewDelete().Model(&config).Where("id = ?", ID).Exec(s.Ctx)
+	exists, err := s.DB.NewSelect().Model((*shared_types.SMTPConfigs)(nil)).Where("id = ?", ID).Exists(s.Ctx)
 	if err != nil {
 		return err
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
+	if !exists {
 		return fmt.Errorf("smtp config not found")
 	}
-	return nil
+	_, err = s.DB.NewDelete().Model((*shared_types.SMTPConfigs)(nil)).Where("id = ?", ID).Exec(s.Ctx)
+	return err
 }
 
 // GetSmtp returns the SMTP configuration associated with the given ID.
@@ -116,9 +122,6 @@ func (s NotificationStorage) GetOrganizationsSmtp(organizationID string) ([]shar
 	configs := []shared_types.SMTPConfigs{}
 	err := s.DB.NewSelect().Model(&configs).Where("organization_id = ?", organizationID).Scan(s.Ctx)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return []shared_types.SMTPConfigs{}, nil
-		}
 		return nil, err
 	}
 	return configs, nil
@@ -263,7 +266,7 @@ func (s *NotificationStorage) initUserPreferences(ctx context.Context, userID uu
 		return fmt.Errorf("failed to insert preference items: %w", err)
 	}
 
-	if err = tx.Commit(); err != nil {
+	if err = commitNotificationBunTx(tx); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
@@ -303,7 +306,7 @@ func (s *NotificationStorage) initDefaultPreferences(ctx context.Context, userID
 		return fmt.Errorf("failed to insert preference items: %w", err)
 	}
 
-	if err = tx.Commit(); err != nil {
+	if err = commitNotificationBunTx(tx); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 

--- a/api/internal/features/notification/storage/init_test.go
+++ b/api/internal/features/notification/storage/init_test.go
@@ -1,0 +1,811 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/notification"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=shared&_busy_timeout=5000")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	for _, m := range []any{
+		(*shared_types.SMTPConfigs)(nil),
+		(*shared_types.WebhookConfig)(nil),
+		(*shared_types.NotificationPreferences)(nil),
+		(*shared_types.PreferenceItem)(nil),
+	} {
+		_, err = db.NewCreateTable().Model(m).IfNotExists().Exec(ctx)
+		require.NoError(t, err)
+	}
+	_, err = db.ExecContext(ctx, `
+		CREATE UNIQUE INDEX IF NOT EXISTS notification_preferences_one_per_user
+		ON notification_preferences (user_id)
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func sampleSMTP(t *testing.T, userID, orgID uuid.UUID) *shared_types.SMTPConfigs {
+	t.Helper()
+	return &shared_types.SMTPConfigs{
+		ID:             uuid.New(),
+		Host:           "smtp.example.com",
+		Port:           587,
+		Username:       "user@example.com",
+		Password:       "secret",
+		FromEmail:      "from@example.com",
+		FromName:       "From",
+		Security:       "tls",
+		UserID:         userID,
+		OrganizationID: orgID,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+		IsActive:       true,
+	}
+}
+
+func insertNotificationPreference(t *testing.T, db *bun.DB, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	prefID := uuid.New()
+	now := time.Now()
+	pref := &shared_types.NotificationPreferences{
+		ID:        prefID,
+		UserID:    userID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	_, err := db.NewInsert().Model(pref).Exec(context.Background())
+	require.NoError(t, err)
+	return prefID
+}
+
+func insertPreferenceItem(t *testing.T, db *bun.DB, prefID uuid.UUID, category, typ string, enabled bool) {
+	t.Helper()
+	now := time.Now()
+	item := &shared_types.PreferenceItem{
+		ID:           uuid.New(),
+		PreferenceID: prefID,
+		Category:     category,
+		Type:         typ,
+		Enabled:      enabled,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	_, err := db.NewInsert().Model(item).Exec(context.Background())
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// AddSmtp
+// ---------------------------------------------------------------------------
+
+func TestAddSmtp_Success(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	cfg := sampleSMTP(t, uuid.New(), uuid.New())
+	require.NoError(t, s.AddSmtp(cfg))
+
+	n, err := db.NewSelect().Model((*shared_types.SMTPConfigs)(nil)).Where("id = ?", cfg.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestAddSmtp_DatabaseError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	err = s.AddSmtp(sampleSMTP(t, uuid.New(), uuid.New()))
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateSmtp
+// ---------------------------------------------------------------------------
+
+func TestUpdateSmtp_AllFields(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	cfg := sampleSMTP(t, uuid.New(), uuid.New())
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	host := "new.host"
+	port := 25
+	user := "u"
+	pass := "p"
+	fn := "name"
+	fe := "fe@x.com"
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	err = s.UpdateSmtp(&notification.UpdateSMTPConfigRequest{
+		ID:        cfg.ID,
+		Host:      &host,
+		Port:      &port,
+		Username:  &user,
+		Password:  &pass,
+		FromName:  &fn,
+		FromEmail: &fe,
+	})
+	require.NoError(t, err)
+
+	var got shared_types.SMTPConfigs
+	err = db.NewSelect().Model(&got).Where("id = ?", cfg.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, host, got.Host)
+	assert.Equal(t, port, got.Port)
+	assert.Equal(t, user, got.Username)
+	assert.Equal(t, pass, got.Password)
+	assert.Equal(t, fn, got.FromName)
+	assert.Equal(t, fe, got.FromEmail)
+}
+
+func TestUpdateSmtp_NoSetColumns_StillExec(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	cfg := sampleSMTP(t, uuid.New(), uuid.New())
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	err = s.UpdateSmtp(&notification.UpdateSMTPConfigRequest{ID: cfg.ID})
+	// Bun/SQLite may reject UPDATE with no SET; accept either error or nil.
+	_ = err
+}
+
+func TestUpdateSmtp_DatabaseError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	h := "x"
+	require.Error(t, s.UpdateSmtp(&notification.UpdateSMTPConfigRequest{ID: uuid.New(), Host: &h}))
+}
+
+// ---------------------------------------------------------------------------
+// DeleteSmtp
+// ---------------------------------------------------------------------------
+
+func TestDeleteSmtp_Success(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	cfg := sampleSMTP(t, uuid.New(), uuid.New())
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	require.NoError(t, s.DeleteSmtp(cfg.ID.String()))
+}
+
+func TestDeleteSmtp_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	err := s.DeleteSmtp(uuid.New().String())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "smtp config not found")
+}
+
+func TestDeleteSmtp_DeleteExecError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	cfg := sampleSMTP(t, uuid.New(), uuid.New())
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `
+		CREATE TRIGGER sc_block_delete BEFORE DELETE ON smtp_configs
+		BEGIN
+			SELECT RAISE(ABORT, 'blocked');
+		END;
+	`)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	err = s.DeleteSmtp(cfg.ID.String())
+	require.Error(t, err)
+}
+
+func TestDeleteSmtp_DatabaseError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	require.Error(t, s.DeleteSmtp(uuid.New().String()))
+}
+
+// ---------------------------------------------------------------------------
+// GetSmtp
+// ---------------------------------------------------------------------------
+
+func TestGetSmtp_Found(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	cfg := sampleSMTP(t, userID, uuid.New())
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	got, err := s.GetSmtp(userID.String())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, cfg.ID, got.ID)
+}
+
+func TestGetSmtp_NoRows(t *testing.T) {
+	db := newTestDB(t)
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	got, err := s.GetSmtp(uuid.New().String())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestGetSmtp_QueryError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	_, err = s.GetSmtp(uuid.New().String())
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// GetOrganizationsSmtp
+// ---------------------------------------------------------------------------
+
+func TestGetOrganizationsSmtp_Found(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	u1 := sampleSMTP(t, uuid.New(), orgID)
+	u2 := sampleSMTP(t, uuid.New(), orgID)
+	otherOrg := sampleSMTP(t, uuid.New(), uuid.New())
+	_, err := db.NewInsert().Model(&[]shared_types.SMTPConfigs{*u1, *u2, *otherOrg}).Exec(ctx)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	list, err := s.GetOrganizationsSmtp(orgID.String())
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+func TestGetOrganizationsSmtp_Empty(t *testing.T) {
+	db := newTestDB(t)
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	list, err := s.GetOrganizationsSmtp(uuid.New().String())
+	require.NoError(t, err)
+	assert.Len(t, list, 0)
+}
+
+func TestGetOrganizationsSmtp_QueryError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	_, err = s.GetOrganizationsSmtp(uuid.New().String())
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// UpdatePreference
+// ---------------------------------------------------------------------------
+
+func TestUpdatePreference_ExistingRow_UpdatesItem(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	prefID := insertNotificationPreference(t, db, userID)
+	insertPreferenceItem(t, db, prefID, "security", "login-alerts", true)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.UpdatePreference(ctx, notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  false,
+	}, userID)
+	require.NoError(t, err)
+
+	var enabled bool
+	err = db.NewSelect().
+		Model((*shared_types.PreferenceItem)(nil)).
+		Column("enabled").
+		Where("preference_id = ? AND category = ? AND type = ?", prefID, "security", "login-alerts").
+		Scan(ctx, &enabled)
+	require.NoError(t, err)
+	assert.False(t, enabled)
+}
+
+func TestUpdatePreference_NoPreferences_InitializesWithRequestOverride(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.UpdatePreference(ctx, notification.UpdatePreferenceRequest{
+		Category: "update",
+		Type:     "newsletter",
+		Enabled:  true,
+	}, userID)
+	require.NoError(t, err)
+
+	var prefID uuid.UUID
+	err = db.NewSelect().
+		Model((*shared_types.NotificationPreferences)(nil)).
+		Column("id").
+		Where("user_id = ?", userID).
+		Scan(ctx, &prefID)
+	require.NoError(t, err)
+
+	var enabled bool
+	err = db.NewSelect().
+		Model((*shared_types.PreferenceItem)(nil)).
+		Column("enabled").
+		Where("preference_id = ? AND category = ? AND type = ?", prefID, "update", "newsletter").
+		Scan(ctx, &enabled)
+	require.NoError(t, err)
+	assert.True(t, enabled)
+}
+
+func TestUpdatePreference_FetchPreferencesError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	_, err = db.NewCreateTable().Model((*shared_types.PreferenceItem)(nil)).IfNotExists().Exec(context.Background())
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: context.Background()}
+	err = s.UpdatePreference(context.Background(), notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  true,
+	}, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch user preferences")
+}
+
+func TestUpdatePreference_UpdateExecError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	prefID := insertNotificationPreference(t, db, userID)
+	insertPreferenceItem(t, db, prefID, "security", "login-alerts", true)
+
+	_, err := db.NewDropTable().Model((*shared_types.PreferenceItem)(nil)).IfExists().Exec(ctx)
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err = s.UpdatePreference(ctx, notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  false,
+	}, userID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update preference")
+}
+
+// ---------------------------------------------------------------------------
+// GetPreferences
+// ---------------------------------------------------------------------------
+
+func TestGetPreferences_ExistingUser(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	prefID := insertNotificationPreference(t, db, userID)
+	insertPreferenceItem(t, db, prefID, "activity", "team-updates", true)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	resp, err := s.GetPreferences(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.GreaterOrEqual(t, len(resp.Activity), 1)
+}
+
+func TestGetPreferences_InitDefaultsWhenMissing(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	resp, err := s.GetPreferences(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Len(t, resp.Activity, 1)
+	assert.Len(t, resp.Security, 3)
+	assert.Len(t, resp.Update, 3)
+
+	n, err := db.NewSelect().Model((*shared_types.PreferenceItem)(nil)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 7, n)
+}
+
+func TestGetPreferences_FetchUserPrefsNonNoRows(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	_, err = db.NewCreateTable().Model((*shared_types.PreferenceItem)(nil)).IfNotExists().Exec(context.Background())
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: context.Background()}
+	_, err = s.GetPreferences(context.Background(), uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch user preferences")
+}
+
+func TestGetPreferences_InitThenFetchItemsError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	_, err := s.GetPreferences(ctx, userID)
+	require.NoError(t, err)
+
+	_, err = db.NewDropTable().Model((*shared_types.PreferenceItem)(nil)).IfExists().Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = s.GetPreferences(ctx, userID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch preference items")
+}
+
+func TestGetPreferences_InitDefaultPreferencesFailure(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	_, err := db.NewDropTable().Model((*shared_types.PreferenceItem)(nil)).IfExists().Exec(ctx)
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	_, err = s.GetPreferences(ctx, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize preferences")
+}
+
+func TestGetPreferences_FetchNewlyCreatedPreferencesFails(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `
+		CREATE TRIGGER np_delete_self_after_insert
+		AFTER INSERT ON notification_preferences
+		BEGIN
+			DELETE FROM notification_preferences WHERE id = NEW.id;
+		END;
+	`)
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	_, err = s.GetPreferences(ctx, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch newly created preferences")
+}
+
+// ---------------------------------------------------------------------------
+// initUserPreferences / initDefaultPreferences — transaction failures
+// ---------------------------------------------------------------------------
+
+func TestInitUserPreferences_BeginTxError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.Close())
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.initUserPreferences(ctx, uuid.New(), notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start transaction")
+}
+
+func TestInitDefaultPreferences_BeginTxError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.Close())
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.initDefaultPreferences(ctx, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start transaction")
+}
+
+func TestInitUserPreferences_CommitError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	prev := bunTxCommitHook
+	bunTxCommitHook = func(*bun.Tx) error { return fmt.Errorf("commit failed") }
+	defer func() { bunTxCommitHook = prev }()
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.initUserPreferences(ctx, uuid.New(), notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to commit transaction")
+}
+
+func TestInitDefaultPreferences_CommitError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	prev := bunTxCommitHook
+	bunTxCommitHook = func(*bun.Tx) error { return fmt.Errorf("commit failed") }
+	defer func() { bunTxCommitHook = prev }()
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.initDefaultPreferences(ctx, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to commit transaction")
+}
+
+func TestInitUserPreferences_InsertPreferencesError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	insertNotificationPreference(t, db, userID)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.initUserPreferences(ctx, userID, notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  false,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to insert preferences")
+}
+
+func TestInitUserPreferences_InsertItemsError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	_, err := db.NewDropTable().Model((*shared_types.PreferenceItem)(nil)).IfExists().Exec(ctx)
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err = s.initUserPreferences(ctx, uuid.New(), notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "login-alerts",
+		Enabled:  true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to insert preference items")
+}
+
+func TestInitDefaultPreferences_InsertPreferencesError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	insertNotificationPreference(t, db, userID)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err := s.initDefaultPreferences(ctx, userID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to insert preferences")
+}
+
+func TestInitDefaultPreferences_InsertItemsError(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	_, err := db.NewDropTable().Model((*shared_types.PreferenceItem)(nil)).IfExists().Exec(ctx)
+	require.NoError(t, err)
+
+	s := &NotificationStorage{DB: db, Ctx: ctx}
+	err = s.initDefaultPreferences(ctx, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to insert preference items")
+}
+
+// ---------------------------------------------------------------------------
+// MapToResponse
+// ---------------------------------------------------------------------------
+
+func TestMapToResponse_AllCategoriesAndIgnoresUnknown(t *testing.T) {
+	prefID := uuid.New()
+	items := []shared_types.PreferenceItem{
+		{PreferenceID: prefID, Category: "activity", Type: "team-updates", Enabled: true},
+		{PreferenceID: prefID, Category: "security", Type: "login-alerts", Enabled: true},
+		{PreferenceID: prefID, Category: "security", Type: "password-changes", Enabled: true},
+		{PreferenceID: prefID, Category: "security", Type: "security-alerts", Enabled: true},
+		{PreferenceID: prefID, Category: "update", Type: "product-updates", Enabled: true},
+		{PreferenceID: prefID, Category: "update", Type: "newsletter", Enabled: false},
+		{PreferenceID: prefID, Category: "update", Type: "marketing", Enabled: false},
+		{PreferenceID: prefID, Category: "update", Type: "unknown-type", Enabled: true},
+		{PreferenceID: prefID, Category: "unknown-cat", Type: "x", Enabled: true},
+	}
+	resp := MapToResponse(items)
+	assert.Len(t, resp.Activity, 1)
+	assert.Len(t, resp.Security, 3)
+	assert.Len(t, resp.Update, 3)
+}
+
+// ---------------------------------------------------------------------------
+// WebhookConfig
+// ---------------------------------------------------------------------------
+
+func TestCreateWebhookConfig_Success(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	cfg := &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           "slack",
+		WebhookURL:     "https://example.com/hook",
+		ChannelID:      "C1",
+		IsActive:       true,
+		UserID:         uuid.New(),
+		OrganizationID: uuid.New(),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	require.NoError(t, s.CreateWebhookConfig(ctx, cfg))
+}
+
+func TestCreateWebhookConfig_Error(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	err = s.CreateWebhookConfig(context.Background(), &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           "slack",
+		WebhookURL:     "u",
+		ChannelID:      "c",
+		UserID:         uuid.New(),
+		OrganizationID: uuid.New(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create webhook config")
+}
+
+func TestUpdateWebhookConfig_Success(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	cfg := &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           "slack",
+		WebhookURL:     "https://a",
+		ChannelID:      "c",
+		IsActive:       true,
+		UserID:         uuid.New(),
+		OrganizationID: uuid.New(),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	cfg.WebhookURL = "https://b"
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	require.NoError(t, s.UpdateWebhookConfig(ctx, cfg))
+}
+
+func TestUpdateWebhookConfig_Error(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	err = s.UpdateWebhookConfig(context.Background(), &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           "slack",
+		WebhookURL:     "u",
+		ChannelID:      "c",
+		UserID:         uuid.New(),
+		OrganizationID: uuid.New(),
+	})
+	require.Error(t, err)
+}
+
+func TestDeleteWebhookConfig_Success(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	cfg := &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           "slack",
+		WebhookURL:     "https://a",
+		ChannelID:      "c",
+		IsActive:       true,
+		UserID:         uuid.New(),
+		OrganizationID: orgID,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	require.NoError(t, s.DeleteWebhookConfig(ctx, "slack", orgID))
+}
+
+func TestDeleteWebhookConfig_Error(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	err = s.DeleteWebhookConfig(context.Background(), "slack", uuid.New())
+	require.Error(t, err)
+}
+
+func TestGetWebhookConfig_Found(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	cfg := &shared_types.WebhookConfig{
+		ID:             uuid.New(),
+		Type:           "discord",
+		WebhookURL:     "https://a",
+		ChannelID:      "c",
+		IsActive:       true,
+		UserID:         uuid.New(),
+		OrganizationID: orgID,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	_, err := db.NewInsert().Model(cfg).Exec(ctx)
+	require.NoError(t, err)
+
+	s := NotificationStorage{DB: db, Ctx: ctx}
+	got, err := s.GetWebhookConfig(ctx, "discord", orgID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, cfg.ID, got.ID)
+}
+
+func TestGetWebhookConfig_NoRows(t *testing.T) {
+	db := newTestDB(t)
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	got, err := s.GetWebhookConfig(context.Background(), "slack", uuid.New())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestGetWebhookConfig_OtherError(t *testing.T) {
+	sqldb, err := sql.Open("sqlite", "file::memory:?cache=private")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	defer db.Close()
+
+	s := NotificationStorage{DB: db, Ctx: context.Background()}
+	_, err = s.GetWebhookConfig(context.Background(), "slack", uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "webhook config not found")
+}

--- a/api/internal/features/notification/tasks/init.go
+++ b/api/internal/features/notification/tasks/init.go
@@ -23,6 +23,26 @@ const (
 	TASK_SEND_NOTIFICATION = "task_send_notification"
 )
 
+// sendNotificationTaskHandler returns the taskq handler that dispatches payloads
+// to the registered channels.
+func sendNotificationTaskHandler(channels map[string]channel.Channel, l logger.Logger) func(ctx context.Context, payload channel.DeliveryPayload) error {
+	return func(ctx context.Context, payload channel.DeliveryPayload) error {
+		ch, ok := channels[payload.Channel]
+		if !ok {
+			l.Log(logger.Error, fmt.Sprintf("unknown notification channel: %s", payload.Channel), "")
+			return fmt.Errorf("unknown notification channel: %s", payload.Channel)
+		}
+
+		if err := ch.Send(ctx, payload.Message); err != nil {
+			l.Log(logger.Error, fmt.Sprintf("notification delivery failed on %s: %s", payload.Channel, err.Error()), "")
+			return err
+		}
+
+		l.Log(logger.Info, fmt.Sprintf("notification delivered via %s to %s", payload.Channel, payload.Message.To), "")
+		return nil
+	}
+}
+
 // SetupNotificationQueue registers the notification delivery queue and task
 // with the shared Redis taskq factory. It follows the same pattern as the
 // deploy task queues but with higher retry limits since notifications are
@@ -43,21 +63,7 @@ func SetupNotificationQueue(channels map[string]channel.Channel, l logger.Logger
 		TaskSendNotification = taskq.RegisterTask(&taskq.TaskOptions{
 			Name:       TASK_SEND_NOTIFICATION,
 			RetryLimit: 3,
-			Handler: func(ctx context.Context, payload channel.DeliveryPayload) error {
-				ch, ok := channels[payload.Channel]
-				if !ok {
-					l.Log(logger.Error, fmt.Sprintf("unknown notification channel: %s", payload.Channel), "")
-					return fmt.Errorf("unknown notification channel: %s", payload.Channel)
-				}
-
-				if err := ch.Send(ctx, payload.Message); err != nil {
-					l.Log(logger.Error, fmt.Sprintf("notification delivery failed on %s: %s", payload.Channel, err.Error()), "")
-					return err
-				}
-
-				l.Log(logger.Info, fmt.Sprintf("notification delivered via %s to %s", payload.Channel, payload.Message.To), "")
-				return nil
-			},
+			Handler:    sendNotificationTaskHandler(channels, l),
 		})
 	})
 }

--- a/api/internal/features/notification/tasks/init_test.go
+++ b/api/internal/features/notification/tasks/init_test.go
@@ -1,0 +1,101 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/notification/channel"
+	"github.com/nixopus/nixopus/api/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubChannel struct {
+	typeName string
+	sendErr  error
+	lastMsg  channel.Message
+}
+
+func (s *stubChannel) Type() string { return s.typeName }
+
+func (s *stubChannel) Send(ctx context.Context, msg channel.Message) error {
+	_ = ctx
+	s.lastMsg = msg
+	return s.sendErr
+}
+
+func TestEnqueue_NotInitialized(t *testing.T) {
+	prevQ, prevT := NotificationQueue, TaskSendNotification
+	NotificationQueue, TaskSendNotification = nil, nil
+	t.Cleanup(func() {
+		NotificationQueue, TaskSendNotification = prevQ, prevT
+	})
+
+	err := Enqueue(channel.DeliveryPayload{Channel: "email"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notification queue not initialized")
+}
+
+func TestSendNotificationTaskHandler_UnknownChannel(t *testing.T) {
+	h := sendNotificationTaskHandler(map[string]channel.Channel{}, logger.NewLogger())
+	err := h(context.Background(), channel.DeliveryPayload{
+		Channel: "missing",
+		Message: channel.Message{To: "x", Body: "b"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown notification channel: missing")
+}
+
+func TestSendNotificationTaskHandler_SendError(t *testing.T) {
+	sendErr := errors.New("transport down")
+	stub := &stubChannel{typeName: "email", sendErr: sendErr}
+	h := sendNotificationTaskHandler(map[string]channel.Channel{"email": stub}, logger.NewLogger())
+
+	err := h(context.Background(), channel.DeliveryPayload{
+		Channel: "email",
+		Message: channel.Message{To: "u@x.com", Body: "hello"},
+	})
+	require.ErrorIs(t, err, sendErr)
+}
+
+func TestSendNotificationTaskHandler_Success(t *testing.T) {
+	stub := &stubChannel{typeName: "slack"}
+	h := sendNotificationTaskHandler(map[string]channel.Channel{"slack": stub}, logger.NewLogger())
+
+	err := h(context.Background(), channel.DeliveryPayload{
+		Channel: "slack",
+		Message: channel.Message{To: "#alerts", Body: "ok"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "#alerts", stub.lastMsg.To)
+	assert.Equal(t, "ok", stub.lastMsg.Body)
+}
+
+func TestSetupNotificationQueue_And_Enqueue(t *testing.T) {
+	mr := miniredis.RunT(t)
+	opt, err := redis.ParseURL("redis://" + mr.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	queue.Init(rdb)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	stub := &stubChannel{typeName: "email"}
+	SetupNotificationQueue(map[string]channel.Channel{"email": stub}, logger.NewLogger())
+
+	require.NotNil(t, NotificationQueue)
+	require.NotNil(t, TaskSendNotification)
+
+	err = Enqueue(channel.DeliveryPayload{
+		Channel:        "email",
+		OrganizationID: "org-1",
+		UserID:         "user-1",
+		Message:        channel.Message{To: "a@b.com", Body: "queued"},
+	})
+	require.NoError(t, err)
+}

--- a/api/internal/features/notification/validation/validator.go
+++ b/api/internal/features/notification/validation/validator.go
@@ -71,7 +71,7 @@ func (v *Validator) validateCreateSMTPConfigRequest(req notification.CreateSMTPC
 	if req.Password == "" {
 		return notification.ErrMissingPassword
 	}
-	if req.OrganizationID.String() == "" {
+	if req.OrganizationID == uuid.Nil {
 		return notification.ErrMissingOrganization
 	}
 	return nil

--- a/api/internal/features/notification/validation/validator_test.go
+++ b/api/internal/features/notification/validation/validator_test.go
@@ -1,0 +1,196 @@
+package validation
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/notification"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newValidator(t *testing.T) *Validator {
+	t.Helper()
+	// ValidateRequest does not use storage; nil repository is sufficient.
+	return NewValidator(nil)
+}
+
+func TestNewValidator_NotNil(t *testing.T) {
+	v := NewValidator(nil)
+	require.NotNil(t, v)
+}
+
+func TestValidateRequest_InvalidType(t *testing.T) {
+	v := newValidator(t)
+	err := v.ValidateRequest("not-a-request")
+	require.ErrorIs(t, err, notification.ErrInvalidRequestType)
+}
+
+func TestValidateRequest_CreateSMTPConfig_Success(t *testing.T) {
+	v := newValidator(t)
+	err := v.ValidateRequest(&notification.CreateSMTPConfigRequest{
+		Host:           "smtp.example.com",
+		Port:           587,
+		Username:       "user@example.com",
+		Password:       "secret",
+		OrganizationID: uuid.New(),
+	})
+	require.NoError(t, err)
+}
+
+func TestValidateRequest_CreateSMTPConfig_Errors(t *testing.T) {
+	v := newValidator(t)
+	orgID := uuid.New()
+
+	t.Run("missing host", func(t *testing.T) {
+		err := v.ValidateRequest(&notification.CreateSMTPConfigRequest{
+			Port:           587,
+			Username:       "u",
+			Password:       "p",
+			OrganizationID: orgID,
+		})
+		require.ErrorIs(t, err, notification.ErrMissingHost)
+	})
+	t.Run("missing port", func(t *testing.T) {
+		err := v.ValidateRequest(&notification.CreateSMTPConfigRequest{
+			Host:           "h",
+			Username:       "u",
+			Password:       "p",
+			OrganizationID: orgID,
+		})
+		require.ErrorIs(t, err, notification.ErrMissingPort)
+	})
+	t.Run("missing username", func(t *testing.T) {
+		err := v.ValidateRequest(&notification.CreateSMTPConfigRequest{
+			Host:           "h",
+			Port:           1,
+			Password:       "p",
+			OrganizationID: orgID,
+		})
+		require.ErrorIs(t, err, notification.ErrMissingUsername)
+	})
+	t.Run("missing password", func(t *testing.T) {
+		err := v.ValidateRequest(&notification.CreateSMTPConfigRequest{
+			Host:           "h",
+			Port:           1,
+			Username:       "u",
+			OrganizationID: orgID,
+		})
+		require.ErrorIs(t, err, notification.ErrMissingPassword)
+	})
+	t.Run("missing organization", func(t *testing.T) {
+		err := v.ValidateRequest(&notification.CreateSMTPConfigRequest{
+			Host:     "h",
+			Port:     1,
+			Username: "u",
+			Password: "p",
+		})
+		require.ErrorIs(t, err, notification.ErrMissingOrganization)
+	})
+}
+
+func TestValidateRequest_GetSMTPConfig(t *testing.T) {
+	v := newValidator(t)
+	err := v.ValidateRequest(&notification.GetSMTPConfigRequest{ID: uuid.Nil})
+	require.ErrorIs(t, err, notification.ErrMissingID)
+
+	err = v.ValidateRequest(&notification.GetSMTPConfigRequest{ID: uuid.New()})
+	require.NoError(t, err)
+}
+
+func TestValidateRequest_UpdateSMTPConfig(t *testing.T) {
+	v := newValidator(t)
+	err := v.ValidateRequest(&notification.UpdateSMTPConfigRequest{ID: uuid.Nil})
+	require.ErrorIs(t, err, notification.ErrMissingID)
+
+	err = v.ValidateRequest(&notification.UpdateSMTPConfigRequest{ID: uuid.New()})
+	require.NoError(t, err)
+}
+
+func TestValidateRequest_DeleteSMTPConfig(t *testing.T) {
+	v := newValidator(t)
+	err := v.ValidateRequest(&notification.DeleteSMTPConfigRequest{ID: uuid.Nil})
+	require.ErrorIs(t, err, notification.ErrMissingID)
+
+	err = v.ValidateRequest(&notification.DeleteSMTPConfigRequest{ID: uuid.New()})
+	require.NoError(t, err)
+}
+
+func TestValidateRequest_UpdatePreference(t *testing.T) {
+	v := newValidator(t)
+
+	err := v.ValidateRequest(&notification.UpdatePreferenceRequest{
+		Category: "security",
+		Type:     "",
+	})
+	require.ErrorIs(t, err, notification.ErrMissingType)
+
+	err = v.ValidateRequest(&notification.UpdatePreferenceRequest{
+		Category: "",
+		Type:     "login-alerts",
+	})
+	require.ErrorIs(t, err, notification.ErrMissingCategory)
+
+	err = v.ValidateRequest(&notification.UpdatePreferenceRequest{
+		Category: "invalid",
+		Type:     "x",
+	})
+	require.ErrorIs(t, err, notification.ErrInvalidRequestType)
+
+	for _, cat := range []string{"activity", "security", "update"} {
+		cat := cat
+		t.Run(cat, func(t *testing.T) {
+			err := v.ValidateRequest(&notification.UpdatePreferenceRequest{
+				Category: cat,
+				Type:     "login-alerts",
+				Enabled:  true,
+			})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestParseRequestBody_ReadError(t *testing.T) {
+	v := newValidator(t)
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	r.Body = io.NopCloser(&failingReader{})
+	var out map[string]any
+	err := v.ParseRequestBody(r, r.Body, &out)
+	require.Error(t, err)
+}
+
+func TestParseRequestBody_JSONError(t *testing.T) {
+	v := newValidator(t)
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{`))
+	err := v.ParseRequestBody(r, r.Body, new(map[string]any))
+	require.Error(t, err)
+}
+
+func TestParseRequestBody_Success_RereadsBody(t *testing.T) {
+	v := newValidator(t)
+	payload := map[string]string{"hello": "world"}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	var decoded map[string]string
+	require.NoError(t, v.ParseRequestBody(r, r.Body, &decoded))
+	assert.Equal(t, "world", decoded["hello"])
+
+	again, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(raw), string(again))
+}
+
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("read failed")
+}

--- a/api/internal/tests/notification/notification_test.go
+++ b/api/internal/tests/notification/notification_test.go
@@ -37,6 +37,39 @@ func TestGetSMTPConfig_ValidAuth_Empty(t *testing.T) {
 	)
 }
 
+func TestGetSMTPConfig_MissingIDQuery(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("GET /notification/smtp without id query returns 400"),
+		Get(tests.GetNotificationSMTPURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestGetSMTPConfig_QueryOrgMismatch(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	otherOrg := uuid.New().String()
+	Test(t,
+		Description("GET /notification/smtp with id not matching active org returns 403"),
+		Get(tests.GetNotificationSMTPURL()+"?id="+otherOrg),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Expect().Status().Equal(http.StatusForbidden),
+	)
+}
+
 func TestCreateSMTPConfig_NoAuth(t *testing.T) {
 	Test(t,
 		Description("POST /notification/smtp without auth returns 401"),
@@ -121,6 +154,69 @@ func TestCreateSMTPConfig_MissingPassword(t *testing.T) {
 		Send().Body().JSON(map[string]interface{}{
 			"host": "smtp.example.com", "port": 587, "username": "user@example.com",
 		}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestCreateSMTPConfig_MissingOrganizationID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /notification/smtp without organization_id returns 400"),
+		Post(tests.GetNotificationSMTPURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"host":     "smtp.example.com",
+			"port":     587,
+			"username": "user@example.com",
+			"password": "password123",
+		}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestCreateSMTPConfig_NilOrganizationUUID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /notification/smtp with zero organization_id returns 400"),
+		Post(tests.GetNotificationSMTPURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"host":            "smtp.example.com",
+			"port":            587,
+			"username":        "user@example.com",
+			"password":        "password123",
+			"organization_id": uuid.Nil.String(),
+		}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestCreateSMTPConfig_InvalidJSONBody(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /notification/smtp with invalid JSON returns 400"),
+		Post(tests.GetNotificationSMTPURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().String("{not valid json"),
 		Expect().Status().Equal(http.StatusBadRequest),
 	)
 }
@@ -219,6 +315,24 @@ func TestUpdateSMTPConfig_MissingID(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestUpdateSMTPConfig_InvalidJSONBody(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PUT /notification/smtp with invalid JSON returns 400"),
+		Put(tests.GetNotificationSMTPURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().String("{"),
 		Expect().Status().Equal(http.StatusBadRequest),
 	)
 }
@@ -323,6 +437,24 @@ func TestDeleteSMTPConfig_MissingID(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestDeleteSMTPConfig_InvalidJSONBody(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("DELETE /notification/smtp with invalid JSON returns 400"),
+		Delete(tests.GetNotificationSMTPURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().String(`{"id": "`),
 		Expect().Status().Equal(http.StatusBadRequest),
 	)
 }
@@ -479,6 +611,24 @@ func TestUpdateNotificationPreferences_MissingType(t *testing.T) {
 		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"category": "activity", "enabled": true}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestUpdateNotificationPreferences_InvalidJSONBody(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("PATCH /notification/preferences with invalid JSON returns 400"),
+		Method(http.MethodPatch, tests.GetNotificationPreferencesURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().String("{"),
 		Expect().Status().Equal(http.StatusBadRequest),
 	)
 }
@@ -874,6 +1024,46 @@ func TestSendNotification_InvalidChannel(t *testing.T) {
 		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
 		Send().Body().JSON(map[string]interface{}{"channel": "telegram", "message": "test"}),
 		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestSendNotification_InvalidJSONBody(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /notification/send with invalid JSON returns 400"),
+		Post(tests.GetNotificationSendURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().String(`{"channel":`),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestSendNotification_EmailChannel_WithRecipient(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	auth, err := setup.GetAuthResponse()
+	if err != nil {
+		t.Fatalf("failed to get auth response: %v", err)
+	}
+
+	Test(t,
+		Description("POST /notification/send with email channel and explicit recipient is accepted"),
+		Post(tests.GetNotificationSendURL()),
+		Send().Headers("Cookie").Add(auth.GetAuthCookiesHeader()),
+		Send().Headers("X-Organization-ID").Add(auth.OrganizationID),
+		Send().Body().JSON(map[string]interface{}{
+			"channel": "email",
+			"to":      "integration-test-recipient@example.com",
+			"message": "integration test email body",
+			"subject": "Integration test subject",
+		}),
+		Expect().Status().OneOf(int64(http.StatusOK), int64(http.StatusInternalServerError)),
 	)
 }
 


### PR DESCRIPTION
## Summary

- **service**: 100% statement coverage via hand-written  mock — all SMTP, preference, and webhook methods tested across success and error paths
- **channel**: 96.2% coverage using  servers, in-memory SQLite, a minimal fake SMTP server, and a concurrent double-check lock test — , , , , 
- **helpers/preferences**: 100% coverage via in-memory SQLite exercising every branch of 
- **storage, dispatcher, event, tasks, validation**: additional test coverage for remaining notification sub-packages

## Test plan

- [ ] FAIL	./api/internal/features/notification/service/... [setup failed]
FAIL — all pass, 100% coverage
- [ ] FAIL	./api/internal/features/notification/channel/... [setup failed]
FAIL — all pass, 96.2% coverage
- [ ] FAIL	./api/internal/features/notification/helpers/... [setup failed]
FAIL — all pass, 100% coverage
- [ ] FAIL	./api/internal/features/notification/... [setup failed]
FAIL — full suite passes