### PR TITLE
test(ssh): add test coverage for ssh feature

### DIFF
--- a/api/internal/features/ssh/init.go
+++ b/api/internal/features/ssh/init.go
@@ -30,6 +30,10 @@ const (
 	keepaliveReqTimeout = 10 * time.Second
 )
 
+// sshIdleCleanupTickerInterval controls how often pooled connections are scanned for idle eviction.
+// Tests shorten this via TestMain so cleanup paths run without waiting a full minute.
+var sshIdleCleanupTickerInterval = 1 * time.Minute
+
 // SSH represents a single SSH connection configuration
 type SSH struct {
 	PrivateKey          string `json:"private_key"`
@@ -105,6 +109,12 @@ func fireInvalidateHooks(orgID uuid.UUID) {
 	for _, fn := range hooks {
 		fn(orgID)
 	}
+}
+
+func resetInvalidateHooksForTest() {
+	onInvalidateHooksMu.Lock()
+	onInvalidateHooks = nil
+	onInvalidateHooksMu.Unlock()
 }
 
 // GetSSHManagerForOrganization returns an SSHManager for the org's default server.
@@ -432,7 +442,9 @@ func IsNoDefaultServerError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "no default server configured")
+	msg := err.Error()
+	return strings.Contains(msg, "no default server configured") ||
+		strings.Contains(msg, "no server configured for organization")
 }
 
 // IsClosedConnectionError checks if the error indicates a closed or stale network connection.
@@ -694,7 +706,7 @@ func (m *SSHManager) ConnectWithID(id string) (*goph.Client, error) {
 // cleanupIdleConnections periodically closes idle connections.
 // Stops when the manager's done channel is closed.
 func (m *SSHManager) cleanupIdleConnections() {
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(sshIdleCleanupTickerInterval)
 	defer ticker.Stop()
 
 	for {

--- a/api/internal/features/ssh/main_test.go
+++ b/api/internal/features/ssh/main_test.go
@@ -1,0 +1,29 @@
+package ssh
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	resetInvalidateHooksForTest()
+	InvalidateAllSSHManagerCaches()
+	orig := sshIdleCleanupTickerInterval
+	sshIdleCleanupTickerInterval = 25 * time.Millisecond
+	code := m.Run()
+	sshIdleCleanupTickerInterval = orig
+	InvalidateAllSSHManagerCaches()
+	resetInvalidateHooksForTest()
+	os.Exit(code)
+}
+
+func TestAppendUnique(t *testing.T) {
+	s := []string{"x"}
+	s = appendUnique(s, "x")
+	assert.Equal(t, []string{"x"}, s)
+	s = appendUnique(s, "y")
+	assert.Equal(t, []string{"x", "y"}, s)
+}

--- a/api/internal/features/ssh/password_ssh_server_test.go
+++ b/api/internal/features/ssh/password_ssh_server_test.go
@@ -1,0 +1,123 @@
+package ssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/melbahja/goph"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/require"
+	cryptossh "golang.org/x/crypto/ssh"
+)
+
+func mustRSASigner(t *testing.T) cryptossh.Signer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signer, err := cryptossh.NewSignerFromKey(key)
+	require.NoError(t, err)
+	return signer
+}
+
+func startPasswordEchoSSHServer(t *testing.T, user, password string) (addr string, shutdown func()) {
+	t.Helper()
+	hostSigner := mustRSASigner(t)
+	cfg := &cryptossh.ServerConfig{
+		PasswordCallback: func(conn cryptossh.ConnMetadata, pass []byte) (*cryptossh.Permissions, error) {
+			if conn.User() == user && string(pass) == password {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("denied")
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleTestSSHConn(conn, cfg)
+		}
+	}()
+
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+func handleTestSSHConn(c net.Conn, cfg *cryptossh.ServerConfig) {
+	defer c.Close()
+	serverConn, chans, reqs, err := cryptossh.NewServerConn(c, cfg)
+	if err != nil {
+		return
+	}
+	defer func() { _ = serverConn.Close() }()
+	go cryptossh.DiscardRequests(reqs)
+	handleSessionChannels(chans)
+}
+
+func handleSessionChannels(chans <-chan cryptossh.NewChannel) {
+	for newChannel := range chans {
+		if newChannel.ChannelType() != "session" {
+			_ = newChannel.Reject(cryptossh.UnknownChannelType, "unknown channel type")
+			continue
+		}
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			continue
+		}
+		go func(ch cryptossh.Channel, reqs <-chan *cryptossh.Request) {
+			defer ch.Close()
+			for req := range reqs {
+				switch req.Type {
+				case "exec":
+					_ = req.Reply(true, nil)
+					cmd := ""
+					p := req.Payload
+					if len(p) >= 4 {
+						n := binary.BigEndian.Uint32(p[:4])
+						if len(p) >= int(4+n) {
+							cmd = string(p[4 : 4+n])
+						}
+					}
+					_, _ = ch.Write([]byte(cmd))
+					_, _ = ch.SendRequest("exit-status", false, cryptossh.Marshal(struct{ Status uint32 }{0}))
+					return
+				default:
+					if req.WantReply {
+						_ = req.Reply(false, nil)
+					}
+				}
+			}
+		}(channel, requests)
+	}
+}
+
+func dialPasswordGoph(t *testing.T, addr, user, password string) (*goph.Client, error) {
+	t.Helper()
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+	s := &SSH{
+		User:     user,
+		Host:     host,
+		Port:     uint(port),
+		Password: password,
+	}
+	return s.ConnectWithPassword()
+}
+
+func testSSHOrgContext(parent context.Context, orgID uuid.UUID) context.Context {
+	return context.WithValue(context.WithValue(parent, types.OrganizationIDKey, orgID.String()), types.ServerIDKey, "")
+}

--- a/api/internal/features/ssh/service/init.go
+++ b/api/internal/features/ssh/service/init.go
@@ -20,12 +20,16 @@ type SSHKeyService struct {
 }
 
 func NewSSHKeyService(store *shared_storage.Store, ctx context.Context, l logger.Logger) *SSHKeyService {
-	sshStorage := &storage.SSHKeyStorage{DB: store.DB, Ctx: ctx}
+	return NewSSHKeyServiceForTest(store, ctx, l, &storage.SSHKeyStorage{DB: store.DB, Ctx: ctx})
+}
+
+// NewSSHKeyServiceForTest constructs the service with an injectable repository (primarily for tests).
+func NewSSHKeyServiceForTest(store *shared_storage.Store, ctx context.Context, l logger.Logger, repo storage.SSHKeyRepository) *SSHKeyService {
 	return &SSHKeyService{
 		store:   store,
 		ctx:     ctx,
 		logger:  l,
-		storage: sshStorage,
+		storage: repo,
 	}
 }
 

--- a/api/internal/features/ssh/service/init_test.go
+++ b/api/internal/features/ssh/service/init_test.go
@@ -1,0 +1,215 @@
+package service_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/ssh/service"
+	"github.com/nixopus/nixopus/api/internal/features/ssh/storage"
+	"github.com/nixopus/nixopus/api/internal/testutils"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ip(i int) *int { return &i }
+
+func sp(s string) *string { return &s }
+
+type mockSSHRepo struct {
+	getDefaultFn func(uuid.UUID) (*types.SSHKey, error)
+	getActiveFn  func(uuid.UUID) (*types.SSHKey, error)
+	getByIDFn    func(uuid.UUID) (*types.SSHKey, error)
+	listFn       func(uuid.UUID) ([]*types.SSHKey, error)
+	promoteFn    func(uuid.UUID) error
+
+	promoteCalls []uuid.UUID
+}
+
+func (m *mockSSHRepo) GetActiveSSHKeyByOrganizationID(orgID uuid.UUID) (*types.SSHKey, error) {
+	if m.getActiveFn != nil {
+		return m.getActiveFn(orgID)
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (m *mockSSHRepo) GetDefaultSSHKeyByOrganizationID(orgID uuid.UUID) (*types.SSHKey, error) {
+	if m.getDefaultFn != nil {
+		return m.getDefaultFn(orgID)
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (m *mockSSHRepo) GetSSHKeyByID(keyID uuid.UUID) (*types.SSHKey, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(keyID)
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (m *mockSSHRepo) ListSSHKeysByOrganizationID(orgID uuid.UUID) ([]*types.SSHKey, error) {
+	if m.listFn != nil {
+		return m.listFn(orgID)
+	}
+	return nil, nil
+}
+
+func (m *mockSSHRepo) PromoteToDefault(keyID uuid.UUID) error {
+	m.promoteCalls = append(m.promoteCalls, keyID)
+	if m.promoteFn != nil {
+		return m.promoteFn(keyID)
+	}
+	return nil
+}
+
+var _ storage.SSHKeyRepository = (*mockSSHRepo)(nil)
+
+func TestGetSSHConfigForOrganization_defaultFound(t *testing.T) {
+	org := uuid.New()
+	host := "h.example"
+	user := "ubuntu"
+	priv := "-----BEGIN RSA PRIVATE KEY-----\nABC\n-----END RSA PRIVATE KEY-----"
+	repo := &mockSSHRepo{
+		getDefaultFn: func(id uuid.UUID) (*types.SSHKey, error) {
+			assert.Equal(t, org, id)
+			return &types.SSHKey{
+				Host:                sp(host),
+				User:                sp(user),
+				Port:                ip(2222),
+				PrivateKeyEncrypted: sp(priv),
+			}, nil
+		},
+	}
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), repo)
+
+	cfg, err := svc.GetSSHConfigForOrganization(org)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, host, cfg.Host)
+	assert.Equal(t, user, cfg.User)
+	assert.Equal(t, uint(2222), cfg.Port)
+	assert.Equal(t, priv, cfg.PrivateKey)
+	assert.Empty(t, repo.promoteCalls)
+}
+
+func TestGetSSHConfigForOrganization_promotesActiveWhenNoDefault(t *testing.T) {
+	org := uuid.New()
+	keyID := uuid.New()
+	host := "10.0.0.2"
+	repo := &mockSSHRepo{
+		getDefaultFn: func(uuid.UUID) (*types.SSHKey, error) { return nil, sql.ErrNoRows },
+		getActiveFn: func(uuid.UUID) (*types.SSHKey, error) {
+			return &types.SSHKey{
+				ID:                  keyID,
+				Host:                sp(host),
+				User:                sp("root"),
+				PasswordEncrypted:   sp("secret"),
+				PrivateKeyEncrypted: nil,
+			}, nil
+		},
+	}
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), repo)
+
+	cfg, err := svc.GetSSHConfigForOrganization(org)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, []uuid.UUID{keyID}, repo.promoteCalls)
+	assert.Equal(t, host, cfg.Host)
+	assert.Equal(t, "secret", cfg.Password)
+	assert.Empty(t, cfg.PrivateKey)
+}
+
+func TestGetSSHConfigForOrganization_getDefaultFails(t *testing.T) {
+	org := uuid.New()
+	dbErr := errors.New("db exploded")
+	repo := &mockSSHRepo{
+		getDefaultFn: func(uuid.UUID) (*types.SSHKey, error) { return nil, dbErr },
+	}
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), repo)
+
+	cfg, err := svc.GetSSHConfigForOrganization(org)
+	assert.Nil(t, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get SSH key for organization")
+}
+
+func TestGetSSHConfigForOrganization_noActiveKeys(t *testing.T) {
+	org := uuid.New()
+	repo := &mockSSHRepo{
+		getDefaultFn: func(uuid.UUID) (*types.SSHKey, error) { return nil, sql.ErrNoRows },
+		getActiveFn:  func(uuid.UUID) (*types.SSHKey, error) { return nil, sql.ErrNoRows },
+	}
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), repo)
+
+	cfg, err := svc.GetSSHConfigForOrganization(org)
+	assert.Nil(t, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no server configured for organization")
+}
+
+func TestGetSSHConfigForOrganization_getActiveFails(t *testing.T) {
+	org := uuid.New()
+	dbErr := errors.New("lookup failed")
+	repo := &mockSSHRepo{
+		getDefaultFn: func(uuid.UUID) (*types.SSHKey, error) { return nil, sql.ErrNoRows },
+		getActiveFn:  func(uuid.UUID) (*types.SSHKey, error) { return nil, dbErr },
+	}
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), repo)
+
+	cfg, err := svc.GetSSHConfigForOrganization(org)
+	assert.Nil(t, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get SSH key for organization")
+}
+
+func TestGetSSHConfigForKey_nil(t *testing.T) {
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), &mockSSHRepo{})
+
+	cfg, err := svc.GetSSHConfigForKey(nil)
+	assert.Nil(t, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ssh key is nil")
+}
+
+func TestGetSSHConfigForKey_mapsPointersAndNegativePortDefault(t *testing.T) {
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), &mockSSHRepo{})
+	key := &types.SSHKey{
+		Host:                sp("1.2.3.4"),
+		ProxyHost:           sp("jump.example"),
+		User:                sp("deploy"),
+		Port:                ip(-9),
+		PrivateKeyEncrypted: sp("-----BEGIN RSA PRIVATE KEY-----\nX\n-----END RSA PRIVATE KEY-----"),
+		PasswordEncrypted:   sp("pw"),
+	}
+
+	cfg, err := svc.GetSSHConfigForKey(key)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "1.2.3.4", cfg.Host)
+	assert.Equal(t, "jump.example", cfg.ProxyHost)
+	assert.Equal(t, "deploy", cfg.User)
+	assert.Equal(t, uint(22), cfg.Port)
+	assert.NotEmpty(t, cfg.PrivateKey)
+	assert.Equal(t, "pw", cfg.Password)
+}
+
+func TestGetSSHConfigForKey_nilPointersUseDefaults(t *testing.T) {
+	svc := service.NewSSHKeyServiceForTest(nil, context.Background(), logger.NewLogger(), &mockSSHRepo{})
+	key := &types.SSHKey{}
+
+	cfg, err := svc.GetSSHConfigForKey(key)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.Host)
+	assert.Equal(t, uint(22), cfg.Port)
+}
+
+func TestNewSSHKeyService_usesDefaultRepository(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	svc := service.NewSSHKeyService(setup.Store, setup.Ctx, logger.NewLogger())
+	require.NotNil(t, svc)
+}

--- a/api/internal/features/ssh/storage/init_test.go
+++ b/api/internal/features/ssh/storage/init_test.go
@@ -96,3 +96,191 @@ func TestGetDefaultSSHKeyByOrganizationID_NoDefault(t *testing.T) {
 	assert.Nil(t, result)
 	assert.True(t, errors.Is(err, sql.ErrNoRows), "expected sql.ErrNoRows, got: %v", err)
 }
+
+func sp(s string) *string { return &s }
+
+func TestGetActiveSSHKeyByOrganizationID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	st := &storage.SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	old := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "older-active",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      time.Now().Add(-time.Hour),
+		UpdatedAt:      time.Now().Add(-time.Hour),
+	}
+	newer := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "newer-active",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	inactive := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "inactive",
+		AuthMethod:     "key",
+		IsActive:       false,
+		IsDefault:      false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	require.NoError(t, insertSSHKey(setup, old))
+	require.NoError(t, insertSSHKey(setup, newer))
+	require.NoError(t, insertSSHKey(setup, inactive))
+
+	got, err := st.GetActiveSSHKeyByOrganizationID(org.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, newer.ID, got.ID)
+
+	missingOrg := uuid.New()
+	gotNil, err := st.GetActiveSSHKeyByOrganizationID(missingOrg)
+	assert.Nil(t, gotNil)
+	assert.True(t, errors.Is(err, sql.ErrNoRows))
+}
+
+func TestGetSSHKeyByID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	st := &storage.SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	host := "10.0.0.1"
+	key := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "by-id",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		Host:           sp(host),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	require.NoError(t, insertSSHKey(setup, key))
+
+	got, err := st.GetSSHKeyByID(key.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, host, *got.Host)
+
+	wrong := uuid.New()
+	_, err = st.GetSSHKeyByID(wrong)
+	assert.True(t, errors.Is(err, sql.ErrNoRows))
+}
+
+func TestGetSSHKeyByID_excludesDeleted(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	st := &storage.SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	now := time.Now()
+	key := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "deleted-row",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		DeletedAt:      &now,
+	}
+	require.NoError(t, insertSSHKey(setup, key))
+
+	_, err = st.GetSSHKeyByID(key.ID)
+	assert.True(t, errors.Is(err, sql.ErrNoRows))
+}
+
+func TestPromoteToDefault(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	st := &storage.SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	a := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "k-a",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	b := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "k-b",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	require.NoError(t, insertSSHKey(setup, a))
+	require.NoError(t, insertSSHKey(setup, b))
+
+	require.NoError(t, st.PromoteToDefault(a.ID))
+
+	refreshed, err := st.GetSSHKeyByID(a.ID)
+	require.NoError(t, err)
+	assert.True(t, refreshed.IsDefault)
+}
+
+func TestListSSHKeysByOrganizationID(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	st := &storage.SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	k1 := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "list-one",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      time.Now().Add(-time.Minute),
+		UpdatedAt:      time.Now().Add(-time.Minute),
+	}
+	k2 := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "list-two",
+		AuthMethod:     "key",
+		IsActive:       false,
+		IsDefault:      false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	require.NoError(t, insertSSHKey(setup, k1))
+	require.NoError(t, insertSSHKey(setup, k2))
+
+	list, err := st.ListSSHKeysByOrganizationID(org.ID)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	assert.Equal(t, k2.ID, list[0].ID)
+	assert.Equal(t, k1.ID, list[1].ID)
+
+	empty, err := st.ListSSHKeysByOrganizationID(uuid.New())
+	require.NoError(t, err)
+	assert.Len(t, empty, 0)
+}

--- a/api/internal/features/ssh/storage/storage_internal_test.go
+++ b/api/internal/features/ssh/storage/storage_internal_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/testutils"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHKeyStorage_promoteUsesTxConnection(t *testing.T) {
+	setup := testutils.NewTestSetup()
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	key := &types.SSHKey{
+		ID:             uuid.New(),
+		OrganizationID: org.ID,
+		Name:           "tx-promote",
+		AuthMethod:     "key",
+		IsActive:       true,
+		IsDefault:      false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	_, err = setup.DB.NewInsert().Model(key).Exec(setup.Ctx)
+	require.NoError(t, err)
+
+	tx, err := setup.DB.BeginTx(setup.Ctx, nil)
+	require.NoError(t, err)
+
+	st := &SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx, tx: &tx}
+	require.NoError(t, st.PromoteToDefault(key.ID))
+	require.NoError(t, tx.Commit())
+
+	stNoTx := &SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+	refreshed, err := stNoTx.GetSSHKeyByID(key.ID)
+	require.NoError(t, err)
+	require.True(t, refreshed.IsDefault)
+}

--- a/api/internal/features/ssh/store_integration_test.go
+++ b/api/internal/features/ssh/store_integration_test.go
@@ -1,0 +1,387 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/melbahja/goph"
+	"github.com/nixopus/nixopus/api/internal/features/ssh/storage"
+	"github.com/nixopus/nixopus/api/internal/testutils"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidateSSHManagerCache_closesCachedManagers(t *testing.T) {
+	resetInvalidateHooksForTest()
+
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	key := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      org.ID,
+		Name:                "srv",
+		AuthMethod:          "password",
+		IsActive:            true,
+		IsDefault:           true,
+		Host:                tsp(host),
+		User:                tsp("u"),
+		Port:                tip(port),
+		PasswordEncrypted:   tsp("pw"),
+		PrivateKeyEncrypted: nil,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, key)
+
+	mgr, err := GetSSHManagerForServer(setup.Ctx, org.ID, key.ID)
+	require.NoError(t, err)
+
+	_, err = mgr.RunCommandWithID("", "ping")
+	require.NoError(t, err)
+
+	InvalidateSSHManagerCache(org.ID)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, org.ID, key.ID)
+	require.NoError(t, err)
+
+	InvalidateServerManagerCache(key.ID)
+
+	resetInvalidateHooksForTest()
+}
+
+func TestInvalidateAllSSHManagerCaches(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	key := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      org.ID,
+		Name:                "srv",
+		AuthMethod:          "password",
+		IsActive:            true,
+		IsDefault:           true,
+		Host:                tsp(host),
+		User:                tsp("u"),
+		Port:                tip(port),
+		PasswordEncrypted:   tsp("pw"),
+		PrivateKeyEncrypted: nil,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, key)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, org.ID, key.ID)
+	require.NoError(t, err)
+
+	InvalidateAllSSHManagerCaches()
+
+	_, err = GetSSHManagerForServer(setup.Ctx, org.ID, key.ID)
+	require.NoError(t, err)
+}
+
+func TestGetSSHManagerForServer_wrongOrg_badCred_badPEM(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	_, orgA, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+	_, orgB, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	key := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      orgA.ID,
+		Name:                "srv",
+		AuthMethod:          "key",
+		IsActive:            true,
+		IsDefault:           true,
+		Host:                tsp("127.0.0.1"),
+		User:                tsp("u"),
+		Port:                tip(22),
+		PasswordEncrypted:   nil,
+		PrivateKeyEncrypted: nil,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, key)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, orgB.ID, key.ID)
+	require.Error(t, err)
+
+	keyNoCred := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      orgA.ID,
+		Name:                "srv2",
+		AuthMethod:          "key",
+		IsActive:            true,
+		IsDefault:           false,
+		Host:                tsp("127.0.0.1"),
+		User:                tsp("u"),
+		Port:                tip(22),
+		PasswordEncrypted:   nil,
+		PrivateKeyEncrypted: nil,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, keyNoCred)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, orgA.ID, keyNoCred.ID)
+	require.Error(t, err)
+
+	keyBadPEM := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      orgA.ID,
+		Name:                "srv3",
+		AuthMethod:          "key",
+		IsActive:            true,
+		IsDefault:           false,
+		Host:                tsp("127.0.0.1"),
+		User:                tsp("u"),
+		Port:                tip(22),
+		PasswordEncrypted:   tsp("pw"),
+		PrivateKeyEncrypted: tsp("NOT PEM HEADER"),
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, keyBadPEM)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, orgA.ID, keyBadPEM.ID)
+	require.Error(t, err)
+}
+
+func TestGetSSHManagerForOrganization_promotesActiveAndRunCommand(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	activeOnly := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      org.ID,
+		Name:                "promotable",
+		AuthMethod:          "password",
+		IsActive:            true,
+		IsDefault:           false,
+		Host:                tsp(host),
+		User:                tsp("u"),
+		Port:                tip(port),
+		PasswordEncrypted:   tsp("pw"),
+		PrivateKeyEncrypted: nil,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, activeOnly)
+
+	mgr, err := GetSSHManagerForOrganization(setup.Ctx, org.ID)
+	require.NoError(t, err)
+	defer mgr.Close()
+
+	store := storage.SSHKeyStorage{DB: setup.DB, Ctx: setup.Ctx}
+	refreshed, err := store.GetSSHKeyByID(activeOnly.ID)
+	require.NoError(t, err)
+	assert.True(t, refreshed.IsDefault)
+
+	out, err := mgr.RunCommandWithID("", "hello-world")
+	require.NoError(t, err)
+	assert.Contains(t, out, "hello-world")
+
+	ctx := testSSHOrgContext(setup.Ctx, org.ID)
+	mgr2, err := GetSSHManagerFromContext(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, mgr2)
+
+	srvCtx := context.WithValue(context.WithValue(setup.Ctx, types.OrganizationIDKey, org.ID.String()), types.ServerIDKey, activeOnly.ID.String())
+	mgr3, err := GetSSHManagerFromContext(srvCtx)
+	require.NoError(t, err)
+	assert.NotNil(t, mgr3)
+}
+
+func TestGetSSHManagerFromContext_badServerIDFallsBackToOrg(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	key := &types.SSHKey{
+		ID:                  uuid.New(),
+		OrganizationID:      org.ID,
+		Name:                "def",
+		AuthMethod:          "password",
+		IsActive:            true,
+		IsDefault:           true,
+		Host:                tsp(host),
+		User:                tsp("u"),
+		Port:                tip(port),
+		PasswordEncrypted:   tsp("pw"),
+		PrivateKeyEncrypted: nil,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+	insertSSHKeyRow(t, setup, key)
+
+	ctx := context.WithValue(context.WithValue(setup.Ctx, types.OrganizationIDKey, org.ID.String()), types.ServerIDKey, "not-a-uuid")
+	mgr, err := GetSSHManagerFromContext(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+	mgr.Close()
+}
+
+func TestGetSSHManagerForOrganization_noServerConfigured(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	_, org, err := setup.CreateTestUserAndOrg()
+	require.NoError(t, err)
+
+	_, err = GetSSHManagerForOrganization(setup.Ctx, org.ID)
+	require.Error(t, err)
+	assert.True(t, IsNoDefaultServerError(err))
+}
+
+func TestSSHManager_idleCleanup_evictsUnusedPoolEntry(t *testing.T) {
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	m := NewSSHManagerForTest(nil, 35*time.Millisecond)
+	defer m.Close()
+
+	require.NoError(t, m.AddClient("default", &SSH{
+		User:     "u",
+		Host:     host,
+		Port:     uint(port),
+		Password: "pw",
+	}))
+	_, err = m.Connect()
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	_, err = m.Connect()
+	require.NoError(t, err)
+}
+
+func TestNewSessionWithRetry_and_RunCommand_manager(t *testing.T) {
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	m := NewSSHManager()
+	defer m.Close()
+
+	require.NoError(t, m.AddClient("default", &SSH{
+		User:     "u",
+		Host:     host,
+		Port:     uint(port),
+		Password: "pw",
+	}))
+
+	sess, err := m.NewSessionWithRetry("")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NoError(t, sess.Close())
+
+	out, err := m.RunCommandWithID("", "abc")
+	require.NoError(t, err)
+	assert.Contains(t, out, "abc")
+
+	out2, err := m.RunCommand("xyz")
+	require.NoError(t, err)
+	assert.Contains(t, out2, "xyz")
+}
+
+func TestSSHManager_deadPoolConnectionReconnects(t *testing.T) {
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	m := NewSSHManager()
+	defer m.Close()
+
+	require.NoError(t, m.AddClient("default", &SSH{
+		User:     "u",
+		Host:     host,
+		Port:     uint(port),
+		Password: "pw",
+	}))
+
+	cl1, err := m.ConnectWithID("")
+	require.NoError(t, err)
+	require.NoError(t, cl1.Close())
+
+	time.Sleep(50 * time.Millisecond)
+
+	cl2, err := m.ConnectWithID("")
+	require.NoError(t, err)
+	require.NotNil(t, cl2)
+}
+
+func TestNewSessionWithRetry_connectionFailure(t *testing.T) {
+	m := NewSSHManagerForTest(func(string) (*goph.Client, error) {
+		return nil, errors.New("dial failed")
+	}, time.Minute)
+	defer m.Close()
+	require.NoError(t, m.AddClient("default", &SSH{}))
+
+	_, err := m.NewSessionWithRetry("")
+	require.Error(t, err)
+}

--- a/api/internal/features/ssh/unit_tests_test.go
+++ b/api/internal/features/ssh/unit_tests_test.go
@@ -1,0 +1,315 @@
+package ssh
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/melbahja/goph"
+	"github.com/nixopus/nixopus/api/internal/config"
+	"github.com/nixopus/nixopus/api/internal/testutils"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tsp(s string) *string { return &s }
+
+func tip(i int) *int { return &i }
+
+func withGlobalStore(t *testing.T, setup *testutils.TestSetup) {
+	t.Helper()
+	prev := config.GlobalStore
+	config.GlobalStore = setup.Store
+	t.Cleanup(func() {
+		InvalidateAllSSHManagerCaches()
+		config.GlobalStore = prev
+	})
+}
+
+func insertSSHKeyRow(t *testing.T, setup *testutils.TestSetup, row *types.SSHKey) {
+	t.Helper()
+	_, err := setup.DB.NewInsert().Model(row).Exec(setup.Ctx)
+	require.NoError(t, err)
+}
+
+func TestIsClosedConnectionError_and_alias(t *testing.T) {
+	assert.False(t, IsClosedConnectionError(nil))
+	assert.True(t, IsClosedConnectionError(io.EOF))
+	assert.True(t, IsClosedConnectionError(fmt.Errorf("broken pipe")))
+	assert.True(t, IsClosedConnectionError(fmt.Errorf("connection reset by peer")))
+	assert.True(t, IsClosedConnectionError(fmt.Errorf("unexpected packet")))
+	assert.False(t, IsClosedConnectionError(fmt.Errorf("other")))
+	assert.False(t, isClosedConnectionError(nil))
+	assert.True(t, isClosedConnectionError(io.EOF))
+}
+
+func TestIsNoDefaultServerError(t *testing.T) {
+	assert.False(t, IsNoDefaultServerError(nil))
+	assert.True(t, IsNoDefaultServerError(fmt.Errorf("no server configured for organization %s", uuid.New())))
+	assert.True(t, IsNoDefaultServerError(errors.New("no default server configured")))
+	assert.False(t, IsNoDefaultServerError(errors.New("other")))
+}
+
+func TestNewSSHFromConfig(t *testing.T) {
+	assert.Nil(t, NewSSHFromConfig(nil))
+	cfg := &types.SSHConfig{
+		PrivateKey:          "pk",
+		Host:                "h",
+		ProxyHost:           "p",
+		User:                "u",
+		Port:                222,
+		Password:            "pw",
+		PrivateKeyProtected: "prot",
+	}
+	s := NewSSHFromConfig(cfg)
+	require.NotNil(t, s)
+	assert.Equal(t, "pk", s.PrivateKey)
+	assert.Equal(t, "h", s.Host)
+	assert.Equal(t, "p", s.ProxyHost)
+	assert.Equal(t, "u", s.User)
+	assert.Equal(t, uint(222), s.Port)
+	assert.Equal(t, "pw", s.Password)
+	assert.Equal(t, "prot", s.PrivateKeyProtected)
+}
+
+func TestSSHManager_AddClient_GetClient_SetDefault_ListClients(t *testing.T) {
+	m := NewSSHManager()
+	require.Error(t, m.AddClient("", &SSH{}))
+	require.Error(t, m.AddClient("x", nil))
+	require.NoError(t, m.AddClient("default", &SSH{Host: "h"}))
+
+	c, err := m.GetClient("default")
+	require.NoError(t, err)
+	assert.Equal(t, "h", c.Host)
+
+	_, err = m.GetClient("missing")
+	require.Error(t, err)
+
+	require.Error(t, m.SetDefault("nope"))
+	require.NoError(t, m.SetDefault("default"))
+
+	ids := m.ListClients()
+	require.Len(t, ids, 1)
+	assert.Equal(t, "default", ids[0])
+
+	m.Close()
+}
+
+func TestSSHManager_GetOrganizationSSH_GetSSHHost_User_Upstream_errors(t *testing.T) {
+	m := NewSSHManager()
+	require.NoError(t, m.AddClient("default", &SSH{Host: "", User: "", ProxyHost: ""}))
+
+	_, err := m.GetOrganizationSSH()
+	require.NoError(t, err)
+
+	_, err = m.GetSSHHost()
+	require.Error(t, err)
+
+	m2 := NewSSHManager()
+	_, err = m2.GetOrganizationSSH()
+	require.Error(t, err)
+
+	require.NoError(t, m2.AddClient("default", &SSH{Host: "srv", User: "", ProxyHost: "jump"}))
+	_, err = m2.GetSSHUser()
+	require.Error(t, err)
+
+	require.NoError(t, m2.AddClient("default", &SSH{Host: "srv", User: "root", ProxyHost: "jump"}))
+	h, err := m2.GetUpstreamHost()
+	require.NoError(t, err)
+	assert.Equal(t, "jump", h)
+
+	m3 := NewSSHManager()
+	require.NoError(t, m3.AddClient("default", &SSH{Host: "only", User: "root"}))
+	up, err := m3.GetUpstreamHost()
+	require.NoError(t, err)
+	assert.Equal(t, "only", up)
+
+	m4 := NewSSHManager()
+	require.NoError(t, m4.AddClient("default", &SSH{Host: "", User: "root"}))
+	_, err = m4.GetUpstreamHost()
+	require.Error(t, err)
+
+	m.Close()
+	m2.Close()
+	m3.Close()
+	m4.Close()
+}
+
+func TestInvalidateSSHManagerCache_alwaysFiresHooks(t *testing.T) {
+	resetInvalidateHooksForTest()
+	var fired uuid.UUID
+	RegisterInvalidateHook(func(id uuid.UUID) { fired = id })
+
+	org := uuid.New()
+	InvalidateSSHManagerCache(org)
+	assert.Equal(t, org, fired)
+	resetInvalidateHooksForTest()
+}
+
+func TestGetSSHManager_missingGlobalStore(t *testing.T) {
+	prev := config.GlobalStore
+	config.GlobalStore = nil
+	t.Cleanup(func() { config.GlobalStore = prev })
+
+	_, err := GetSSHManagerForOrganization(context.Background(), uuid.New())
+	require.Error(t, err)
+
+	_, err = GetSSHManagerForServer(context.Background(), uuid.New(), uuid.New())
+	require.Error(t, err)
+}
+
+func TestGetSSHManagerForServer_validationErrors(t *testing.T) {
+	setup := testutils.NewTestSetup()
+	withGlobalStore(t, setup)
+
+	_, err := GetSSHManagerForServer(setup.Ctx, uuid.Nil, uuid.New())
+	require.Error(t, err)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, uuid.New(), uuid.Nil)
+	require.Error(t, err)
+
+	_, err = GetSSHManagerForServer(setup.Ctx, uuid.New(), uuid.New())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "not found"))
+}
+
+func TestSSH_Connect_helpers_and_TerminalEarlyExit(t *testing.T) {
+	_, err := (&SSH{Host: "127.0.0.1", User: ""}).Connect()
+	require.Error(t, err)
+
+	_, err = (&SSH{Host: "", User: "u"}).Connect()
+	require.Error(t, err)
+
+	_, err = (&SSH{User: "u", Host: "h"}).ConnectWithPrivateKey()
+	require.Error(t, err)
+
+	_, err = (&SSH{PrivateKey: "x", User: "u", Host: "127.0.0.1", Port: 65530}).ConnectWithPrivateKey()
+	require.Error(t, err)
+
+	_, err = (&SSH{User: "u", Host: "127.0.0.1"}).ConnectWithPassword()
+	require.Error(t, err)
+
+	sBad := &SSH{Host: "127.0.0.1", User: "u", PrivateKey: "-----BEGIN RSA PRIVATE KEY-----\nBAD\n-----END RSA PRIVATE KEY-----"}
+	_, err = sBad.ConnectWithRetry()
+	require.Error(t, err)
+
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	host, ps, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(ps)
+	require.NoError(t, err)
+
+	s := &SSH{
+		User:       "u",
+		Host:       host,
+		Port:       uint(port),
+		PrivateKey: "-----BEGIN RSA PRIVATE KEY-----\nBAD\n-----END RSA PRIVATE KEY-----",
+		Password:   "pw",
+	}
+	cl, err := s.ConnectWithRetry()
+	require.NoError(t, err)
+	defer cl.Close()
+
+	out, err := s.RunCommand("echo-x")
+	require.NoError(t, err)
+	assert.Contains(t, out, "echo-x")
+
+	s.Terminal()
+
+	m := NewSSHManagerForTest(nil, 0)
+	defer m.Close()
+	assert.NotNil(t, m)
+}
+
+func TestSSHManager_ConnectWithID_factoryErrors_and_Borrow(t *testing.T) {
+	m := NewSSHManagerForTest(func(string) (*goph.Client, error) {
+		return nil, errors.New("boom")
+	}, time.Minute)
+	defer m.Close()
+	require.NoError(t, m.AddClient("default", &SSH{}))
+
+	_, err := m.ConnectWithID("")
+	require.Error(t, err)
+
+	m2 := NewSSHManagerForTest(func(string) (*goph.Client, error) {
+		return nil, nil
+	}, time.Minute)
+	defer m2.Close()
+	require.NoError(t, m2.AddClient("default", &SSH{}))
+
+	_, err = m2.ConnectWithID("")
+	require.Error(t, err)
+
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	m3 := NewSSHManagerForTest(func(string) (*goph.Client, error) {
+		cl, err := dialPasswordGoph(t, addr, "u", "pw")
+		require.NoError(t, err)
+		return cl, nil
+	}, time.Minute)
+	defer m3.Close()
+	require.NoError(t, m3.AddClient("default", &SSH{}))
+
+	cl, rel, err := m3.Borrow("")
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	rel()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := m3.ConnectWithID("")
+			assert.NoError(t, err)
+			assert.NotNil(t, c)
+		}()
+	}
+	wg.Wait()
+
+	m3.CloseConnection("")
+	m3.Close()
+	m3.Close()
+}
+
+func Test_sendKeepalive_closedClient(t *testing.T) {
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	cl, err := dialPasswordGoph(t, addr, "u", "pw")
+	require.NoError(t, err)
+	require.NoError(t, cl.Close())
+
+	assert.False(t, sendKeepalive(cl, time.Second))
+}
+
+func Test_StartKeepalive_nilClient_noop(t *testing.T) {
+	StartKeepalive(nil, time.Millisecond, 4, nil)
+}
+
+func Test_StartKeepalive_stopImmediate(t *testing.T) {
+	addr, shutdown := startPasswordEchoSSHServer(t, "u", "pw")
+	defer shutdown()
+
+	cl, err := dialPasswordGoph(t, addr, "u", "pw")
+	require.NoError(t, err)
+	defer cl.Close()
+
+	stop := make(chan struct{})
+	close(stop)
+	StartKeepalive(cl, time.Millisecond, 4, stop)
+	time.Sleep(30 * time.Millisecond)
+}


### PR DESCRIPTION
## Summary
- Full test coverage for `ssh/service`, `ssh/storage`, and root `ssh` package
- Mock `SSHKeyRepository` for service-layer unit tests
- In-process password SSH server for connection pool, keepalive, and exec path tests
- Storage tests cover all repo methods including the transaction path

## Test plan
- [ ] `go test ./internal/features/ssh/service` passes (100% coverage on `service/init.go`)
- [ ] `go test ./internal/features/ssh/storage` passes against `nixopus_test` DB
- [ ] `go test ./internal/features/ssh` passes against `nixopus_test` DB