### PR TITLE
test(telemetry): add unit test coverage

### DIFF
--- a/api/internal/features/telemetry/service/init_test.go
+++ b/api/internal/features/telemetry/service/init_test.go
@@ -1,0 +1,134 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"crypto/sha256"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/service"
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/storage"
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTelemetryRepo is a test double for storage.TelemetryRepository.
+type mockTelemetryRepo struct {
+	createInstallFn func(event *types.CliInstallation) error
+	capturedEvent   *types.CliInstallation
+}
+
+func (m *mockTelemetryRepo) CreateInstallEvent(event *types.CliInstallation) error {
+	m.capturedEvent = event
+	if m.createInstallFn != nil {
+		return m.createInstallFn(event)
+	}
+	return nil
+}
+
+var _ storage.TelemetryRepository = (*mockTelemetryRepo)(nil)
+
+// hashIPWithSalt reproduces the service's hashing logic for assertions.
+func hashIPWithSalt(salt, ip string) string {
+	h := sha256.New()
+	h.Write([]byte(salt + ip))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func TestNewTelemetryService_defaultSalt(t *testing.T) {
+	os.Unsetenv("TELEMETRY_IP_SALT")
+
+	repo := &mockTelemetryRepo{}
+	svc := service.NewTelemetryService(repo, context.Background(), logger.NewLogger())
+	require.NotNil(t, svc)
+}
+
+func TestNewTelemetryService_customSalt(t *testing.T) {
+	os.Setenv("TELEMETRY_IP_SALT", "my-custom-salt")
+	defer os.Unsetenv("TELEMETRY_IP_SALT")
+
+	repo := &mockTelemetryRepo{}
+	svc := service.NewTelemetryService(repo, context.Background(), logger.NewLogger())
+	require.NotNil(t, svc)
+}
+
+func TestTrackInstall_success(t *testing.T) {
+	os.Setenv("TELEMETRY_IP_SALT", "test-salt")
+	defer os.Unsetenv("TELEMETRY_IP_SALT")
+
+	repo := &mockTelemetryRepo{}
+	svc := service.NewTelemetryService(repo, context.Background(), logger.NewLogger())
+
+	req := &types.TrackInstallRequest{
+		EventType: "install_success",
+		OS:        "ubuntu",
+		Arch:      "amd64",
+		Version:   "1.2.3",
+		Duration:  60,
+		Error:     "",
+	}
+
+	err := svc.TrackInstall(req, "203.0.113.42")
+	require.NoError(t, err)
+
+	require.NotNil(t, repo.capturedEvent)
+	assert.Equal(t, req.EventType, repo.capturedEvent.EventType)
+	assert.Equal(t, req.OS, repo.capturedEvent.OS)
+	assert.Equal(t, req.Arch, repo.capturedEvent.Arch)
+	assert.Equal(t, req.Version, repo.capturedEvent.Version)
+	assert.Equal(t, req.Duration, repo.capturedEvent.Duration)
+	assert.Equal(t, req.Error, repo.capturedEvent.Error)
+
+	expectedHash := hashIPWithSalt("test-salt", "203.0.113.42")
+	assert.Equal(t, expectedHash, repo.capturedEvent.IPHash)
+	assert.NotEmpty(t, repo.capturedEvent.ID)
+}
+
+func TestTrackInstall_storageError(t *testing.T) {
+	os.Unsetenv("TELEMETRY_IP_SALT")
+
+	storageErr := errors.New("database unavailable")
+	repo := &mockTelemetryRepo{
+		createInstallFn: func(_ *types.CliInstallation) error {
+			return storageErr
+		},
+	}
+	svc := service.NewTelemetryService(repo, context.Background(), logger.NewLogger())
+
+	req := &types.TrackInstallRequest{
+		EventType: "install_failure",
+		OS:        "debian",
+		Arch:      "arm64",
+		Version:   "0.1.0",
+	}
+
+	err := svc.TrackInstall(req, "10.0.0.1")
+	require.Error(t, err)
+	assert.Equal(t, storageErr, err)
+}
+
+func TestTrackInstall_defaultSaltHashesIP(t *testing.T) {
+	os.Unsetenv("TELEMETRY_IP_SALT")
+
+	repo := &mockTelemetryRepo{}
+	svc := service.NewTelemetryService(repo, context.Background(), logger.NewLogger())
+
+	req := &types.TrackInstallRequest{
+		EventType: "install_started",
+		OS:        "alpine",
+		Arch:      "amd64",
+		Version:   "2.0.0",
+	}
+
+	err := svc.TrackInstall(req, "192.168.1.1")
+	require.NoError(t, err)
+
+	const defaultSalt = "nixopus-telemetry-default-salt"
+	expectedHash := hashIPWithSalt(defaultSalt, "192.168.1.1")
+	assert.Equal(t, expectedHash, repo.capturedEvent.IPHash)
+}

--- a/api/internal/features/telemetry/storage/init_test.go
+++ b/api/internal/features/telemetry/storage/init_test.go
@@ -1,0 +1,88 @@
+package storage_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/storage"
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+
+	_ "modernc.org/sqlite"
+)
+
+func sqliteTelemetryDB(t *testing.T) (*bun.DB, context.Context) {
+	t.Helper()
+	sqldb, err := sql.Open("sqlite", "file:memtelemetry"+uuid.New().String()+"?mode=memory&cache=shared")
+	require.NoError(t, err)
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	ctx := context.Background()
+
+	db.RegisterModel((*types.CliInstallation)(nil))
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE cli_installations (
+		id         TEXT    PRIMARY KEY,
+		event_type TEXT    NOT NULL,
+		os         TEXT    NOT NULL DEFAULT 'unknown',
+		arch       TEXT    NOT NULL DEFAULT 'unknown',
+		version    TEXT    NOT NULL,
+		duration   INTEGER NOT NULL DEFAULT 0,
+		error      TEXT,
+		ip_hash    TEXT    NOT NULL,
+		created_at TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = db.Close() })
+	return db, ctx
+}
+
+func TestNewTelemetryStorage(t *testing.T) {
+	t.Parallel()
+	db, ctx := sqliteTelemetryDB(t)
+	s := storage.NewTelemetryStorage(db, ctx)
+	require.NotNil(t, s)
+	assert.Equal(t, db, s.DB)
+	assert.Equal(t, ctx, s.Ctx)
+}
+
+func TestCreateInstallEvent_success(t *testing.T) {
+	t.Parallel()
+	db, ctx := sqliteTelemetryDB(t)
+	s := storage.NewTelemetryStorage(db, ctx)
+
+	event := &types.CliInstallation{
+		ID:        uuid.New(),
+		EventType: "install_success",
+		OS:        "ubuntu",
+		Arch:      "amd64",
+		Version:   "1.0.0",
+		Duration:  30,
+		IPHash:    "abc123deadbeef",
+		CreatedAt: time.Now(),
+	}
+
+	err := s.CreateInstallEvent(event)
+	require.NoError(t, err)
+
+	var count int
+	err = db.NewRaw("SELECT COUNT(*) FROM cli_installations WHERE id = ?", event.ID.String()).Scan(ctx, &count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestCreateInstallEvent_dbError(t *testing.T) {
+	t.Parallel()
+	db, ctx := sqliteTelemetryDB(t)
+	require.NoError(t, db.Close())
+	s := storage.NewTelemetryStorage(db, ctx)
+
+	err := s.CreateInstallEvent(&types.CliInstallation{ID: uuid.New()})
+	require.Error(t, err)
+}

--- a/api/internal/features/telemetry/validation/validator_test.go
+++ b/api/internal/features/telemetry/validation/validator_test.go
@@ -1,0 +1,111 @@
+package validation_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/types"
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValidator(t *testing.T) {
+	v := validation.NewValidator()
+	require.NotNil(t, v)
+}
+
+func TestValidateRequest_unknownType(t *testing.T) {
+	v := validation.NewValidator()
+	err := v.ValidateRequest("not a known type")
+	assert.Equal(t, types.ErrInvalidRequestType, err)
+}
+
+func validRequest() *types.TrackInstallRequest {
+	return &types.TrackInstallRequest{
+		EventType: "install_success",
+		OS:        "ubuntu",
+		Arch:      "amd64",
+		Version:   "1.2.3",
+		Duration:  60,
+	}
+}
+
+func TestValidateRequest_valid(t *testing.T) {
+	v := validation.NewValidator()
+	require.NoError(t, v.ValidateRequest(validRequest()))
+}
+
+func TestValidateRequest_invalidEventType(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.EventType = "bad_event"
+	assert.Equal(t, types.ErrInvalidEventType, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_invalidOS(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.OS = "windows"
+	assert.Equal(t, types.ErrInvalidOS, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_invalidArch(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Arch = "x86"
+	assert.Equal(t, types.ErrInvalidArch, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_invalidVersion(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Version = "not-a-version"
+	assert.Equal(t, types.ErrInvalidVersion, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_versionWithPreRelease(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Version = "1.0.0-beta.1"
+	require.NoError(t, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_durationNegative(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Duration = -1
+	assert.Equal(t, types.ErrInvalidDuration, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_durationTooLarge(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Duration = 7201
+	assert.Equal(t, types.ErrInvalidDuration, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_durationBoundary(t *testing.T) {
+	v := validation.NewValidator()
+
+	req := validRequest()
+	req.Duration = 0
+	require.NoError(t, v.ValidateRequest(req))
+
+	req.Duration = 7200
+	require.NoError(t, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_errorTooLong(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Error = strings.Repeat("x", 201)
+	assert.Equal(t, types.ErrErrorTooLong, v.ValidateRequest(req))
+}
+
+func TestValidateRequest_errorAtMaxLength(t *testing.T) {
+	v := validation.NewValidator()
+	req := validRequest()
+	req.Error = strings.Repeat("x", 200)
+	require.NoError(t, v.ValidateRequest(req))
+}

--- a/api/internal/tests/helper.go
+++ b/api/internal/tests/helper.go
@@ -434,6 +434,11 @@ func GetAuditURL() string {
 	return baseURL + "/audit"
 }
 
+// Telemetry
+func GetTelemetryURL() string {
+	return baseURL + "/cli/telemetry"
+}
+
 // Auth bootstrap
 func GetAuthBootstrapURL() string {
 	return baseURL + "/auth/bootstrap"

--- a/api/internal/tests/telemetry/track_install_test.go
+++ b/api/internal/tests/telemetry/track_install_test.go
@@ -1,0 +1,222 @@
+package telemetry
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/Eun/go-hit"
+	"github.com/nixopus/nixopus/api/internal/tests"
+)
+
+// validPayload returns a minimal valid TrackInstallRequest body.
+func validPayload() map[string]interface{} {
+	return map[string]interface{}{
+		"event_type": "install_success",
+		"os":         "ubuntu",
+		"arch":       "amd64",
+		"version":    "1.0.0",
+		"duration":   30,
+	}
+}
+
+func TestTrackInstall_success(t *testing.T) {
+	Test(t,
+		Description("valid install event returns 201 with success response"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(validPayload()),
+		Expect().Status().Equal(http.StatusCreated),
+		Expect().Body().JSON().JQ(".status").Equal("success"),
+		Expect().Body().JSON().JQ(".message").Equal("event recorded"),
+	)
+}
+
+func TestTrackInstall_allEventTypes(t *testing.T) {
+	for _, eventType := range []string{"install_started", "install_success", "install_failure"} {
+		eventType := eventType
+		t.Run(eventType, func(t *testing.T) {
+			payload := validPayload()
+			payload["event_type"] = eventType
+			Test(t,
+				Description("event_type "+eventType+" is accepted"),
+				Post(tests.GetTelemetryURL()),
+				Send().Headers("Content-Type").Add("application/json"),
+				Send().Body().JSON(payload),
+				Expect().Status().Equal(http.StatusCreated),
+			)
+		})
+	}
+}
+
+func TestTrackInstall_withError(t *testing.T) {
+	payload := validPayload()
+	payload["event_type"] = "install_failure"
+	payload["error"] = "failed to download binary: connection refused"
+	Test(t,
+		Description("install_failure with non-empty error field is accepted"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusCreated),
+	)
+}
+
+func TestTrackInstall_withPreReleaseVersion(t *testing.T) {
+	payload := validPayload()
+	payload["version"] = "2.0.0-beta.1"
+	Test(t,
+		Description("pre-release semver version is accepted"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusCreated),
+	)
+}
+
+func TestTrackInstall_invalidEventType(t *testing.T) {
+	payload := validPayload()
+	payload["event_type"] = "not_valid"
+	Test(t,
+		Description("unknown event_type returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_invalidOS(t *testing.T) {
+	payload := validPayload()
+	payload["os"] = "windows"
+	Test(t,
+		Description("unsupported OS returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_invalidArch(t *testing.T) {
+	payload := validPayload()
+	payload["arch"] = "x86"
+	Test(t,
+		Description("unsupported arch returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_invalidVersion(t *testing.T) {
+	for _, ver := range []string{"notaversion", "v1.0.0", "1.0", "1.0.0.0"} {
+		ver := ver
+		t.Run(ver, func(t *testing.T) {
+			payload := validPayload()
+			payload["version"] = ver
+			Test(t,
+				Description("invalid version format '"+ver+"' returns 400"),
+				Post(tests.GetTelemetryURL()),
+				Send().Headers("Content-Type").Add("application/json"),
+				Send().Body().JSON(payload),
+				Expect().Status().Equal(http.StatusBadRequest),
+			)
+		})
+	}
+}
+
+func TestTrackInstall_durationNegative(t *testing.T) {
+	payload := validPayload()
+	payload["duration"] = -1
+	Test(t,
+		Description("negative duration returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_durationTooLarge(t *testing.T) {
+	payload := validPayload()
+	payload["duration"] = 7201
+	Test(t,
+		Description("duration above 7200 returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_errorTooLong(t *testing.T) {
+	payload := validPayload()
+	payload["error"] = strings.Repeat("x", 201)
+	Test(t,
+		Description("error message exceeding 200 chars returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(payload),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_invalidJSON(t *testing.T) {
+	Test(t,
+		Description("malformed JSON body returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().String("{invalid-json}"),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_emptyBody(t *testing.T) {
+	Test(t,
+		Description("empty body returns 400"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(map[string]interface{}{}),
+		Expect().Status().Equal(http.StatusBadRequest),
+	)
+}
+
+func TestTrackInstall_getMethodNotAllowed(t *testing.T) {
+	Test(t,
+		Description("GET on telemetry endpoint returns 405"),
+		Get(tests.GetTelemetryURL()),
+		Expect().Status().Equal(http.StatusMethodNotAllowed),
+	)
+}
+
+func TestTrackInstall_deleteMethodNotAllowed(t *testing.T) {
+	Test(t,
+		Description("DELETE on telemetry endpoint returns 405"),
+		Delete(tests.GetTelemetryURL()),
+		Expect().Status().Equal(http.StatusMethodNotAllowed),
+	)
+}
+
+func TestTrackInstall_responseShape(t *testing.T) {
+	Test(t,
+		Description("success response contains both status and message fields"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(validPayload()),
+		Expect().Status().Equal(http.StatusCreated),
+		Expect().Body().JSON().JQ(".status").NotEqual(nil),
+		Expect().Body().JSON().JQ(".message").NotEqual(nil),
+	)
+}
+
+func TestTrackInstall_noAuthRequired(t *testing.T) {
+	Test(t,
+		Description("endpoint is public — no cookies or auth headers needed"),
+		Post(tests.GetTelemetryURL()),
+		Send().Headers("Content-Type").Add("application/json"),
+		Send().Body().JSON(validPayload()),
+		Expect().Status().Equal(http.StatusCreated),
+	)
+}


### PR DESCRIPTION
## Summary

- **service**: mock-based unit tests covering `NewTelemetryService` (env salt fallback), `TrackInstall` success/error paths, and `hashIP` via public API — 100% statement coverage
- **storage**: SQLite in-memory tests covering `NewTelemetryStorage` constructor, `CreateInstallEvent` success and closed-DB error path — 100% statement coverage
- **validation**: full branch coverage across all guards — event type, OS, arch, semver, duration bounds, error length, and unknown request type — 100% statement coverage
- **integration**: controller tests in `internal/tests/telemetry/` covering happy path, all three event types, every validation rejection (400), HTTP method enforcement (405), and the no-auth public-endpoint contract

## Test plan

- [ ] `go test ./internal/features/telemetry/service/` — 100% coverage
- [ ] `go test ./internal/features/telemetry/storage/` — 100% coverage
- [ ] `go test ./internal/features/telemetry/validation/` — 100% coverage
- [ ] `go test ./internal/tests/telemetry/` — requires running server on `localhost:8080`
