### PR TITLE
test(caddy): expand coverage with hooks + httptest

### DIFF
--- a/api/internal/features/deploy/caddy/coverage_expansion_test.go
+++ b/api/internal/features/deploy/caddy/coverage_expansion_test.go
@@ -1,0 +1,364 @@
+package caddy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/config"
+	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/features/ssh"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/raghavyuva/caddygo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetCaddyHooks(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		testGetCaddyClientHook = nil
+		tunnelCreateHook = nil
+		tunnelDialSSHHook = nil
+		getSSHHostForOrgHook = nil
+		reconcileGetPublishedPortHook = nil
+		getDockerServiceFromContext = docker.GetDockerServiceFromContext
+		getSSHManagerFromContextForCaddy = ssh.GetSSHManagerFromContext
+		pingCaddyProbe = PingCaddy
+		caddyTunnelCacheMu.Lock()
+		for _, e := range caddyTunnelCache {
+			if e != nil && e.tunnel != nil {
+				e.tunnel.Close()
+			}
+		}
+		caddyTunnelCache = make(map[string]*caddyTunnelEntry)
+		caddyTunnelCacheMu.Unlock()
+		enqueueReconcileAfterRecovery = EnqueueReconcile
+	})
+}
+
+// attachTunnelHarness directs createCaddyTunnelForClient → local httptest admin (real GetCaddyClient path).
+func attachTunnelHarness(t *testing.T, cfg *memCaddyCfg) *httptest.Server {
+	t.Helper()
+	srv := newTestCaddyAdminServer(t, cfg)
+	tunnelCreateHook = func(*ssh.SSH, string, uuid.UUID, logger.Logger) (*CaddyTunnel, error) {
+		return &CaddyTunnel{
+			endpoint: strings.TrimSuffix(srv.URL, "/"),
+			cleanup:  func() error { return nil },
+		}, nil
+	}
+	return srv
+}
+
+func TestGetCaddyClient_viaTunnelHook_cache_nilLogger_errors(t *testing.T) {
+	resetCaddyHooks(t)
+
+	cfgMem := newMemCaddyCfg(`{}`)
+	attachTunnelHarness(t, cfgMem)
+
+	host := "c-client-" + uuid.New().String() + ".invalid"
+	sshCli := &ssh.SSH{Host: host}
+	ctx := context.Background()
+	log := logger.NewLogger()
+
+	_, err := GetCaddyClient(ctx, &ssh.SSH{Host: ""}, &log)
+	require.Error(t, err)
+
+	orig := config.AppConfig.Proxy
+	t.Cleanup(func() { config.AppConfig.Proxy = orig })
+	config.AppConfig.Proxy.CaddyPort = "nan"
+	_, err = GetCaddyClient(ctx, sshCli, &log)
+	require.Error(t, err)
+
+	config.AppConfig.Proxy = orig
+
+	c1, err := GetCaddyClient(ctx, sshCli, &log)
+	require.NoError(t, err)
+	c2, err := GetCaddyClient(ctx, sshCli, &log)
+	require.NoError(t, err)
+	require.Same(t, c1, c2)
+
+	c3, err := GetCaddyClient(ctx, sshCli, nil)
+	require.NoError(t, err)
+	require.Same(t, c1, c3)
+	require.NoError(t, PingCaddy(ctx, sshCli, &log))
+}
+
+func TestAddRemoveDomainsAtomic_withTunnelHook(t *testing.T) {
+	resetCaddyHooks(t)
+
+	cfgMem := newMemCaddyCfg(`{}`)
+	attachTunnelHarness(t, cfgMem)
+
+	ctx := context.Background()
+	l := logger.NewLogger()
+	sshCli := &ssh.SSH{Host: "atomic-" + uuid.New().String() + ".invalid"}
+
+	require.NoError(t, AddDomainsAtomic(ctx, sshCli, &l, []DomainRoute{
+		{Domain: "atomic.example.test", UpstreamDial: "127.0.0.1:15000"},
+	}))
+
+	require.NoError(t, RemoveDomainsAtomic(ctx, sshCli, &l, []string{"atomic.example.test"}))
+
+	atomicErr := AddDomainsAtomic(ctx, sshCli, &l, []DomainRoute{
+		{Domain: "bad.invalid", UpstreamDial: "not-a-valid-dial"},
+	})
+	require.Error(t, atomicErr)
+}
+
+func Test_getSSHHostForOrg_managerError(t *testing.T) {
+	orig := getSSHManagerFromContextForCaddy
+	getSSHManagerFromContextForCaddy = func(context.Context) (*ssh.SSHManager, error) {
+		return nil, errors.New("no ssh manager")
+	}
+	t.Cleanup(func() {
+		getSSHManagerFromContextForCaddy = orig
+	})
+
+	_, err := getSSHHostForOrg(context.Background())
+	require.ErrorContains(t, err, "no ssh manager")
+}
+
+func TestHealthMonitor_enqueueAll_fetchError(t *testing.T) {
+	rec := NewReconciler(&deployRepoTestStub{}, logger.NewLogger())
+	h := NewHealthMonitor(logger.NewLogger(), rec, time.Hour,
+		func(context.Context) ([]uuid.UUID, error) {
+			return nil, errors.New("orgs unavailable")
+		},
+	)
+	h.enqueueAll(context.Background())
+}
+
+// memCaddyCfg stores JSON returned by GET /config/ and updated by POST.
+type memCaddyCfg struct {
+	mu sync.Mutex
+	b  []byte
+}
+
+func newMemCaddyCfg(initial string) *memCaddyCfg {
+	m := &memCaddyCfg{b: []byte(initial)}
+	if strings.TrimSpace(string(m.b)) == "" {
+		m.b = []byte(`{}`)
+	}
+	return m
+}
+
+func newTestCaddyAdminServer(t *testing.T, cfg *memCaddyCfg) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/config/":
+			switch r.Method {
+			case http.MethodGet:
+				cfg.mu.Lock()
+				payload := cfg.b
+				cfg.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(payload)
+			case http.MethodPost:
+				body, _ := io.ReadAll(r.Body)
+				cfg.mu.Lock()
+				cfg.b = body
+				cfg.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+			default:
+				http.NotFound(w, r)
+			}
+			return
+		case "/config":
+			http.Redirect(w, r, "/config/", http.StatusPermanentRedirect)
+		case "/load":
+			if r.Method != http.MethodPost {
+				http.NotFound(w, r)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			cfg.mu.Lock()
+			cfg.b = body
+			cfg.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func clientForHarness(srv *httptest.Server) *caddygo.Client {
+	cli := &http.Client{}
+	return &caddygo.Client{
+		BaseURL:    strings.TrimSuffix(srv.URL, "/"),
+		HTTPClient: cli,
+	}
+}
+
+func hookClientFromHarness(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	c := clientForHarness(srv)
+	testGetCaddyClientHook = func(context.Context, *ssh.SSH, *logger.Logger) (*caddygo.Client, error) {
+		return c, nil
+	}
+}
+
+func TestPingCaddy_and_GetCurrentDomains_viaHook(t *testing.T) {
+	resetCaddyHooks(t)
+
+	cfgMem := newMemCaddyCfg(`{}`)
+	srv := newTestCaddyAdminServer(t, cfgMem)
+	hookClientFromHarness(t, srv)
+
+	l := logger.NewLogger()
+	ctx := context.Background()
+	require.NoError(t, PingCaddy(ctx, nil, &l))
+
+	doms, err := GetCurrentDomains(ctx, nil, &l)
+	require.NoError(t, err)
+	assert.Nil(t, doms)
+}
+
+func TestGetCaddyConfig_RestoreCaddyConfig(t *testing.T) {
+	resetCaddyHooks(t)
+
+	payload := func() []byte {
+		b, err := json.Marshal(&caddy.Config{})
+		require.NoError(t, err)
+		return b
+	}()
+	cfgMem := newMemCaddyCfg(string(payload))
+	srv := newTestCaddyAdminServer(t, cfgMem)
+	hookClientFromHarness(t, srv)
+
+	ctx := context.Background()
+	l := logger.NewLogger()
+	got, err := GetCaddyConfig(ctx, nil, &l)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	swap := func() shared_types.ProxyConfig {
+		return config.AppConfig.Proxy
+	}
+	origProxy := swap()
+	t.Cleanup(func() {
+		config.AppConfig.Proxy = origProxy
+	})
+	config.AppConfig.Proxy.CaddyPort = ""
+
+	routes := `[{"match":[{"host":["z.example.test"]}],"handle":[{"handler":"reverse_proxy","upstreams":[{"dial":"127.0.0.1:9090"}]}]}]`
+	patchJSON := fmt.Sprintf(`{"apps":{"http":{"servers":{"nixopus":{"routes":%s}}}}}`, routes)
+	cfgMem.mu.Lock()
+	cfgMem.b = []byte(patchJSON)
+	cfgMem.mu.Unlock()
+
+	require.NoError(t, RestoreCaddyConfig(ctx, nil, &l, got))
+}
+
+func TestInvalidateTunnel_earlyReturn_badPort(t *testing.T) {
+	orig := config.AppConfig.Proxy
+	t.Cleanup(func() { config.AppConfig.Proxy = orig })
+	config.AppConfig.Proxy.CaddyPort = "not-a-number"
+
+	key := "h:2019"
+	caddyTunnelCacheMu.Lock()
+	caddyTunnelCache[key] = &caddyTunnelEntry{lastUsed: time.Now()}
+	caddyTunnelCacheMu.Unlock()
+	t.Cleanup(func() {
+		caddyTunnelCacheMu.Lock()
+		delete(caddyTunnelCache, key)
+		caddyTunnelCacheMu.Unlock()
+	})
+
+	InvalidateTunnel("h")
+
+	caddyTunnelCacheMu.RLock()
+	_, exists := caddyTunnelCache[key]
+	caddyTunnelCacheMu.RUnlock()
+	assert.True(t, exists, "invalid Caddy port should skip eviction")
+}
+
+func TestAddDomains_RemoveDomains_operations_withHarness(t *testing.T) {
+	resetCaddyHooks(t)
+
+	cfgMem := newMemCaddyCfg(`{}`)
+	srv := newTestCaddyAdminServer(t, cfgMem)
+	hookClientFromHarness(t, srv)
+
+	ctx := context.Background()
+	l := logger.NewLogger()
+	domains := []DomainRoute{{Domain: "op.example.test", UpstreamDial: "127.0.0.1:1234"}}
+	require.NoError(t, AddDomainsWithRetry(ctx, nil, &l, domains))
+
+	var calls atomic.Int32
+	testGetCaddyClientHook = func(context.Context, *ssh.SSH, *logger.Logger) (*caddygo.Client, error) {
+		if calls.Add(1) == 1 {
+			return nil, errors.New("transient miss")
+		}
+		return clientForHarness(srv), nil
+	}
+	sshKick := &ssh.SSH{Host: "invalidate.example"}
+	defer InvalidateTunnelByKey("invalidate.example:2019")
+	transientL := logger.NewLogger()
+	require.NoError(t, AddDomainsWithRetry(context.Background(), sshKick, &transientL, domains))
+
+	require.NoError(t, RemoveDomainsWithRetry(context.Background(), nil, &l, []string{"op.example.test"}))
+}
+
+func TestReconcileOrganization_add_and_pendingRemovals_viaHooks(t *testing.T) {
+	resetCaddyHooks(t)
+	setupTestRedis(t)
+
+	cfgMem := newMemCaddyCfg(`{}`)
+	srv := newTestCaddyAdminServer(t, cfgMem)
+	hookClientFromHarness(t, srv)
+
+	orgID := uuid.New()
+	ctxOrg := context.WithValue(context.Background(), shared_types.OrganizationIDKey, orgID.String())
+	getSSHHostForOrgHook = func(context.Context) (string, error) {
+		return "proxy.internal", nil
+	}
+	reconcileGetPublishedPortHook = func(*Reconciler, context.Context, string) (int, error) {
+		return 7000, nil
+	}
+
+	d := shared_types.ApplicationDomain{Domain: "rec.example"}
+	app := shared_types.Application{
+		ID:              uuid.New(),
+		Name:            "svc-a",
+		BuildPack:       shared_types.DockerFile,
+		Domains:         []*shared_types.ApplicationDomain{&d},
+		Servers:         []*shared_types.ApplicationServer{{}},
+		RoutingStrategy: shared_types.RoutingStrategySingle,
+	}
+	st := &deployRepoTestStub{
+		servers:      []shared_types.ApplicationServer{{}},
+		deployedApps: []shared_types.Application{app},
+	}
+	rec := NewReconciler(st, logger.NewLogger())
+
+	err := TrackExtensionDomain(orgID, "ext.rec", "10.10.10.10:4434")
+	require.NoError(t, err)
+
+	err = EnqueuePendingRemoval(orgID, "removed.example")
+	require.NoError(t, err)
+
+	rs, err := rec.ReconcileOrganization(ctxOrg, orgID)
+	require.NoError(t, err)
+	assert.Contains(t, rs.Added, "rec.example")
+	assert.Contains(t, rs.Added, "ext.rec")
+	require.NotEmpty(t, rs.Removed)
+	assert.Contains(t, rs.Removed, "removed.example")
+}

--- a/api/internal/features/deploy/caddy/deploy_repository_stub_test.go
+++ b/api/internal/features/deploy/caddy/deploy_repository_stub_test.go
@@ -1,0 +1,183 @@
+package caddy
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+
+	"github.com/nixopus/nixopus/api/internal/features/deploy/storage"
+	deploy_types "github.com/nixopus/nixopus/api/internal/features/deploy/types"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+)
+
+// deployRepoTestStub satisfies storage.DeployRepository for route-builder tests.
+// Only GetApplicationServers is observed; everything else returns zero values.
+type deployRepoTestStub struct {
+	servers         []shared_types.ApplicationServer
+	err             error
+	deployedApps    []shared_types.Application
+	deployedAppsErr error
+}
+
+func (s *deployRepoTestStub) RunInTransaction(fn func(tx bun.Tx) error) error {
+	return nil
+}
+func (s *deployRepoTestStub) IsNameAlreadyTaken(name string) (bool, error) {
+	return false, nil
+}
+func (s *deployRepoTestStub) IsDomainAlreadyTaken(domain string) (bool, error) {
+	return false, nil
+}
+func (s *deployRepoTestStub) IsPortAlreadyTaken(port int) (bool, error) {
+	return false, nil
+}
+func (s *deployRepoTestStub) IsDomainValid(domain string) (bool, error) {
+	return false, nil
+}
+func (s *deployRepoTestStub) AddApplication(application *shared_types.Application) error {
+	return nil
+}
+func (s *deployRepoTestStub) AddApplicationLogs(applicationLogs *shared_types.ApplicationLogs) error {
+	return nil
+}
+func (s *deployRepoTestStub) AddApplicationLogsBatch(logs []shared_types.ApplicationLogs) error {
+	return nil
+}
+func (s *deployRepoTestStub) AddApplicationStatus(applicationStatus *shared_types.ApplicationStatus) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetApplications(page int, pageSize int, sortBy string, sortDirection string, organizationID uuid.UUID, serverID *uuid.UUID) ([]shared_types.Application, int, error) {
+	return nil, 0, nil
+}
+func (s *deployRepoTestStub) UpdateApplicationStatus(applicationStatus *shared_types.ApplicationStatus) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetApplicationById(id string, organizationID uuid.UUID) (shared_types.Application, error) {
+	return shared_types.Application{}, nil
+}
+func (s *deployRepoTestStub) GetApplicationBasicById(id string, organizationID uuid.UUID) (shared_types.Application, error) {
+	return shared_types.Application{}, nil
+}
+func (s *deployRepoTestStub) AddApplicationDeployment(deployment *shared_types.ApplicationDeployment) error {
+	return nil
+}
+func (s *deployRepoTestStub) AddApplicationDeploymentStatus(deployment_status *shared_types.ApplicationDeploymentStatus) error {
+	return nil
+}
+func (s *deployRepoTestStub) UpdateApplicationDeploymentStatus(applicationStatus *shared_types.ApplicationDeploymentStatus) error {
+	return nil
+}
+func (s *deployRepoTestStub) UpdateApplication(application *shared_types.Application) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetApplicationDeploymentById(deploymentID string) (shared_types.ApplicationDeployment, error) {
+	return shared_types.ApplicationDeployment{}, nil
+}
+func (s *deployRepoTestStub) DeleteDeployment(deployment *deploy_types.DeleteDeploymentRequest, userID uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) UpdateApplicationDeployment(deployment *shared_types.ApplicationDeployment) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetApplicationDeployments(applicationID uuid.UUID) ([]shared_types.ApplicationDeployment, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) GetPaginatedApplicationDeployments(applicationID uuid.UUID, page, pageSize int) ([]shared_types.ApplicationDeployment, int, error) {
+	return nil, 0, nil
+}
+func (s *deployRepoTestStub) GetLogs(applicationID string, page, pageSize int, level string, startTime, endTime time.Time, searchTerm string) ([]shared_types.ApplicationLogs, int, error) {
+	return nil, 0, nil
+}
+func (s *deployRepoTestStub) AddApplicationDomains(applicationID uuid.UUID, domains []string) error {
+	return nil
+}
+func (s *deployRepoTestStub) RemoveApplicationDomain(applicationID uuid.UUID, domain string) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetApplicationDomains(applicationID uuid.UUID) ([]shared_types.ApplicationDomain, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) GetDeploymentLogs(deploymentID string, page, pageSize int, level string, startTime, endTime time.Time, searchTerm string) ([]shared_types.ApplicationLogs, int, error) {
+	return nil, 0, nil
+}
+func (s *deployRepoTestStub) GetApplicationByRepositoryID(repositoryID uint64) (shared_types.Application, error) {
+	return shared_types.Application{}, nil
+}
+func (s *deployRepoTestStub) GetApplicationByRepositoryIDAndBranch(repositoryID uint64, branch string) ([]shared_types.Application, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) UpdateApplicationLabels(applicationID uuid.UUID, labels []string, organizationID uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetProjectsByFamilyID(familyID uuid.UUID, organizationID uuid.UUID) ([]shared_types.Application, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) UpdateApplicationFamilyID(applicationID uuid.UUID, familyID *uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) IsEnvironmentInFamily(familyID uuid.UUID, environment shared_types.Environment) (bool, error) {
+	return false, nil
+}
+func (s *deployRepoTestStub) GetEnvironmentsInFamily(familyID uuid.UUID, organizationID uuid.UUID) ([]shared_types.Environment, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) CountFamilyMembers(familyID uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (s *deployRepoTestStub) ClearFamilyIDIfSingleMember(familyID uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetLatestDeployments(organizationID uuid.UUID, limit int) ([]shared_types.ApplicationDeployment, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) GetDeployedApplications(organizationID uuid.UUID) ([]shared_types.Application, error) {
+	if s.deployedAppsErr != nil {
+		return nil, s.deployedAppsErr
+	}
+	return s.deployedApps, nil
+}
+func (s *deployRepoTestStub) GetLatestDeploymentsByServer(organizationID uuid.UUID, serverID uuid.UUID, limit int) ([]shared_types.ApplicationDeployment, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) GetLatestS3Deployment(applicationID uuid.UUID) (*shared_types.ApplicationDeployment, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) UpsertComposeServices(applicationID uuid.UUID, services []shared_types.ComposeService) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetComposeServices(applicationID uuid.UUID) ([]shared_types.ComposeService, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) GetComposeServiceByName(applicationID uuid.UUID, serviceName string) (*shared_types.ComposeService, error) {
+	return nil, nil
+}
+func (s *deployRepoTestStub) AddApplicationDomainWithService(applicationID uuid.UUID, domain string, composeServiceID *uuid.UUID, port *int) error {
+	return nil
+}
+func (s *deployRepoTestStub) UpdateApplicationDomainService(applicationID uuid.UUID, domain string, composeServiceID *uuid.UUID, port *int) error {
+	return nil
+}
+func (s *deployRepoTestStub) GetApplicationServers(appID uuid.UUID) ([]shared_types.ApplicationServer, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.servers, nil
+}
+func (s *deployRepoTestStub) SetApplicationServers(appID uuid.UUID, serverIDs []uuid.UUID, primaryServerID *uuid.UUID, routingStrategy shared_types.RoutingStrategy) error {
+	return nil
+}
+func (s *deployRepoTestStub) EnsureApplicationServers(appID uuid.UUID, orgID uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) CopyApplicationServers(srcAppID, dstAppID uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) DeleteApplicationDeploymentByID(id uuid.UUID) error {
+	return nil
+}
+func (s *deployRepoTestStub) ClearDeploymentArtifactFields(deploymentID uuid.UUID) error {
+	return nil
+}
+
+var _ storage.DeployRepository = (*deployRepoTestStub)(nil)

--- a/api/internal/features/deploy/caddy/health.go
+++ b/api/internal/features/deploy/caddy/health.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/melbahja/goph"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
-	"github.com/nixopus/nixopus/api/internal/features/ssh"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/vmihailenco/taskq/v3"
 )
@@ -76,14 +75,18 @@ func (h *HealthMonitor) SetupQueue() {
 		Name:       TASK_CADDY_HEALTH,
 		RetryLimit: 0,
 		Handler: func(ctx context.Context, payload CaddyTaskPayload) error {
-			orgID, err := uuid.Parse(payload.OrganizationID)
-			if err != nil {
-				return fmt.Errorf("invalid org ID in health check task: %w", err)
-			}
-			h.checkServer(ctx, orgID)
-			return nil
+			return h.healthCheckTask(ctx, payload)
 		},
 	})
+}
+
+func (h *HealthMonitor) healthCheckTask(ctx context.Context, payload CaddyTaskPayload) error {
+	orgID, err := uuid.Parse(payload.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("invalid org ID in health check task: %w", err)
+	}
+	h.checkServer(ctx, orgID)
+	return nil
 }
 
 func (h *HealthMonitor) Start(ctx context.Context) {
@@ -173,7 +176,7 @@ func (h *HealthMonitor) checkServer(ctx context.Context, orgID uuid.UUID) {
 		return
 	}
 
-	err = PingCaddy(orgCtx, nil, &h.logger)
+	err = pingCaddyProbe(orgCtx, nil, &h.logger)
 
 	h.mu.RLock()
 	prev, existed := h.servers[orgID]
@@ -258,7 +261,7 @@ func (h *HealthMonitor) recordRestartAttempt(orgID uuid.UUID, containerMissing b
 }
 
 func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID, host string) {
-	manager, err := ssh.GetSSHManagerFromContext(ctx)
+	manager, err := getSSHManagerFromContextForCaddy(ctx)
 	if err != nil {
 		h.logger.Log(logger.Error, "failed to get SSH manager for caddy restart", err.Error())
 		return
@@ -390,7 +393,7 @@ func (h *HealthMonitor) trySystemdRestart(conn *goph.Client, orgID uuid.UUID, ho
 // triggerReconciliation enqueues a reconcile job via Redis instead of running
 // it inline, so any available worker picks it up.
 func (h *HealthMonitor) triggerReconciliation(orgID uuid.UUID) {
-	if err := EnqueueReconcile(orgID); err != nil {
+	if err := enqueueReconcileAfterRecovery(orgID); err != nil {
 		h.logger.Log(logger.Error, "failed to enqueue post-recovery reconciliation", err.Error())
 	}
 }

--- a/api/internal/features/deploy/caddy/health_monitor_test.go
+++ b/api/internal/features/deploy/caddy/health_monitor_test.go
@@ -1,0 +1,42 @@
+package caddy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthMonitor_GetServerHealth_unknownOrg(t *testing.T) {
+	l := logger.NewLogger()
+	rec := NewReconciler(&deployRepoTestStub{}, l)
+	h := NewHealthMonitor(l, rec, time.Minute, func(context.Context) ([]uuid.UUID, error) {
+		return nil, nil
+	})
+
+	assert.Nil(t, h.GetServerHealth(uuid.New()))
+	assert.Empty(t, h.GetAllHealth())
+}
+
+func TestHealthMonitor_SetupQueue_idempotent(t *testing.T) {
+	orig := TaskCaddyHealthCheck
+	t.Cleanup(func() { TaskCaddyHealthCheck = orig })
+	TaskCaddyHealthCheck = nil
+
+	l := logger.NewLogger()
+	rec := NewReconciler(&deployRepoTestStub{}, l)
+	h := NewHealthMonitor(l, rec, time.Hour, func(context.Context) ([]uuid.UUID, error) {
+		return nil, nil
+	})
+
+	h.SetupQueue()
+	first := TaskCaddyHealthCheck
+	require.NotNil(t, first)
+
+	h.SetupQueue()
+	assert.Same(t, first, TaskCaddyHealthCheck)
+}

--- a/api/internal/features/deploy/caddy/operations.go
+++ b/api/internal/features/deploy/caddy/operations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 
@@ -120,6 +121,9 @@ func PingCaddy(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Logger) erro
 	}
 	return nil
 }
+
+// pingCaddyProbe forwards to PingCaddy; tests may swap it.
+var pingCaddyProbe = PingCaddy
 
 // GetCurrentDomains reads the current Caddy config and returns all configured
 // domain-to-upstream mappings. This is used by the reconciler to diff against
@@ -371,7 +375,7 @@ type jsonBody struct {
 
 func (j *jsonBody) Read(p []byte) (int, error) {
 	if j.pos >= len(j.data) {
-		return 0, fmt.Errorf("EOF")
+		return 0, io.EOF
 	}
 	n := copy(p, j.data[j.pos:])
 	j.pos += n

--- a/api/internal/features/deploy/caddy/operations_test.go
+++ b/api/internal/features/deploy/caddy/operations_test.go
@@ -1,0 +1,173 @@
+package caddy
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatDial(t *testing.T) {
+	assert.Equal(t, "10.0.0.5:8443", FormatDial("10.0.0.5", 8443))
+}
+
+func Test_parseDial(t *testing.T) {
+	host, port, err := parseDial("127.0.0.1:2019")
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", host)
+	assert.Equal(t, 2019, port)
+
+	host, port, err = parseDial("[::1]:443")
+	require.NoError(t, err)
+	assert.Equal(t, "::1", host)
+	assert.Equal(t, 443, port)
+
+	_, _, err = parseDial("nohostport")
+	require.Error(t, err)
+
+	_, _, err = parseDial("h:badport")
+	require.Error(t, err)
+
+	_, _, err = parseDial("h:0")
+	require.Error(t, err)
+
+	_, _, err = parseDial("h:99999")
+	require.Error(t, err)
+}
+
+func Test_resolveLogger(t *testing.T) {
+	l := logger.NewLogger()
+	out := resolveLogger(&l)
+	assert.Equal(t, l, out)
+
+	nilFallback := resolveLogger(nil)
+	assert.NotNil(t, nilFallback)
+}
+
+func Test_jsonBody_Read(t *testing.T) {
+	data := []byte(`{"hello":"world"}`)
+	r := jsonReader(data)
+	buf := make([]byte, 3)
+	n, err := r.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	rest := make([]byte, 64)
+	total := n
+	for {
+		n, err := r.Read(rest)
+		total += n
+		if err != nil {
+			assert.True(t, errors.Is(err, io.EOF))
+			break
+		}
+	}
+	assert.Equal(t, len(data), total)
+
+	buf2 := make([]byte, 16)
+	n2, err2 := jsonReader(nil).Read(buf2)
+	assert.Equal(t, 0, n2)
+	assert.True(t, errors.Is(err2, io.EOF))
+}
+
+func Test_extractDomainFromRoute_missingHost(t *testing.T) {
+	assert.Empty(t, extractDomainFromRoute(caddyhttp.Route{}))
+
+	routeJSON := []byte(`{"match":[{"not_host":["x.example"]}],"handle":[]}`)
+	var r caddyhttp.Route
+	require.NoError(t, json.Unmarshal(routeJSON, &r))
+	assert.Empty(t, extractDomainFromRoute(r))
+}
+
+func Test_extractUpstreamsFromRoute_skipsNonReverseProxy(t *testing.T) {
+	hRaw, err := json.Marshal(map[string]string{"handler": "static_response"})
+	require.NoError(t, err)
+	r := caddyhttp.Route{HandlersRaw: []json.RawMessage{hRaw}}
+	assert.Empty(t, extractUpstreamsFromRoute(r))
+
+	badUpstream, err := json.Marshal(map[string]string{"handler": "reverse_proxy"})
+	require.NoError(t, err)
+	r2 := caddyhttp.Route{HandlersRaw: []json.RawMessage{badUpstream}}
+	assert.Empty(t, extractUpstreamsFromRoute(r2))
+}
+
+func Test_extractDomainRoutes(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		routes, err := extractDomainRoutes(&caddy.Config{})
+		require.NoError(t, err)
+		assert.Nil(t, routes)
+	})
+
+	t.Run("nixopus_server_routes", func(t *testing.T) {
+		cfgJSON := []byte(`{
+			"apps": {
+				"http": {
+					"servers": {
+						"nixopus": {
+							"routes": [
+								{
+									"match": [{"host": ["a.example.com"]}],
+									"handle": [{"handler": "reverse_proxy", "upstreams": [{"dial": "10.1.1.1:8080"}]}]
+								},
+								{
+									"match": [{"host": ["b.example.com"]}],
+									"handle": [{"handler": "reverse_proxy", "upstreams": [{"dial": "10.1.1.2:8080"},{"dial": "10.1.1.3:9080"}]}]
+								},
+								{"match": [], "handle": []}
+							]
+						}
+					}
+				}
+			}
+		}`)
+		var cfg caddy.Config
+		require.NoError(t, json.Unmarshal(cfgJSON, &cfg))
+
+		routes, err := extractDomainRoutes(&cfg)
+		require.NoError(t, err)
+		require.Len(t, routes, 2)
+
+		var founda, foundb bool
+		for _, rt := range routes {
+			switch rt.Domain {
+			case "a.example.com":
+				founda = true
+				assert.Equal(t, "10.1.1.1:8080", rt.UpstreamDial)
+				assert.Nil(t, rt.Upstreams)
+			case "b.example.com":
+				foundb = true
+				assert.Equal(t, []string{"10.1.1.2:8080", "10.1.1.3:9080"}, rt.Upstreams)
+			}
+		}
+		assert.True(t, founda && foundb, "both domains must be extracted")
+	})
+
+	t.Run("invalid_http_app", func(t *testing.T) {
+		cfg := &caddy.Config{
+			AppsRaw: map[string]json.RawMessage{"http": json.RawMessage(`{`)},
+		}
+		_, err := extractDomainRoutes(cfg)
+		require.Error(t, err)
+	})
+}
+
+func Test_AddRemoveDomains_atomic_emptySlices(t *testing.T) {
+	ctx := t.Context()
+	assert.NoError(t, AddDomainsWithRetry(ctx, nil, nil, nil))
+	assert.NoError(t, RemoveDomainsWithRetry(ctx, nil, nil, nil))
+	assert.NoError(t, AddDomainsAtomic(ctx, nil, nil, nil))
+	assert.NoError(t, RemoveDomainsAtomic(ctx, nil, nil, nil))
+}
+
+func Test_extDomainsKey_and_pendingRemovalKey_format(t *testing.T) {
+	id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	assert.Equal(t, "caddy:ext_domains:"+id.String(), extDomainsKey(id))
+	assert.Equal(t, "caddy:pending_removals:"+id.String(), pendingRemovalKey(id))
+}

--- a/api/internal/features/deploy/caddy/reconciler.go
+++ b/api/internal/features/deploy/caddy/reconciler.go
@@ -19,6 +19,18 @@ import (
 	"github.com/vmihailenco/taskq/v3"
 )
 
+var (
+	getSSHManagerFromContextForCaddy = ssh.GetSSHManagerFromContext
+	getDockerServiceFromContext      = docker.GetDockerServiceFromContext
+	getSSHHostForOrgHook             func(ctx context.Context) (string, error)
+	reconcileGetPublishedPortHook    func(r *Reconciler, ctx context.Context, serviceName string) (int, error)
+	enqueueReconcileAfterRecovery    func(orgID uuid.UUID) error
+)
+
+func init() {
+	enqueueReconcileAfterRecovery = EnqueueReconcile
+}
+
 // ReconcileResult tracks what the reconciler did during a single run.
 type ReconcileResult struct {
 	Added   []string
@@ -274,7 +286,11 @@ func upstreamsEqual(a, b []string) bool {
 }
 
 func (r *Reconciler) getPublishedPort(ctx context.Context, serviceName string) (int, error) {
-	dockerService, err := docker.GetDockerServiceFromContext(ctx)
+	if reconcileGetPublishedPortHook != nil {
+		return reconcileGetPublishedPortHook(r, ctx, serviceName)
+	}
+
+	dockerService, err := getDockerServiceFromContext(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get docker service: %w", err)
 	}
@@ -341,7 +357,10 @@ func (r *Reconciler) fullRebuild(ctx context.Context, desired []DomainRoute) (*R
 }
 
 func getSSHHostForOrg(ctx context.Context) (string, error) {
-	manager, err := ssh.GetSSHManagerFromContext(ctx)
+	if getSSHHostForOrgHook != nil {
+		return getSSHHostForOrgHook(ctx)
+	}
+	manager, err := getSSHManagerFromContextForCaddy(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get SSH manager: %w", err)
 	}
@@ -417,20 +436,7 @@ func (d *ReconcilerDaemon) SetupQueues() {
 			Name:       TASK_CADDY_RECONCILE,
 			RetryLimit: 2,
 			Handler: func(ctx context.Context, payload CaddyTaskPayload) error {
-				orgID, err := uuid.Parse(payload.OrganizationID)
-				if err != nil {
-					return fmt.Errorf("invalid org ID in reconcile task: %w", err)
-				}
-				result, err := d.reconciler.ReconcileOrganization(ctx, orgID)
-				if err != nil {
-					return err
-				}
-				if len(result.Errors) > 0 {
-					d.logger.Log(logger.Warning,
-						fmt.Sprintf("reconciliation for org %s had %d errors", orgID, len(result.Errors)),
-						fmt.Sprintf("%v", result.Errors))
-				}
-				return nil
+				return d.handleReconcileTask(ctx, payload)
 			},
 		})
 
@@ -458,6 +464,23 @@ func (d *ReconcilerDaemon) Stop() {
 // Reconciler returns the underlying reconciler for on-demand reconciliation.
 func (d *ReconcilerDaemon) Reconciler() *Reconciler {
 	return d.reconciler
+}
+
+func (d *ReconcilerDaemon) handleReconcileTask(ctx context.Context, payload CaddyTaskPayload) error {
+	orgID, err := uuid.Parse(payload.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("invalid org ID in reconcile task: %w", err)
+	}
+	result, err := d.reconciler.ReconcileOrganization(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	if len(result.Errors) > 0 {
+		d.logger.Log(logger.Warning,
+			fmt.Sprintf("reconciliation for org %s had %d errors", orgID, len(result.Errors)),
+			fmt.Sprintf("%v", result.Errors))
+	}
+	return nil
 }
 
 // EnqueueReconcile adds a single org reconciliation job to the Redis queue.

--- a/api/internal/features/deploy/caddy/reconciler_test.go
+++ b/api/internal/features/deploy/caddy/reconciler_test.go
@@ -1,0 +1,89 @@
+package caddy
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_upstreamsEqual(t *testing.T) {
+	assert.True(t, upstreamsEqual(nil, nil))
+	a := []string{"x:1", "y:2"}
+	b := []string{"x:1", "y:2"}
+	assert.True(t, upstreamsEqual(a, b))
+	copyB := append([]string(nil), b...)
+	assert.True(t, upstreamsEqual(a, copyB))
+
+	assert.False(t, upstreamsEqual([]string{"x:1", "y:2"}, []string{"x:1", "y:2", "z:3"}))
+	assert.False(t, upstreamsEqual([]string{"a", "b"}, []string{"b", "a"}))
+}
+
+func Test_extractPublishedPort(t *testing.T) {
+	name := "websvc"
+	pub := uint32(7443)
+
+	svc := swarm.Service{}
+	svc.Spec.Annotations.Name = name
+	svc.Endpoint.Ports = []swarm.PortConfig{{PublishedPort: pub}}
+
+	got, err := extractPublishedPort(svc)
+	require.NoError(t, err)
+	assert.Equal(t, int(pub), got)
+
+	specOnly := swarm.Service{}
+	specOnly.Spec.Annotations.Name = name
+	specOnly.Spec.EndpointSpec = &swarm.EndpointSpec{
+		Ports: []swarm.PortConfig{{PublishedPort: 9000}},
+	}
+	got2, err := extractPublishedPort(specOnly)
+	require.NoError(t, err)
+	assert.Equal(t, 9000, got2)
+
+	noPort := swarm.Service{}
+	noPort.Spec.Annotations.Name = name
+	_, err = extractPublishedPort(noPort)
+	require.Error(t, err)
+}
+
+func TestEnqueueReconcile_queueNotInitialized(t *testing.T) {
+	origQ, origT := ReconcileQueue, TaskCaddyReconcile
+	ReconcileQueue, TaskCaddyReconcile = nil, nil
+	t.Cleanup(func() {
+		ReconcileQueue, TaskCaddyReconcile = origQ, origT
+	})
+
+	assert.Error(t, EnqueueReconcile(uuid.New()))
+}
+
+func TestReconciler_orgLock_returnsStableMutexPerOrg(t *testing.T) {
+	l := logger.NewLogger()
+	stubRepo := &deployRepoTestStub{}
+	r := NewReconciler(stubRepo, l)
+	a := uuid.New()
+	b := uuid.New()
+
+	muA := r.orgLock(a)
+	muB := r.orgLock(b)
+	assert.Same(t, muA, r.orgLock(a))
+	assert.NotSame(t, muA, muB)
+}
+
+func TestReconciler_fullRebuild_emptyDesired(t *testing.T) {
+	l := logger.NewLogger()
+	stubRepo := &deployRepoTestStub{}
+	r := NewReconciler(stubRepo, l)
+
+	ctx := t.Context()
+	got, err := r.fullRebuild(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, got.Added)
+
+	got2, err := r.fullRebuild(ctx, []DomainRoute{})
+	require.NoError(t, err)
+	assert.Empty(t, got2.Added)
+}

--- a/api/internal/features/deploy/caddy/redis_tracking_test.go
+++ b/api/internal/features/deploy/caddy/redis_tracking_test.go
@@ -1,0 +1,88 @@
+package caddy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestRedis(t *testing.T) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	opt, err := redis.ParseURL("redis://" + mr.Addr())
+	require.NoError(t, err)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() {
+		_ = rdb.Close()
+		mr.Close()
+		queue.Init(nil)
+	})
+
+	queue.Init(rdb)
+}
+
+func TestTrackExtensionDomain_Untrack_GetExtensionDomains(t *testing.T) {
+	setupTestRedis(t)
+	org := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+
+	require.NoError(t, TrackExtensionDomain(org, "ext.example.com", "127.0.0.1:3000"))
+
+	routes, err := GetExtensionDomains(context.Background(), org)
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	assert.Equal(t, "ext.example.com", routes[0].Domain)
+	assert.Equal(t, "127.0.0.1:3000", routes[0].UpstreamDial)
+
+	require.NoError(t, UntrackExtensionDomain(org, "ext.example.com"))
+	routes, err = GetExtensionDomains(context.Background(), org)
+	require.NoError(t, err)
+	assert.Empty(t, routes)
+}
+
+func TestExtensionDomain_redis_uninitialized(t *testing.T) {
+	queue.Init(nil)
+	org := uuid.New()
+
+	assert.Error(t, TrackExtensionDomain(org, "d", "h:1"))
+	assert.Error(t, UntrackExtensionDomain(org, "d"))
+
+	_, err := GetExtensionDomains(context.Background(), org)
+	assert.Error(t, err)
+}
+
+func TestPendingRemoval_roundTrip(t *testing.T) {
+	setupTestRedis(t)
+	org := uuid.MustParse("22222222-3333-4444-5555-666666666666")
+
+	assert.NoError(t, EnqueuePendingRemoval(org))
+	assert.NoError(t, EnqueuePendingRemoval(org, "a.example", "b.example"))
+
+	names, err := GetPendingRemovals(context.Background(), org)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a.example", "b.example"}, names)
+
+	require.NoError(t, ClearPendingRemoval(org, "a.example"))
+	names, err = GetPendingRemovals(context.Background(), org)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"b.example"}, names)
+}
+
+func TestPendingRemoval_redis_uninitialized_and_emptyAdds(t *testing.T) {
+	queue.Init(nil)
+	org := uuid.New()
+
+	assert.Error(t, EnqueuePendingRemoval(org, "x"))
+	assert.Error(t, ClearPendingRemoval(org, "x"))
+	_, err := GetPendingRemovals(context.Background(), org)
+	assert.Error(t, err)
+
+	setupTestRedis(t)
+	assert.NoError(t, EnqueuePendingRemoval(org))
+	assert.NoError(t, ClearPendingRemoval(org))
+}

--- a/api/internal/features/deploy/caddy/retry_cache_test.go
+++ b/api/internal/features/deploy/caddy/retry_cache_test.go
@@ -1,0 +1,121 @@
+package caddy
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRetry_successFirstAttempt(t *testing.T) {
+	var calls int
+	l := logger.NewLogger()
+	err := WithRetry(func() error {
+		calls++
+		return nil
+	}, 3, l, func() {})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestWithRetry_invokesOnFailureThenSucceeds(t *testing.T) {
+	var failures, onFails int
+	l := logger.NewLogger()
+	err := WithRetry(func() error {
+		failures++
+		if failures == 1 {
+			return errors.New("transient")
+		}
+		return nil
+	}, 3, l, func() { onFails++ })
+	require.NoError(t, err)
+	require.Equal(t, 2, failures)
+	require.Equal(t, 1, onFails)
+}
+
+func TestWithRetry_exhaustsAttempts(t *testing.T) {
+	var onFails int
+	l := logger.NewLogger()
+	permanentErr := errors.New("perm")
+	err := WithRetry(func() error { return permanentErr }, 2, l, func() { onFails++ })
+	require.ErrorIs(t, err, permanentErr)
+	require.Equal(t, 1, onFails)
+}
+
+func TestInvalidateTunnelByKey_removesCacheEntryAndClosesListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	tunnel := &CaddyTunnel{
+		listener: ln,
+		cleanup: func() error {
+			return ln.Close()
+		},
+	}
+	key := "unit-test-host.invalid:2019"
+	caddyTunnelCacheMu.Lock()
+	caddyTunnelCache[key] = &caddyTunnelEntry{
+		tunnel:   tunnel,
+		client:   nil,
+		lastUsed: time.Now(),
+	}
+	caddyTunnelCacheMu.Unlock()
+
+	t.Cleanup(func() {
+		caddyTunnelCacheMu.Lock()
+		delete(caddyTunnelCache, key)
+		caddyTunnelCacheMu.Unlock()
+	})
+
+	InvalidateTunnelByKey(key)
+
+	caddyTunnelCacheMu.RLock()
+	_, exists := caddyTunnelCache[key]
+	caddyTunnelCacheMu.RUnlock()
+	require.False(t, exists)
+
+	conn, err := net.DialTimeout("tcp", ln.Addr().String(), 50*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("listener should have been closed")
+	}
+}
+
+func Test_evictIdleTunnels_removesStaleEntry(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	key := "idle-evict.invalid:2019"
+	caddyTunnelCacheMu.Lock()
+	caddyTunnelCache[key] = &caddyTunnelEntry{
+		tunnel: &CaddyTunnel{
+			listener: ln,
+			cleanup: func() error {
+				return ln.Close()
+			},
+		},
+		lastUsed: time.Now().Add(-tunnelIdleTTL - time.Minute),
+	}
+	caddyTunnelCacheMu.Unlock()
+
+	t.Cleanup(func() {
+		caddyTunnelCacheMu.Lock()
+		if e, ok := caddyTunnelCache[key]; ok {
+			if e.tunnel != nil {
+				_ = e.tunnel.Close()
+			}
+			delete(caddyTunnelCache, key)
+		}
+		caddyTunnelCacheMu.Unlock()
+	})
+
+	evictIdleTunnels()
+
+	caddyTunnelCacheMu.RLock()
+	_, exists := caddyTunnelCache[key]
+	caddyTunnelCacheMu.RUnlock()
+	require.False(t, exists)
+}

--- a/api/internal/features/deploy/caddy/route_builder_test.go
+++ b/api/internal/features/deploy/caddy/route_builder_test.go
@@ -1,0 +1,180 @@
+package caddy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string { return &s }
+
+func Test_mapRoutingStrategy(t *testing.T) {
+	assert.Equal(t, "round_robin", mapRoutingStrategy(shared_types.RoutingStrategyRoundRobin))
+	assert.Equal(t, "first", mapRoutingStrategy(shared_types.RoutingStrategyPrimaryFailover))
+	assert.Equal(t, "", mapRoutingStrategy(shared_types.RoutingStrategySingle))
+	assert.Equal(t, "", mapRoutingStrategy(shared_types.RoutingStrategyPerServerDomain))
+}
+
+func Test_orderPrimaryFirst(t *testing.T) {
+	u := []string{"a", "b", "c"}
+	assert.Equal(t, []string{"a", "b", "c"}, orderPrimaryFirst(u, 0))
+	assert.Equal(t, []string{"a", "b", "c"}, orderPrimaryFirst(u, -1))
+	assert.Equal(t, []string{"a", "b", "c"}, orderPrimaryFirst(u, 3))
+
+	assert.Equal(t, []string{"b", "a", "c"}, orderPrimaryFirst([]string{"a", "b", "c"}, 1))
+}
+
+func Test_buildSingleUpstreamRoutes(t *testing.T) {
+	up := []shared_types.ApplicationDomain{{Domain: "x.example"}, {Domain: ""}}
+	routes := buildSingleUpstreamRoutes(up, "proxy.internal", 9000, shared_types.DockerFile)
+	require.Len(t, routes, 1)
+	assert.Equal(t, "proxy.internal:9000", routes[0].UpstreamDial)
+
+	p90 := 90
+	svcPort := shared_types.ComposeService{Port: 4000}
+	domCompose := []shared_types.ApplicationDomain{
+		{Domain: "c.example", ComposeService: &svcPort},
+		{Domain: "orphan.compose", ComposeService: nil},
+		{
+			Domain:         "override.example",
+			ComposeService: nil,
+			Port:           &p90,
+		},
+	}
+	rc := buildSingleUpstreamRoutes(domCompose, "ignore", 0, shared_types.DockerCompose)
+	require.Len(t, rc, 2)
+	for _, rr := range rc {
+		if rr.Domain == "c.example" {
+			assert.Equal(t, "ignore:4000", rr.UpstreamDial)
+		}
+		if rr.Domain == "override.example" {
+			assert.Equal(t, "ignore:90", rr.UpstreamDial)
+		}
+	}
+}
+
+func Test_resolveServerHosts_defaultVsMultiProxy(t *testing.T) {
+	l := logger.NewLogger()
+	h1 := "internal-1.proxy"
+	h2 := "internal-2.proxy"
+	pub := "pub.example.net"
+
+	def := shared_types.ApplicationServer{
+		IsPrimary: true,
+		Server: &shared_types.SSHKey{
+			Host:      strPtr("raw-a"),
+			ProxyHost: strPtr(pub),
+			IsDefault: true,
+		},
+	}
+
+	servers := []shared_types.ApplicationServer{
+		def,
+		{
+			Server: &shared_types.SSHKey{
+				Host:      strPtr(h1),
+				IsDefault: false,
+			},
+		},
+		{
+			IsPrimary: false,
+			Server: &shared_types.SSHKey{
+				Host:      strPtr(h2),
+				IsDefault: false,
+			},
+		},
+	}
+
+	hosts, primaryIdx := resolveServerHosts([]shared_types.ApplicationServer{{Server: nil}}, &l)
+	assert.Empty(t, hosts)
+	assert.Equal(t, -1, primaryIdx)
+
+	hosts, primaryIdx = resolveServerHosts(servers, &l)
+	assert.Equal(t, 0, primaryIdx)
+	require.Len(t, hosts, 3)
+	assert.Equal(t, pub, hosts[0])
+	assert.Equal(t, h1, hosts[1])
+	assert.Equal(t, h2, hosts[2])
+
+	multiHosts, _ := resolveServerHosts(servers[1:], &l)
+	require.Len(t, multiHosts, 2)
+	assert.Equal(t, h1, multiHosts[0])
+	assert.Equal(t, h2, multiHosts[1])
+}
+
+func TestBuildMultiUpstreamRoutes_singleServer_fallback(t *testing.T) {
+	l := logger.NewLogger()
+	app := shared_types.Application{
+		ID: uuid.New(),
+	}
+	stub := &deployRepoTestStub{servers: []shared_types.ApplicationServer{{}}}
+	doms := []shared_types.ApplicationDomain{{Domain: "app.example"}}
+
+	got := BuildMultiUpstreamRoutes(context.Background(), stub, &l, app, doms, "10.10.10.10", 7000)
+	require.Len(t, got, 1)
+	assert.Equal(t, "app.example", got[0].Domain)
+	assert.Equal(t, "10.10.10.10:7000", got[0].UpstreamDial)
+	assert.Empty(t, got[0].Upstreams)
+}
+
+func TestBuildMultiUpstreamRoutes_GetApplicationServersErr_falls_back(t *testing.T) {
+	l := logger.NewLogger()
+	app := shared_types.Application{ID: uuid.New()}
+	stub := &deployRepoTestStub{err: assert.AnError}
+	doms := []shared_types.ApplicationDomain{{Domain: "e.example"}}
+
+	got := BuildMultiUpstreamRoutes(context.Background(), stub, &l, app, doms, "fallback.host", 5000)
+	require.Len(t, got, 1)
+	assert.Equal(t, "fallback.host:5000", got[0].UpstreamDial)
+}
+
+func TestBuildMultiUpstreamRoutes_multi_upstream_roundRobin(t *testing.T) {
+	l := logger.NewLogger()
+	app := shared_types.Application{
+		ID:              uuid.New(),
+		RoutingStrategy: shared_types.RoutingStrategyRoundRobin,
+		BuildPack:       shared_types.DockerFile,
+	}
+	hA, hB := "10.0.0.1", "10.0.0.2"
+	stub := &deployRepoTestStub{
+		servers: []shared_types.ApplicationServer{
+			{IsPrimary: true, Server: &shared_types.SSHKey{Host: strPtr(hA), IsDefault: false}},
+			{Server: &shared_types.SSHKey{Host: strPtr(hB), IsDefault: false}},
+		},
+	}
+	doms := []shared_types.ApplicationDomain{{Domain: "lb.example"}}
+
+	got := BuildMultiUpstreamRoutes(context.Background(), stub, &l, app, doms, "unused", 3000)
+	require.Len(t, got, 1)
+	assert.Equal(t, "lb.example", got[0].Domain)
+	assert.Equal(t, "round_robin", got[0].LBPolicy)
+	require.Len(t, got[0].Upstreams, 2)
+	for _, dial := range got[0].Upstreams {
+		assert.True(t, strings.HasSuffix(dial, ":3000"))
+	}
+}
+
+func TestBuildMultiUpstreamRoutes_multi_hostsEmpty_fallsBackToSingleUpstream(t *testing.T) {
+	l := logger.NewLogger()
+	app := shared_types.Application{
+		ID:              uuid.New(),
+		RoutingStrategy: shared_types.RoutingStrategyRoundRobin,
+	}
+	stub := &deployRepoTestStub{
+		servers: []shared_types.ApplicationServer{
+			{Server: &shared_types.SSHKey{}},
+			{Server: nil},
+			{},
+		},
+	}
+	got := BuildMultiUpstreamRoutes(context.Background(), stub, &l, app, []shared_types.ApplicationDomain{{Domain: "skip.me"}}, "host", 1)
+	require.Len(t, got, 1)
+	assert.Equal(t, "skip.me", got[0].Domain)
+	assert.Equal(t, "host:1", got[0].UpstreamDial)
+}

--- a/api/internal/features/deploy/caddy/tunnel.go
+++ b/api/internal/features/deploy/caddy/tunnel.go
@@ -84,7 +84,13 @@ func (t *CaddyTunnel) getOrCreateSSH() (*goph.Client, error) {
 		return t.persistSSH, nil
 	}
 
-	client, err := t.sshClient.Connect()
+	var client *goph.Client
+	var err error
+	if tunnelDialSSHHook != nil {
+		client, err = tunnelDialSSHHook(t.sshClient)
+	} else {
+		client, err = t.sshClient.Connect()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +235,22 @@ func evictIdleTunnels() {
 
 const defaultCaddyPort = "2019"
 
+var (
+	// testGetCaddyClientHook, when set by package tests, bypasses SSH tunnel creation.
+	testGetCaddyClientHook func(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Logger) (*caddygo.Client, error)
+	// tunnelCreateHook overrides CreateCaddyTunnel (tests can return a tunnel with a local admin URL).
+	tunnelCreateHook func(sshClient *ssh.SSH, remotePort string, orgID uuid.UUID, lgr logger.Logger) (*CaddyTunnel, error)
+	// tunnelDialSSHHook overrides ssh Connect when forwarding through a CaddyTunnel.
+	tunnelDialSSHHook func(sshClient *ssh.SSH) (*goph.Client, error)
+)
+
+func createCaddyTunnelForClient(sshClient *ssh.SSH, remotePort string, orgID uuid.UUID, lgr logger.Logger) (*CaddyTunnel, error) {
+	if tunnelCreateHook != nil {
+		return tunnelCreateHook(sshClient, remotePort, orgID, lgr)
+	}
+	return CreateCaddyTunnel(sshClient, remotePort, orgID, lgr)
+}
+
 func getCaddyPort() (string, error) {
 	port := config.AppConfig.Proxy.CaddyPort
 	if port == "" {
@@ -265,6 +287,10 @@ func orgIDFromContext(ctx context.Context) uuid.UUID {
 // the Caddy admin API on the given host. Uses existing SSH config (ctx org or sshClient).
 // Caches tunnel per host+port for reuse.
 func GetCaddyClient(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Logger) (*caddygo.Client, error) {
+	if testGetCaddyClientHook != nil {
+		return testGetCaddyClientHook(ctx, sshClient, lgr)
+	}
+
 	remotePort, err := getCaddyPort()
 	if err != nil {
 		return nil, err
@@ -312,7 +338,7 @@ func GetCaddyClient(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Logger)
 		def := logger.NewLogger()
 		lgr = &def
 	}
-	tunnel, err := CreateCaddyTunnel(s, remotePort, orgID, *lgr)
+	tunnel, err := createCaddyTunnelForClient(s, remotePort, orgID, *lgr)
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/features/deploy/caddy/tunnel_context_test.go
+++ b/api/internal/features/deploy/caddy/tunnel_context_test.go
@@ -1,0 +1,50 @@
+package caddy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/config"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_orgIDFromContext(t *testing.T) {
+	org := uuid.MustParse("33333333-4444-5555-6666-777777777777")
+
+	assert.Equal(t, uuid.Nil, orgIDFromContext(context.Background()))
+
+	s := org.String()
+	ctx := context.WithValue(context.Background(), shared_types.OrganizationIDKey, s)
+	assert.Equal(t, org, orgIDFromContext(ctx))
+
+	ctx = context.WithValue(context.Background(), shared_types.OrganizationIDKey, org)
+	assert.Equal(t, org, orgIDFromContext(ctx))
+
+	ctx = context.WithValue(context.Background(), shared_types.OrganizationIDKey, "not-a-uuid")
+	assert.Equal(t, uuid.Nil, orgIDFromContext(ctx))
+
+	ctx = context.WithValue(context.Background(), shared_types.OrganizationIDKey, 42)
+	assert.Equal(t, uuid.Nil, orgIDFromContext(ctx))
+}
+
+func Test_getCaddyPort_defaultsAndValidation(t *testing.T) {
+	orig := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = orig })
+
+	config.AppConfig.Proxy.CaddyPort = ""
+	port, err := getCaddyPort()
+	require.NoError(t, err)
+	assert.Equal(t, defaultCaddyPort, port)
+
+	config.AppConfig.Proxy.CaddyPort = "9555"
+	port, err = getCaddyPort()
+	require.NoError(t, err)
+	assert.Equal(t, "9555", port)
+
+	config.AppConfig.Proxy.CaddyPort = "not-int"
+	_, err = getCaddyPort()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for the deploy Caddy package (operations, tunnel, reconciler hooks, redis tracking, route builder, retry/cache, health monitor).
- Introduces test seams (`testGetCaddyClientHook`, `tunnelCreateHook`, `tunnelDialSSHHook`, SSH/docker/reconcile hooks) so the admin API can be exercised via `httptest` without live SSH.
- Fixes `jsonBody.Read` to return `io.EOF` so HTTP client request bodies complete correctly (e.g. `RestoreCaddyConfig`).

## Test plan
- [x] `go test ./api/internal/features/deploy/caddy/...`