### PR TITLE
feat: structured logging across API stack

### DIFF
--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/joho/godotenv"
 	extservice "github.com/nixopus/nixopus/api/internal/features/extension/service"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/secrets"
 	"github.com/nixopus/nixopus/api/internal/storage"
 	"github.com/nixopus/nixopus/api/internal/types"
@@ -116,7 +117,8 @@ func Init() *storage.Store {
 	}
 
 	storageInstance := storage.NewStore(store)
-	storageInstance.ExtensionLoader = extservice.NewTemplateLoader(storageInstance.DB)
+	extLoaderLog := logger.NewLogger()
+	storageInstance.ExtensionLoader = extservice.NewTemplateLoader(storageInstance.DB, &extLoaderLog)
 
 	err = initStoreInit(storageInstance, context.Background())
 

--- a/api/internal/features/auth/controller/bootstrap.go
+++ b/api/internal/features/auth/controller/bootstrap.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -17,18 +18,39 @@ func (ac *AuthController) HandleBootstrap(c fuego.ContextNoBody) (*auth_types.Bo
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		ac.logger.Log(logger.Error, "bootstrap: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
+	userCtx := fmt.Sprintf("user_id=%s", user.ID)
+	ac.logger.Log(logger.Info, "bootstrap: start", userCtx)
+
 	sessionResp, err := auth.VerifySession(r)
 	if err != nil {
-		ac.logger.Log(logger.Error, "bootstrap: verify session failed", err.Error())
+		ac.logger.Log(logger.Error, fmt.Sprintf("bootstrap: verify session failed: %v", err), userCtx)
 		return nil, fuego.UnauthorizedError{Detail: err.Error(), Err: err}
 	}
 
+	activeOrgID := "none"
+	if p := sessionResp.Session.ActiveOrganizationID; p != nil && *p != "" {
+		activeOrgID = *p
+	}
+	ctxStr := fmt.Sprintf("%s active_org_id=%s", userCtx, activeOrgID)
+	ac.logger.Log(logger.Info, "bootstrap: session verified", ctxStr)
+
 	resp, err := ac.service.BuildBootstrap(ctx, user, sessionResp.Session.ActiveOrganizationID)
 	if err != nil {
+		ac.logger.Log(logger.Error, fmt.Sprintf("bootstrap: build failed: %v", err), ctxStr)
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
+
+	ac.logger.Log(logger.Info, "bootstrap: success", fmt.Sprintf(
+		"%s org_count=%d has_servers=%v is_onboarded=%v provision_status=%q",
+		ctxStr,
+		len(resp.Organizations),
+		resp.HasServers,
+		resp.User.IsOnboarded,
+		resp.User.ProvisionStatus,
+	))
 	return resp, nil
 }

--- a/api/internal/features/auth/controller/is_admin_registered.go
+++ b/api/internal/features/auth/controller/is_admin_registered.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,17 +16,19 @@ import (
 //
 // On cache errors the handler falls through to the database transparently.
 func (ar *AuthController) IsAdminRegistered(s fuego.ContextNoBody) (*auth_types.AdminRegisteredResponse, error) {
-	ar.logger.Log(logger.Info, "checking if admin is registered", "")
+	ar.logger.Log(logger.Debug, "auth: IsAdminRegistered start", "")
 
 	registered, err := ar.service.GetAdminRegistered(ar.ctx)
 	if err != nil {
-		ar.logger.Log(logger.Error, "failed to check admin registration", err.Error())
+		ar.logger.Log(logger.Error, fmt.Sprintf("auth: IsAdminRegistered failed: %v", err), "")
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
 			Status: http.StatusInternalServerError,
 		}
 	}
+
+	ar.logger.Log(logger.Info, "auth: IsAdminRegistered ok", fmt.Sprintf("admin_registered=%v", registered))
 
 	return &auth_types.AdminRegisteredResponse{
 		Status:  "success",

--- a/api/internal/features/auth/service/init.go
+++ b/api/internal/features/auth/service/init.go
@@ -32,7 +32,7 @@ func NewAuthService(
 	if redisURL != "" {
 		c, err := cache.NewCache(redisURL)
 		if err != nil {
-			l.Log(logger.Error, "failed to create auth cache, proceeding without cache", err.Error())
+			l.Log(logger.Error, fmt.Sprintf("auth service: failed to create cache: %v", err), "falling back without redis cache")
 		} else {
 			authCache = c
 		}
@@ -48,20 +48,35 @@ func NewAuthService(
 }
 
 func (s *AuthService) GetUserByEmail(email string) (*shared_types.User, error) {
-	return s.storage.FindUserByEmail(email)
+	s.logger.Log(logger.Debug, "auth service: GetUserByEmail", fmt.Sprintf("email=%q", email))
+	u, err := s.storage.FindUserByEmail(email)
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("auth service: GetUserByEmail: %v", err), fmt.Sprintf("email=%q", email))
+		return nil, err
+	}
+	s.logger.Log(logger.Debug, "auth service: GetUserByEmail ok", fmt.Sprintf("email=%q user_id=%s", email, u.ID))
+	return u, nil
 }
 
 func (s *AuthService) userStorage(ctx context.Context) (*storage.UserStorage, error) {
 	if s.db == nil {
 		return nil, fmt.Errorf("auth service: database not configured")
 	}
-	return &storage.UserStorage{DB: s.db, Ctx: ctx}, nil
+	return &storage.UserStorage{DB: s.db, Ctx: ctx, Logger: &s.logger}, nil
 }
 
 // BuildBootstrap assembles bootstrap session payload (orgs, active org, servers, provisioning).
 func (s *AuthService) BuildBootstrap(ctx context.Context, user *shared_types.User, sessionActiveOrgID *string) (*auth_types.BootstrapResponse, error) {
+	activeOrgStr := "none"
+	if sessionActiveOrgID != nil && *sessionActiveOrgID != "" {
+		activeOrgStr = *sessionActiveOrgID
+	}
+	ctxStr := fmt.Sprintf("user_id=%s session_active_org_id=%s", user.ID, activeOrgStr)
+	s.logger.Log(logger.Info, "auth service: BuildBootstrap start", ctxStr)
+
 	st, err := s.userStorage(ctx)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("auth service: BuildBootstrap userStorage: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -72,7 +87,7 @@ func (s *AuthService) BuildBootstrap(ctx context.Context, user *shared_types.Use
 
 	orgRows, err := st.ListBootstrapOrganizations(ctx, user.ID)
 	if err != nil {
-		s.logger.Log(logger.Error, "bootstrap: failed to query members", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("auth service: BuildBootstrap list organizations: %v", err), ctxStr)
 		orgRows = nil
 	}
 
@@ -102,9 +117,13 @@ func (s *AuthService) BuildBootstrap(ctx context.Context, user *shared_types.Use
 	if activeOrgID != "" {
 		if orgUUID, perr := uuid.Parse(activeOrgID); perr == nil {
 			exists, errExists := st.OrgHasSSHKeys(ctx, orgUUID)
-			if errExists == nil && exists {
+			if errExists != nil {
+				s.logger.Log(logger.Debug, fmt.Sprintf("auth service: BuildBootstrap OrgHasSSHKeys: %v", errExists), ctxStr)
+			} else if exists {
 				hasServers = true
 			}
+		} else {
+			s.logger.Log(logger.Debug, fmt.Sprintf("auth service: BuildBootstrap skip OrgHasSSHKeys invalid org uuid: %v", perr), ctxStr)
 		}
 	}
 
@@ -113,7 +132,7 @@ func (s *AuthService) BuildBootstrap(ctx context.Context, user *shared_types.Use
 	if provisionStatus == "provisioning" {
 		upd, errUpd := st.GetLatestUserProvisionDetails(ctx, user.ID)
 		if errUpd != nil {
-			s.logger.Log(logger.Error, "bootstrap: failed to query user_provision_details", errUpd.Error())
+			s.logger.Log(logger.Error, fmt.Sprintf("auth service: BuildBootstrap provision details: %v", errUpd), ctxStr)
 			return nil, errUpd
 		}
 		id := upd.ID.String()
@@ -123,6 +142,19 @@ func (s *AuthService) BuildBootstrap(ctx context.Context, user *shared_types.Use
 			provisionStep = &step
 		}
 	}
+
+	effectiveOrg := activeOrgID
+	if effectiveOrg == "" {
+		effectiveOrg = "none"
+	}
+	s.logger.Log(logger.Info, "auth service: BuildBootstrap ok", fmt.Sprintf(
+		"%s org_count=%d effective_active_org_id=%s has_servers=%v provision_status=%q",
+		ctxStr,
+		len(orgs),
+		effectiveOrg,
+		hasServers,
+		provisionStatus,
+	))
 
 	return &auth_types.BootstrapResponse{
 		User: auth_types.BootstrapUser{
@@ -142,23 +174,28 @@ func (s *AuthService) BuildBootstrap(ctx context.Context, user *shared_types.Use
 
 // GetAdminRegistered returns whether a password credential account exists (cache-aside).
 func (s *AuthService) GetAdminRegistered(ctx context.Context) (bool, error) {
+	s.logger.Log(logger.Debug, "auth service: GetAdminRegistered start", "")
+
 	if s.Cache != nil {
 		registered, hit, err := s.Cache.GetAdminRegistered(ctx)
 		if err != nil {
-			s.logger.Log(logger.Error, "cache read failed, falling through to db", err.Error())
+			s.logger.Log(logger.Error, fmt.Sprintf("auth service: GetAdminRegistered cache read: %v", err), "")
 		}
 		if hit && err == nil {
+			s.logger.Log(logger.Info, "auth service: GetAdminRegistered ok", fmt.Sprintf("registered=%v source=cache", registered))
 			return registered, nil
 		}
 	}
 
 	st, err := s.userStorage(ctx)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("auth service: GetAdminRegistered userStorage: %v", err), "")
 		return false, err
 	}
 
 	count, err := st.CountAccountsWithPassword(ctx)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("auth service: GetAdminRegistered count passwords: %v", err), "")
 		return false, err
 	}
 
@@ -166,9 +203,11 @@ func (s *AuthService) GetAdminRegistered(ctx context.Context) (bool, error) {
 
 	if s.Cache != nil {
 		if cacheErr := s.Cache.SetAdminRegistered(ctx, adminRegistered); cacheErr != nil {
-			s.logger.Log(logger.Error, "failed to cache admin registration status", cacheErr.Error())
+			s.logger.Log(logger.Error, fmt.Sprintf("auth service: GetAdminRegistered cache set: %v", cacheErr), fmt.Sprintf("registered=%v", adminRegistered))
 		}
 	}
+
+	s.logger.Log(logger.Info, "auth service: GetAdminRegistered ok", fmt.Sprintf("registered=%v source=db", adminRegistered))
 
 	return adminRegistered, nil
 }

--- a/api/internal/features/auth/storage/storage.go
+++ b/api/internal/features/auth/storage/storage.go
@@ -2,17 +2,29 @@ package storage
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type UserStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
-	tx  *bun.Tx
+	DB     *bun.DB
+	Ctx    context.Context
+	tx     *bun.Tx
+	Logger *logger.Logger // optional; nil disables storage logs
+}
+
+func (u *UserStorage) storageLog(sev logger.Severity, msg, data string) {
+	if u.Logger == nil {
+		return
+	}
+	u.Logger.Log(sev, msg, data)
 }
 
 type AuthRepository interface {
@@ -23,9 +35,10 @@ type AuthRepository interface {
 
 func (u *UserStorage) WithTx(tx bun.Tx) AuthRepository {
 	return &UserStorage{
-		DB:  u.DB,
-		Ctx: u.Ctx,
-		tx:  &tx,
+		DB:     u.DB,
+		Ctx:    u.Ctx,
+		tx:     &tx,
+		Logger: u.Logger,
 	}
 }
 
@@ -41,6 +54,8 @@ func (u *UserStorage) getDB() bun.IDB {
 }
 
 func (u *UserStorage) FindUserByEmail(email string) (*types.User, error) {
+	u.storageLog(logger.Debug, "storage: FindUserByEmail", fmt.Sprintf("email=%q", email))
+
 	user := &types.User{}
 	err := u.getDB().NewSelect().
 		Model(user).
@@ -48,6 +63,11 @@ func (u *UserStorage) FindUserByEmail(email string) (*types.User, error) {
 		Relation("Organizations").
 		Scan(u.Ctx)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			u.storageLog(logger.Debug, "storage: FindUserByEmail not found", fmt.Sprintf("email=%q", email))
+		} else {
+			u.storageLog(logger.Error, fmt.Sprintf("storage: FindUserByEmail user scan: %v", err), fmt.Sprintf("email=%q", email))
+		}
 		return nil, err
 	}
 
@@ -57,11 +77,13 @@ func (u *UserStorage) FindUserByEmail(email string) (*types.User, error) {
 		Relation("Organization").
 		Scan(u.Ctx)
 	if err != nil {
+		u.storageLog(logger.Error, fmt.Sprintf("storage: FindUserByEmail org users scan: %v", err), fmt.Sprintf("email=%q user_id=%s", email, user.ID))
 		return nil, err
 	}
 
 	user.ComputeCompatibilityFields()
 
+	u.storageLog(logger.Debug, "storage: FindUserByEmail ok", fmt.Sprintf("email=%q user_id=%s", email, user.ID))
 	return user, nil
 }
 
@@ -79,10 +101,17 @@ type Account struct {
 
 // CountAccountsWithPassword returns how many rows have a password set (email/password signups).
 func (u *UserStorage) CountAccountsWithPassword(ctx context.Context) (int, error) {
-	return u.getDB().NewSelect().
+	u.storageLog(logger.Debug, "storage: CountAccountsWithPassword", "")
+	n, err := u.getDB().NewSelect().
 		Model((*Account)(nil)).
 		Where("password IS NOT NULL").
 		Count(ctx)
+	if err != nil {
+		u.storageLog(logger.Error, fmt.Sprintf("storage: CountAccountsWithPassword: %v", err), "")
+		return 0, err
+	}
+	u.storageLog(logger.Debug, "storage: CountAccountsWithPassword ok", fmt.Sprintf("count=%d", n))
+	return n, nil
 }
 
 // BootstrapOrgRow is one organization membership for bootstrap (member + organization).
@@ -94,6 +123,9 @@ type BootstrapOrgRow struct {
 
 // ListBootstrapOrganizations returns the user's orgs via member, ordered by membership created_at.
 func (u *UserStorage) ListBootstrapOrganizations(ctx context.Context, userID uuid.UUID) ([]BootstrapOrgRow, error) {
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
+	u.storageLog(logger.Debug, "storage: ListBootstrapOrganizations", ctxStr)
+
 	var members []types.Member
 	err := u.getDB().NewSelect().
 		Model(&members).
@@ -101,6 +133,7 @@ func (u *UserStorage) ListBootstrapOrganizations(ctx context.Context, userID uui
 		Order("created_at ASC").
 		Scan(ctx)
 	if err != nil {
+		u.storageLog(logger.Error, fmt.Sprintf("storage: ListBootstrapOrganizations members: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -109,6 +142,7 @@ func (u *UserStorage) ListBootstrapOrganizations(ctx context.Context, userID uui
 		var org types.Organization
 		errOrg := u.getDB().NewSelect().Model(&org).Where("id = ?", m.OrganizationID).Scan(ctx)
 		if errOrg != nil {
+			u.storageLog(logger.Debug, fmt.Sprintf("storage: ListBootstrapOrganizations skip org: %v", errOrg), fmt.Sprintf("%s org_id=%s", ctxStr, m.OrganizationID))
 			continue
 		}
 		out = append(out, BootstrapOrgRow{
@@ -117,22 +151,35 @@ func (u *UserStorage) ListBootstrapOrganizations(ctx context.Context, userID uui
 			Role: m.Role,
 		})
 	}
+	u.storageLog(logger.Debug, "storage: ListBootstrapOrganizations ok", fmt.Sprintf("%s count=%d", ctxStr, len(out)))
 	return out, nil
 }
 
 // OrgHasSSHKeys reports whether the organization has at least one non-deleted ssh_keys row.
 func (u *UserStorage) OrgHasSSHKeys(ctx context.Context, organizationID uuid.UUID) (bool, error) {
-	return u.getDB().NewSelect().
+	ctxStr := fmt.Sprintf("org_id=%s", organizationID)
+	u.storageLog(logger.Debug, "storage: OrgHasSSHKeys", ctxStr)
+
+	exists, err := u.getDB().NewSelect().
 		Table("ssh_keys").
 		ColumnExpr("1").
 		Where("organization_id = ?", organizationID).
 		Where("deleted_at IS NULL").
 		Limit(1).
 		Exists(ctx)
+	if err != nil {
+		u.storageLog(logger.Error, fmt.Sprintf("storage: OrgHasSSHKeys: %v", err), ctxStr)
+		return false, err
+	}
+	u.storageLog(logger.Debug, "storage: OrgHasSSHKeys ok", fmt.Sprintf("%s exists=%v", ctxStr, exists))
+	return exists, nil
 }
 
 // GetLatestUserProvisionDetails returns the most recent user provision row for the user.
 func (u *UserStorage) GetLatestUserProvisionDetails(ctx context.Context, userID uuid.UUID) (*types.UserProvisionDetails, error) {
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
+	u.storageLog(logger.Debug, "storage: GetLatestUserProvisionDetails", ctxStr)
+
 	var upd types.UserProvisionDetails
 	err := u.getDB().NewSelect().
 		Model(&upd).
@@ -141,7 +188,13 @@ func (u *UserStorage) GetLatestUserProvisionDetails(ctx context.Context, userID 
 		Limit(1).
 		Scan(ctx)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			u.storageLog(logger.Debug, "storage: GetLatestUserProvisionDetails not found", ctxStr)
+		} else {
+			u.storageLog(logger.Error, fmt.Sprintf("storage: GetLatestUserProvisionDetails: %v", err), ctxStr)
+		}
 		return nil, err
 	}
+	u.storageLog(logger.Debug, "storage: GetLatestUserProvisionDetails ok", fmt.Sprintf("%s provision_id=%s", ctxStr, upd.ID))
 	return &upd, nil
 }

--- a/api/internal/features/auth/verify.go
+++ b/api/internal/features/auth/verify.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/nixopus/nixopus/api/internal/config"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 var (
@@ -19,7 +19,20 @@ var (
 	// Overridable in tests: net/http never exposes cookies without a Cookie header, but
 	// callers may still want the AddCookie path when using custom request shims.
 	forwardCookiesList = func(r *http.Request) []*http.Cookie { return r.Cookies() }
+
+	// VerifySessionLogger, when set (e.g. from routes.NewRouter), is used for VerifySession logs.
+	// If nil, logging falls back to a default Development logger.NewLogger().
+	VerifySessionLogger *logger.Logger
 )
+
+func verifySessionLog(sev logger.Severity, msg, data string) {
+	if VerifySessionLogger != nil {
+		VerifySessionLogger.Log(sev, msg, data)
+		return
+	}
+	l := logger.NewLogger()
+	l.Log(sev, msg, data)
+}
 
 // HTTPClient is a shared HTTP client for Better Auth API calls.
 // Uses connection pooling and timeouts to reduce latency from repeated connection setup.
@@ -76,7 +89,7 @@ func forwardCookies(originalReq *http.Request, targetReq *http.Request) {
 	cookieHeader := originalReq.Header.Get("Cookie")
 	if cookieHeader != "" {
 		targetReq.Header.Set("Cookie", cookieHeader)
-		log.Printf("DEBUG VerifySession: Forwarding Cookie header (length: %d)", len(cookieHeader))
+		verifySessionLog(logger.Debug, "auth: VerifySession forward Cookie header", fmt.Sprintf("length=%d", len(cookieHeader)))
 		return
 	}
 
@@ -85,9 +98,9 @@ func forwardCookies(originalReq *http.Request, targetReq *http.Request) {
 		for _, cookie := range cookies {
 			targetReq.AddCookie(cookie)
 		}
-		log.Printf("DEBUG VerifySession: Forwarding %d cookies individually", len(cookies))
+		verifySessionLog(logger.Debug, "auth: VerifySession forward cookies individually", fmt.Sprintf("count=%d", len(cookies)))
 	} else {
-		log.Printf("WARN VerifySession: No cookies found in request - session validation will likely fail")
+		verifySessionLog(logger.Warning, "auth: VerifySession no cookies on request", "session validation may fail")
 	}
 }
 
@@ -166,24 +179,27 @@ func parseSessionResponse(body []byte, statusCode int, url string, req *http.Req
 			}
 			cookieInfo = fmt.Sprintf("%d cookies: %v", len(cookieNames), cookieNames)
 		}
-		log.Printf("ERROR VerifySession: Better Auth returned null response. Status: %d, URL: %s, Origin: %s, Referer: %s, Cookies: %s",
-			statusCode, url, req.Header.Get("Origin"), req.Header.Get("Referer"), cookieInfo)
+		verifySessionLog(logger.Error, "auth: VerifySession Better Auth returned null",
+			fmt.Sprintf("status=%d url=%s origin=%s referer=%s cookies=%s",
+				statusCode, url, req.Header.Get("Origin"), req.Header.Get("Referer"), cookieInfo))
 		return nil, fmt.Errorf("invalid session: Better Auth returned null (no active session)")
 	}
 
 	var sessionResp SessionResponse
 	if err := json.Unmarshal(body, &sessionResp); err != nil {
-		log.Printf("ERROR VerifySession: Failed to parse JSON response: %v, body: %s, status: %d", err, bodyStr, statusCode)
+		verifySessionLog(logger.Error, fmt.Sprintf("auth: VerifySession parse JSON: %v", err),
+			fmt.Sprintf("status=%d body=%s", statusCode, bodyStr))
 		return nil, fmt.Errorf("failed to parse response: %w (body: %s)", err, bodyStr)
 	}
 
 	if sessionResp.Error != nil {
-		log.Printf("ERROR VerifySession: Better Auth returned error: %s (status: %d)", sessionResp.Error.Message, sessionResp.Error.Status)
+		verifySessionLog(logger.Error, "auth: VerifySession Better Auth error response",
+			fmt.Sprintf("message=%s status=%d", sessionResp.Error.Message, sessionResp.Error.Status))
 		return nil, fmt.Errorf("session verification failed: %s (status: %d)", sessionResp.Error.Message, sessionResp.Error.Status)
 	}
 
 	if sessionResp.User.ID == "" {
-		log.Printf("ERROR VerifySession: Session has no user data, response: %s", bodyStr)
+		verifySessionLog(logger.Error, "auth: VerifySession missing user in response", fmt.Sprintf("body=%s", bodyStr))
 		return nil, fmt.Errorf("invalid session: no user data (response: %s)", bodyStr)
 	}
 
@@ -198,7 +214,7 @@ func VerifySession(r *http.Request) (*SessionResponse, error) {
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Printf("ERROR VerifySession: Failed to create request: %v", err)
+		verifySessionLog(logger.Error, fmt.Sprintf("auth: VerifySession build request: %v", err), url)
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -207,14 +223,14 @@ func VerifySession(r *http.Request) (*SessionResponse, error) {
 
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
-		log.Printf("ERROR VerifySession: HTTP request failed: %v", err)
+		verifySessionLog(logger.Error, fmt.Sprintf("auth: VerifySession HTTP: %v", err), url)
 		return nil, fmt.Errorf("failed to verify session: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := authReadAll(resp.Body)
 	if err != nil {
-		log.Printf("ERROR VerifySession: Failed to read response body: %v", err)
+		verifySessionLog(logger.Error, fmt.Sprintf("auth: VerifySession read body: %v", err), fmt.Sprintf("url=%s", url))
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 

--- a/api/internal/features/container/controller/get_container.go
+++ b/api/internal/features/container/controller/get_container.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -13,12 +14,16 @@ import (
 func (c *ContainerController) GetContainer(f fuego.ContextNoBody) (*types.GetContainerResponse, error) {
 	containerID := f.PathParam("container_id")
 	if _, err := uuid.Parse(containerID); err != nil {
+		c.logger.Log(logger.Debug, "container: GetContainer invalid id", containerID)
 		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 	ctx := f.Request().Context()
+	ctxStr := fmt.Sprintf("container_id=%s", containerID)
+	c.logger.Log(logger.Info, "container: GetContainer", ctxStr)
 
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: GetContainer docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -28,7 +33,7 @@ func (c *ContainerController) GetContainer(f fuego.ContextNoBody) (*types.GetCon
 
 	containerData, err := service.GetContainer(dockerService, c.logger, containerID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("container: GetContainer: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -36,6 +41,7 @@ func (c *ContainerController) GetContainer(f fuego.ContextNoBody) (*types.GetCon
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: GetContainer ok", ctxStr)
 	return &types.GetContainerResponse{
 		Status:  "success",
 		Message: "Container fetched successfully",

--- a/api/internal/features/container/controller/get_container_logs.go
+++ b/api/internal/features/container/controller/get_container_logs.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -14,6 +15,7 @@ import (
 func (c *ContainerController) GetContainerLogs(f fuego.ContextWithBody[types.ContainerLogsRequest]) (*types.ContainerLogsResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: GetContainerLogs invalid body: %v", err), "")
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -24,15 +26,19 @@ func (c *ContainerController) GetContainerLogs(f fuego.ContextWithBody[types.Con
 		req.ID = f.PathParam("container_id")
 	}
 	if _, err := uuid.Parse(req.ID); err != nil {
+		c.logger.Log(logger.Debug, "container: GetContainerLogs invalid id", req.ID)
 		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 
 	_, r := f.Response(), f.Request()
 	ctx := r.Context()
 	orgID := utils.GetOrganizationID(r)
+	ctxStr := fmt.Sprintf("container_id=%s org_id=%s tail=%d follow=%v", req.ID, orgID, req.Tail, req.Follow)
+	c.logger.Log(logger.Info, "container: GetContainerLogs", ctxStr)
 
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: GetContainerLogs docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -57,7 +63,7 @@ func (c *ContainerController) GetContainerLogs(f fuego.ContextWithBody[types.Con
 		},
 	)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("container: GetContainerLogs: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -65,6 +71,7 @@ func (c *ContainerController) GetContainerLogs(f fuego.ContextWithBody[types.Con
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: GetContainerLogs ok", fmt.Sprintf("%s bytes=%d", ctxStr, len(decodedLogs)))
 	return &types.ContainerLogsResponse{
 		Status:  "success",
 		Message: "Container logs fetched successfully",

--- a/api/internal/features/container/controller/init.go
+++ b/api/internal/features/container/controller/init.go
@@ -50,15 +50,17 @@ func (c *ContainerController) getDockerService(ctx context.Context) (docker.Dock
 func (c *ContainerController) isProtectedContainer(ctx context.Context, containerID string, action string) (*types.ContainerActionResponse, bool) {
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: isProtectedContainer skip (%s): docker service: %v", action, err), fmt.Sprintf("container_id=%s", containerID))
 		return nil, false
 	}
 	details, err := dockerService.GetContainerById(containerID)
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: isProtectedContainer skip (%s): %v", action, err), fmt.Sprintf("container_id=%s", containerID))
 		return nil, false
 	}
 	name := strings.ToLower(details.Name)
 	if strings.Contains(name, "nixopus") {
-		c.logger.Log(logger.Info, fmt.Sprintf("Skipping %s for protected container", action), details.Name)
+		c.logger.Log(logger.Info, fmt.Sprintf("container: protected skip %s", action), fmt.Sprintf("name=%s container_id=%s", details.Name, containerID))
 		return &types.ContainerActionResponse{
 			Status:  "success",
 			Message: "Operation skipped for protected container",

--- a/api/internal/features/container/controller/list_containers.go
+++ b/api/internal/features/container/controller/list_containers.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -8,14 +9,19 @@ import (
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	containertypes "github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (c *ContainerController) ListContainers(fuegoCtx fuego.ContextNoBody) (*containertypes.ListContainersResponse, error) {
 	params := parseContainerListParams(fuegoCtx.Request())
 	ctx := fuegoCtx.Request().Context()
 
+	ctxStr := fmt.Sprintf("page=%d page_size=%d status=%q search=%q", params.Page, params.PageSize, params.Status, params.Search)
+	c.logger.Log(logger.Info, "container: ListContainers", ctxStr)
+
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: ListContainers docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -25,6 +31,7 @@ func (c *ContainerController) ListContainers(fuegoCtx fuego.ContextNoBody) (*con
 
 	resp, err := service.ListContainers(dockerService, c.logger, params)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: ListContainers: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -32,6 +39,7 @@ func (c *ContainerController) ListContainers(fuegoCtx fuego.ContextNoBody) (*con
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: ListContainers ok", fmt.Sprintf("%s group_count=%d total_count=%d", ctxStr, resp.Data.GroupCount, resp.Data.TotalCount))
 	return &resp, nil
 }
 

--- a/api/internal/features/container/controller/list_images.go
+++ b/api/internal/features/container/controller/list_images.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/go-fuego/fuego"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 type ListImagesRequest struct {
@@ -19,6 +21,7 @@ type ListImagesRequest struct {
 func (c *ContainerController) ListImages(f fuego.ContextWithBody[ListImagesRequest]) (*container_types.ListImagesResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: ListImages invalid body: %v", err), "")
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -26,8 +29,12 @@ func (c *ContainerController) ListImages(f fuego.ContextWithBody[ListImagesReque
 	}
 
 	ctx := f.Request().Context()
+	ctxStr := fmt.Sprintf("all=%v container_id=%s image_prefix=%q", req.All, req.ContainerID, req.ImagePrefix)
+	c.logger.Log(logger.Info, "container: ListImages", ctxStr)
+
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: ListImages docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -39,6 +46,7 @@ func (c *ContainerController) ListImages(f fuego.ContextWithBody[ListImagesReque
 	if req.ContainerID != "" {
 		_, err := dockerService.GetContainerById(req.ContainerID)
 		if err != nil {
+			c.logger.Log(logger.Debug, fmt.Sprintf("container: ListImages container not found: %v", err), ctxStr)
 			return nil, fuego.NotFoundError{
 				Detail: err.Error(),
 				Err:    err,
@@ -60,6 +68,7 @@ func (c *ContainerController) ListImages(f fuego.ContextWithBody[ListImagesReque
 	})
 
 	if len(images) == 0 {
+		c.logger.Log(logger.Info, "container: ListImages ok", fmt.Sprintf("%s count=0", ctxStr))
 		return &container_types.ListImagesResponse{
 			Status:  "success",
 			Message: "No images found",
@@ -83,6 +92,7 @@ func (c *ContainerController) ListImages(f fuego.ContextWithBody[ListImagesReque
 		result = append(result, imageData)
 	}
 
+	c.logger.Log(logger.Info, "container: ListImages ok", fmt.Sprintf("%s count=%d", ctxStr, len(result)))
 	return &container_types.ListImagesResponse{
 		Status:  "success",
 		Message: "Images listed successfully",

--- a/api/internal/features/container/controller/prune_build_cache.go
+++ b/api/internal/features/container/controller/prune_build_cache.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 type PruneBuildCacheRequest struct {
@@ -16,6 +18,7 @@ type PruneBuildCacheRequest struct {
 func (c *ContainerController) PruneBuildCache(f fuego.ContextWithBody[PruneBuildCacheRequest]) (*container_types.MessageResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: PruneBuildCache invalid body: %v", err), "")
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -23,8 +26,12 @@ func (c *ContainerController) PruneBuildCache(f fuego.ContextWithBody[PruneBuild
 	}
 
 	ctx := f.Request().Context()
+	ctxStr := fmt.Sprintf("all=%v filters=%q", req.All, req.Filters)
+	c.logger.Log(logger.Info, "container: PruneBuildCache", ctxStr)
+
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: PruneBuildCache docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -38,6 +45,7 @@ func (c *ContainerController) PruneBuildCache(f fuego.ContextWithBody[PruneBuild
 
 	response, err := service.PruneBuildCache(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: PruneBuildCache: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -45,5 +53,6 @@ func (c *ContainerController) PruneBuildCache(f fuego.ContextWithBody[PruneBuild
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: PruneBuildCache ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/controller/prune_images.go
+++ b/api/internal/features/container/controller/prune_images.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 type PruneImagesRequest struct {
@@ -17,6 +19,7 @@ type PruneImagesRequest struct {
 func (c *ContainerController) PruneImages(f fuego.ContextWithBody[PruneImagesRequest]) (*types.PruneImagesResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: PruneImages invalid body: %v", err), "")
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -24,8 +27,12 @@ func (c *ContainerController) PruneImages(f fuego.ContextWithBody[PruneImagesReq
 	}
 
 	ctx := f.Request().Context()
+	ctxStr := fmt.Sprintf("until=%q label=%q dangling=%v", req.Until, req.Label, req.Dangling)
+	c.logger.Log(logger.Info, "container: PruneImages", ctxStr)
+
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: PruneImages docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -41,6 +48,7 @@ func (c *ContainerController) PruneImages(f fuego.ContextWithBody[PruneImagesReq
 
 	response, err := service.PruneImages(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: PruneImages: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -48,5 +56,6 @@ func (c *ContainerController) PruneImages(f fuego.ContextWithBody[PruneImagesReq
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: PruneImages ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/controller/remove_container.go
+++ b/api/internal/features/container/controller/remove_container.go
@@ -1,16 +1,20 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (c *ContainerController) RemoveContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
 	ctx := f.Request().Context()
+	ctxStr := fmt.Sprintf("container_id=%s", containerID)
+	c.logger.Log(logger.Info, "container: RemoveContainer", ctxStr)
 
 	if resp, skipped := c.isProtectedContainer(ctx, containerID, "remove"); skipped {
 		return resp, nil
@@ -18,6 +22,7 @@ func (c *ContainerController) RemoveContainer(f fuego.ContextNoBody) (*types.Con
 
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: RemoveContainer docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -32,6 +37,7 @@ func (c *ContainerController) RemoveContainer(f fuego.ContextNoBody) (*types.Con
 
 	response, err := service.RemoveContainer(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: RemoveContainer: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -39,5 +45,6 @@ func (c *ContainerController) RemoveContainer(f fuego.ContextNoBody) (*types.Con
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: RemoveContainer ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/controller/restart_container.go
+++ b/api/internal/features/container/controller/restart_container.go
@@ -1,17 +1,20 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (c *ContainerController) RestartContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
 	if _, err := uuid.Parse(containerID); err != nil {
+		c.logger.Log(logger.Debug, "container: RestartContainer invalid id", containerID)
 		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 	ctx := f.Request().Context()
@@ -23,14 +26,16 @@ func (c *ContainerController) RestartContainer(f fuego.ContextNoBody) (*types.Co
 	_, r := f.Response(), f.Request()
 	orgSettings := c.getOrganizationSettings(r)
 
-	// Use timeout from settings, default to 10 seconds if not set
 	timeout := 10
 	if orgSettings.ContainerStopTimeout != nil {
 		timeout = *orgSettings.ContainerStopTimeout
 	}
+	ctxStr := fmt.Sprintf("container_id=%s stop_timeout_sec=%d", containerID, timeout)
+	c.logger.Log(logger.Info, "container: RestartContainer", ctxStr)
 
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: RestartContainer docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -45,6 +50,7 @@ func (c *ContainerController) RestartContainer(f fuego.ContextNoBody) (*types.Co
 
 	response, err := service.RestartContainer(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: RestartContainer: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -52,5 +58,6 @@ func (c *ContainerController) RestartContainer(f fuego.ContextNoBody) (*types.Co
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: RestartContainer ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/controller/start_container.go
+++ b/api/internal/features/container/controller/start_container.go
@@ -1,20 +1,25 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (c *ContainerController) StartContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
 	if _, err := uuid.Parse(containerID); err != nil {
+		c.logger.Log(logger.Debug, "container: StartContainer invalid id", containerID)
 		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 	ctx := f.Request().Context()
+	ctxStr := fmt.Sprintf("container_id=%s", containerID)
+	c.logger.Log(logger.Info, "container: StartContainer", ctxStr)
 
 	if resp, skipped := c.isProtectedContainer(ctx, containerID, "start"); skipped {
 		return resp, nil
@@ -22,6 +27,7 @@ func (c *ContainerController) StartContainer(f fuego.ContextNoBody) (*types.Cont
 
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: StartContainer docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -35,6 +41,7 @@ func (c *ContainerController) StartContainer(f fuego.ContextNoBody) (*types.Cont
 
 	response, err := service.StartContainer(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: StartContainer: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -42,5 +49,6 @@ func (c *ContainerController) StartContainer(f fuego.ContextNoBody) (*types.Cont
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: StartContainer ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/controller/stop_container.go
+++ b/api/internal/features/container/controller/stop_container.go
@@ -1,17 +1,20 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (c *ContainerController) StopContainer(f fuego.ContextNoBody) (*types.ContainerActionResponse, error) {
 	containerID := f.PathParam("container_id")
 	if _, err := uuid.Parse(containerID); err != nil {
+		c.logger.Log(logger.Debug, "container: StopContainer invalid id", containerID)
 		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 	ctx := f.Request().Context()
@@ -23,14 +26,16 @@ func (c *ContainerController) StopContainer(f fuego.ContextNoBody) (*types.Conta
 	_, r := f.Response(), f.Request()
 	orgSettings := c.getOrganizationSettings(r)
 
-	// Use timeout from settings, default to 10 seconds if not set
 	timeout := 10
 	if orgSettings.ContainerStopTimeout != nil {
 		timeout = *orgSettings.ContainerStopTimeout
 	}
+	ctxStr := fmt.Sprintf("container_id=%s stop_timeout_sec=%d", containerID, timeout)
+	c.logger.Log(logger.Info, "container: StopContainer", ctxStr)
 
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: StopContainer docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -45,6 +50,7 @@ func (c *ContainerController) StopContainer(f fuego.ContextNoBody) (*types.Conta
 
 	response, err := service.StopContainer(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: StopContainer: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -52,5 +58,6 @@ func (c *ContainerController) StopContainer(f fuego.ContextNoBody) (*types.Conta
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: StopContainer ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/controller/update_container_resources.go
+++ b/api/internal/features/container/controller/update_container_resources.go
@@ -1,12 +1,14 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/container/service"
 	"github.com/nixopus/nixopus/api/internal/features/container/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 // UpdateContainerResources updates the resource limits (memory, swap, CPU) of a running container.
@@ -14,6 +16,7 @@ import (
 func (c *ContainerController) UpdateContainerResources(f fuego.ContextWithBody[types.UpdateContainerResourcesRequest]) (*types.UpdateContainerResourcesResponse, error) {
 	containerID := f.PathParam("container_id")
 	if _, err := uuid.Parse(containerID); err != nil {
+		c.logger.Log(logger.Debug, "container: UpdateContainerResources invalid id", containerID)
 		return nil, fuego.BadRequestError{Detail: "container_id must be a valid UUID"}
 	}
 	ctx := f.Request().Context()
@@ -30,14 +33,19 @@ func (c *ContainerController) UpdateContainerResources(f fuego.ContextWithBody[t
 
 	body, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("container: UpdateContainerResources invalid body: %v", err), fmt.Sprintf("container_id=%s", containerID))
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
+	ctxStr := fmt.Sprintf("container_id=%s memory=%v memory_swap=%v cpu_shares=%v", containerID, body.Memory, body.MemorySwap, body.CPUShares)
+	c.logger.Log(logger.Info, "container: UpdateContainerResources", ctxStr)
+
 	dockerService, err := c.getDockerService(ctx)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: UpdateContainerResources docker service: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -54,6 +62,7 @@ func (c *ContainerController) UpdateContainerResources(f fuego.ContextWithBody[t
 
 	response, err := service.UpdateContainerResources(dockerService, c.logger, opts)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("container: UpdateContainerResources: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -61,5 +70,6 @@ func (c *ContainerController) UpdateContainerResources(f fuego.ContextWithBody[t
 		}
 	}
 
+	c.logger.Log(logger.Info, "container: UpdateContainerResources ok", ctxStr)
 	return &response, nil
 }

--- a/api/internal/features/container/service/get_container.go
+++ b/api/internal/features/container/service/get_container.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"strconv"
 
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
@@ -16,7 +17,7 @@ func GetContainer(
 ) (container_types.Container, error) {
 	containerInfo, err := dockerService.GetContainerById(containerID)
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: GetContainer: %v", err), containerID)
 		return container_types.Container{}, err
 	}
 

--- a/api/internal/features/container/service/get_container_logs.go
+++ b/api/internal/features/container/service/get_container_logs.go
@@ -54,7 +54,7 @@ func GetContainerLogs(
 		ShowStderr: opts.Stderr,
 	})
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: GetContainerLogs docker: %v", err), opts.ContainerID)
 		return "", fmt.Errorf("failed to get container logs: %w", err)
 	}
 
@@ -62,7 +62,7 @@ func GetContainerLogs(
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, logsReader)
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: GetContainerLogs read: %v", err), opts.ContainerID)
 		return "", fmt.Errorf("failed to read container logs: %w", err)
 	}
 

--- a/api/internal/features/container/service/list_containers.go
+++ b/api/internal/features/container/service/list_containers.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -22,7 +23,7 @@ func ListContainers(
 		Filters: buildDockerFilters(params),
 	})
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: ListContainers: %v", err), "")
 		return container_types.ListContainersResponse{}, err
 	}
 

--- a/api/internal/features/container/service/list_images.go
+++ b/api/internal/features/container/service/list_images.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types/filters"
@@ -29,7 +30,7 @@ func ListImages(
 	if opts.ContainerID != "" {
 		_, err := dockerService.GetContainerById(opts.ContainerID)
 		if err != nil {
-			l.Log(logger.Error, err.Error(), "")
+			l.Log(logger.Error, fmt.Sprintf("container service: ListImages invalid container: %v", err), opts.ContainerID)
 			return container_types.ListImagesResponse{}, err
 		}
 	}

--- a/api/internal/features/container/service/prune_build_cache.go
+++ b/api/internal/features/container/service/prune_build_cache.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
@@ -22,7 +24,7 @@ func PruneBuildCache(
 		All: opts.All,
 	})
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: PruneBuildCache: %v", err), "")
 		return container_types.MessageResponse{}, err
 	}
 

--- a/api/internal/features/container/service/prune_images.go
+++ b/api/internal/features/container/service/prune_images.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types/filters"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
@@ -33,7 +35,7 @@ func PruneImages(
 
 	pruneReport, err := dockerService.PruneImages(filterArgs)
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: PruneImages: %v", err), "")
 		return container_types.PruneImagesResponse{}, err
 	}
 

--- a/api/internal/features/container/service/remove_container.go
+++ b/api/internal/features/container/service/remove_container.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types/container"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
@@ -23,7 +25,7 @@ func RemoveContainer(
 		Force: opts.Force,
 	})
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: RemoveContainer: %v", err), opts.ContainerID)
 		return container_types.ContainerActionResponse{}, err
 	}
 

--- a/api/internal/features/container/service/restart_container.go
+++ b/api/internal/features/container/service/restart_container.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types/container"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
@@ -26,7 +28,7 @@ func RestartContainer(
 
 	err := dockerService.RestartContainer(opts.ContainerID, stopOpts)
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: RestartContainer: %v", err), opts.ContainerID)
 		return container_types.ContainerActionResponse{}, err
 	}
 

--- a/api/internal/features/container/service/start_container.go
+++ b/api/internal/features/container/service/start_container.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types/container"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
@@ -20,7 +22,7 @@ func StartContainer(
 ) (container_types.ContainerActionResponse, error) {
 	err := dockerService.StartContainer(opts.ContainerID, container.StartOptions{})
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: StartContainer: %v", err), opts.ContainerID)
 		return container_types.ContainerActionResponse{}, err
 	}
 

--- a/api/internal/features/container/service/stop_container.go
+++ b/api/internal/features/container/service/stop_container.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types/container"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/docker"
@@ -26,7 +28,7 @@ func StopContainer(
 
 	err := dockerService.StopContainer(opts.ContainerID, stopOpts)
 	if err != nil {
-		l.Log(logger.Error, err.Error(), "")
+		l.Log(logger.Error, fmt.Sprintf("container service: StopContainer: %v", err), opts.ContainerID)
 		return container_types.ContainerActionResponse{}, err
 	}
 

--- a/api/internal/features/container/service/update_container_resources.go
+++ b/api/internal/features/container/service/update_container_resources.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/docker/docker/api/types/container"
 	container_types "github.com/nixopus/nixopus/api/internal/features/container/types"
@@ -26,33 +27,33 @@ func UpdateContainerResources(
 	// Validate resource limits before constructing updateConfig
 	const minMemoryBytes = 6 * 1024 * 1024 // 6MB minimum
 	if opts.Memory != 0 && opts.Memory < minMemoryBytes {
-		l.Log(logger.Error, "Invalid memory limit", opts.ContainerID)
+		l.Log(logger.Error, "container service: UpdateContainerResources invalid memory", opts.ContainerID)
 		return container_types.UpdateContainerResourcesResponse{}, errors.New("memory must be 0 or >= 6MB")
 	}
 
 	// Validate MemorySwap: if non-zero, must be >= Memory or -1 (unlimited swap)
 	if opts.MemorySwap != 0 && opts.MemorySwap != -1 {
 		if opts.MemorySwap < opts.Memory {
-			l.Log(logger.Error, "Invalid memory swap limit", opts.ContainerID)
+			l.Log(logger.Error, "container service: UpdateContainerResources invalid memory_swap", opts.ContainerID)
 			return container_types.UpdateContainerResourcesResponse{}, errors.New("memory_swap must be >= memory, 0 (unlimited), or -1 (unlimited swap)")
 		}
 	}
 
 	// Validate CPUShares: must be >= 2 if provided (non-zero)
 	if opts.CPUShares != 0 && opts.CPUShares < 2 {
-		l.Log(logger.Error, "Invalid CPU shares", opts.ContainerID)
+		l.Log(logger.Error, "container service: UpdateContainerResources invalid cpu_shares", opts.ContainerID)
 		return container_types.UpdateContainerResourcesResponse{}, errors.New("cpu_shares must be >= 2")
 	}
 
 	// Verify container state before updating resources
 	containerInfo, err := dockerService.GetContainerById(opts.ContainerID)
 	if err != nil {
-		l.Log(logger.Error, "Failed to inspect container", err.Error())
+		l.Log(logger.Error, fmt.Sprintf("container service: UpdateContainerResources inspect: %v", err), opts.ContainerID)
 		return container_types.UpdateContainerResourcesResponse{}, err
 	}
 
 	if containerInfo.State != nil && !containerInfo.State.Running {
-		l.Log(logger.Error, "Container is not running", opts.ContainerID)
+		l.Log(logger.Error, "container service: UpdateContainerResources not running", opts.ContainerID)
 		return container_types.UpdateContainerResourcesResponse{}, errors.New("container must be running to update resource limits")
 	}
 
@@ -68,11 +69,11 @@ func UpdateContainerResources(
 	// Update the container resources
 	result, err := dockerService.UpdateContainerResources(opts.ContainerID, updateConfig)
 	if err != nil {
-		l.Log(logger.Error, "Failed to update container resources", err.Error())
+		l.Log(logger.Error, fmt.Sprintf("container service: UpdateContainerResources docker update: %v", err), opts.ContainerID)
 		return container_types.UpdateContainerResourcesResponse{}, err
 	}
 
-	l.Log(logger.Info, "Container resources updated successfully", opts.ContainerID)
+	l.Log(logger.Info, "container service: UpdateContainerResources ok", opts.ContainerID)
 
 	return container_types.UpdateContainerResourcesResponse{
 		Status:  "success",

--- a/api/internal/features/deploy/caddy/health.go
+++ b/api/internal/features/deploy/caddy/health.go
@@ -127,10 +127,10 @@ func (h *HealthMonitor) run(ctx context.Context) {
 	for {
 		select {
 		case <-h.stopCh:
-			h.logger.Log(logger.Info, "health monitor stopped", "")
+			h.logger.Log(logger.Info, "deploy caddy: health monitor stopped", "")
 			return
 		case <-ctx.Done():
-			h.logger.Log(logger.Info, "health monitor context cancelled", "")
+			h.logger.Log(logger.Info, "deploy caddy: health monitor context cancelled", "")
 			return
 		case <-ticker.C:
 			h.enqueueAll(ctx)
@@ -143,12 +143,12 @@ func (h *HealthMonitor) run(ctx context.Context) {
 func (h *HealthMonitor) enqueueAll(ctx context.Context) {
 	orgIDs, err := h.orgFetcher(ctx)
 	if err != nil {
-		h.logger.Log(logger.Error, "health monitor: failed to fetch organizations", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: health monitor: failed to fetch organizations", err.Error())
 		return
 	}
 
 	if HealthCheckQueue == nil || TaskCaddyHealthCheck == nil {
-		h.logger.Log(logger.Warning, "health check queue not initialized, falling back to direct checks", "")
+		h.logger.Log(logger.Warning, "deploy caddy: health check queue not initialized, falling back to direct checks", "")
 		for _, orgID := range orgIDs {
 			h.checkServer(ctx, orgID)
 		}
@@ -162,7 +162,7 @@ func (h *HealthMonitor) enqueueAll(ctx context.Context) {
 		msg.OnceInPeriod(15 * time.Second)
 
 		if err := HealthCheckQueue.Add(msg); err != nil {
-			h.logger.Log(logger.Warning, "failed to enqueue health check for org "+orgID.String(), err.Error())
+			h.logger.Log(logger.Warning, "deploy caddy: failed to enqueue health check for org "+orgID.String(), err.Error())
 		}
 	}
 }
@@ -189,7 +189,7 @@ func (h *HealthMonitor) checkServer(ctx context.Context, orgID uuid.UUID) {
 		health := h.GetServerHealth(orgID)
 		if health != nil && health.FailCount >= 3 && h.shouldAttemptRestart(orgID) {
 			h.logger.Log(logger.Warning,
-				fmt.Sprintf("caddy on %s unreachable for %d consecutive checks, attempting recovery", host, health.FailCount),
+				fmt.Sprintf("deploy caddy: caddy on %s unreachable for %d consecutive checks, attempting recovery", host, health.FailCount),
 				orgID.String())
 			h.attemptCaddyRestart(orgCtx, orgID, host)
 		}
@@ -200,7 +200,7 @@ func (h *HealthMonitor) checkServer(ctx context.Context, orgID uuid.UUID) {
 
 	if !wasHealthy && existed {
 		h.logger.Log(logger.Info,
-			fmt.Sprintf("caddy on %s recovered, triggering reconciliation", host),
+			fmt.Sprintf("deploy caddy: caddy on %s recovered, triggering reconciliation", host),
 			orgID.String())
 		h.triggerReconciliation(orgID)
 	}
@@ -263,13 +263,13 @@ func (h *HealthMonitor) recordRestartAttempt(orgID uuid.UUID, containerMissing b
 func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID, host string) {
 	manager, err := getSSHManagerFromContextForCaddy(ctx)
 	if err != nil {
-		h.logger.Log(logger.Error, "failed to get SSH manager for caddy restart", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: failed to get SSH manager for caddy restart", err.Error())
 		return
 	}
 
 	sshClient, err := manager.GetDefaultSSH()
 	if err != nil {
-		h.logger.Log(logger.Error, "failed to get SSH config for caddy restart", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: failed to get SSH config for caddy restart", err.Error())
 		return
 	}
 
@@ -278,7 +278,7 @@ func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID
 	// the pooled connection.
 	conn, err := sshClient.Connect()
 	if err != nil {
-		h.logger.Log(logger.Error, "failed to SSH connect for caddy restart", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: failed to SSH connect for caddy restart", err.Error())
 		return
 	}
 	defer conn.Close()
@@ -287,7 +287,7 @@ func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID
 	dockerRestarted, containerMissing := h.tryDockerRestart(conn, orgID, host)
 	if dockerRestarted {
 		h.recordRestartAttempt(orgID, false)
-		h.logger.Log(logger.Info, fmt.Sprintf("caddy container restarted on %s", host), orgID.String())
+		h.logger.Log(logger.Info, fmt.Sprintf("deploy caddy: caddy container restarted on %s", host), orgID.String())
 		InvalidateTunnel(host)
 		return
 	}
@@ -303,7 +303,7 @@ func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID
 	// may have been caused by a stale SSH tunnel, not a dead Caddy).
 	if h.isCaddyAPIReachable(conn, host) {
 		h.logger.Log(logger.Info,
-			fmt.Sprintf("caddy on %s runs as a system service, admin API is reachable — refreshing tunnel", host),
+			fmt.Sprintf("deploy caddy: caddy on %s runs as a system service, admin API is reachable — refreshing tunnel", host),
 			orgID.String())
 		h.recordRestartAttempt(orgID, false)
 		InvalidateTunnel(host)
@@ -313,14 +313,14 @@ func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID
 	// Strategy 3: Admin API not reachable — try systemd restart.
 	if h.trySystemdRestart(conn, orgID, host) {
 		h.recordRestartAttempt(orgID, false)
-		h.logger.Log(logger.Info, fmt.Sprintf("caddy systemd service restarted on %s", host), orgID.String())
+		h.logger.Log(logger.Info, fmt.Sprintf("deploy caddy: caddy systemd service restarted on %s", host), orgID.String())
 		InvalidateTunnel(host)
 		return
 	}
 
 	h.recordRestartAttempt(orgID, true)
 	h.logger.Log(logger.Warning,
-		fmt.Sprintf("caddy on %s: no Docker container and systemd restart failed, will retry with backoff", host),
+		fmt.Sprintf("deploy caddy: caddy on %s: no Docker container and systemd restart failed, will retry with backoff", host),
 		orgID.String())
 }
 
@@ -330,7 +330,7 @@ func (h *HealthMonitor) attemptCaddyRestart(ctx context.Context, orgID uuid.UUID
 func (h *HealthMonitor) tryDockerRestart(conn *goph.Client, orgID uuid.UUID, host string) (restarted, containerMissing bool) {
 	session, err := conn.NewSession()
 	if err != nil {
-		h.logger.Log(logger.Error, "failed to create SSH session for docker restart", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: failed to create SSH session for docker restart", err.Error())
 		return false, false
 	}
 	defer session.Close()
@@ -340,7 +340,7 @@ func (h *HealthMonitor) tryDockerRestart(conn *goph.Client, orgID uuid.UUID, hos
 		missing := strings.Contains(string(output), "No such container")
 		if !missing {
 			h.logger.Log(logger.Error,
-				fmt.Sprintf("caddy container restart failed on %s", host),
+				fmt.Sprintf("deploy caddy: caddy container restart failed on %s", host),
 				fmt.Sprintf("error: %v, output: %s", err, string(output)))
 		}
 		return false, missing
@@ -375,7 +375,7 @@ func (h *HealthMonitor) isCaddyAPIReachable(conn *goph.Client, host string) bool
 func (h *HealthMonitor) trySystemdRestart(conn *goph.Client, orgID uuid.UUID, host string) bool {
 	session, err := conn.NewSession()
 	if err != nil {
-		h.logger.Log(logger.Error, "failed to create SSH session for systemd restart", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: failed to create SSH session for systemd restart", err.Error())
 		return false
 	}
 	defer session.Close()
@@ -383,7 +383,7 @@ func (h *HealthMonitor) trySystemdRestart(conn *goph.Client, orgID uuid.UUID, ho
 	output, err := session.CombinedOutput("systemctl restart caddy-api 2>/dev/null || systemctl restart caddy 2>/dev/null")
 	if err != nil {
 		h.logger.Log(logger.Warning,
-			fmt.Sprintf("caddy systemd restart failed on %s", host),
+			fmt.Sprintf("deploy caddy: caddy systemd restart failed on %s", host),
 			fmt.Sprintf("error: %v, output: %s", err, string(output)))
 		return false
 	}
@@ -394,6 +394,6 @@ func (h *HealthMonitor) trySystemdRestart(conn *goph.Client, orgID uuid.UUID, ho
 // it inline, so any available worker picks it up.
 func (h *HealthMonitor) triggerReconciliation(orgID uuid.UUID) {
 	if err := enqueueReconcileAfterRecovery(orgID); err != nil {
-		h.logger.Log(logger.Error, "failed to enqueue post-recovery reconciliation", err.Error())
+		h.logger.Log(logger.Error, "deploy caddy: failed to enqueue post-recovery reconciliation", err.Error())
 	}
 }

--- a/api/internal/features/deploy/caddy/operations.go
+++ b/api/internal/features/deploy/caddy/operations.go
@@ -215,7 +215,7 @@ func AddDomainsAtomic(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Logge
 
 	if addErr := AddDomainsWithRetry(ctx, sshClient, lgr, domains); addErr != nil {
 		l := resolveLogger(lgr)
-		l.Log(logger.Warning, "domain add failed, rolling back caddy config", addErr.Error())
+		l.Log(logger.Warning, "deploy caddy: domain add failed, rolling back caddy config", addErr.Error())
 
 		if restoreErr := RestoreCaddyConfig(ctx, sshClient, lgr, snapshot); restoreErr != nil {
 			return fmt.Errorf("add failed AND rollback failed: %w (original: %v)", restoreErr, addErr)
@@ -239,7 +239,7 @@ func RemoveDomainsAtomic(ctx context.Context, sshClient *ssh.SSH, lgr *logger.Lo
 
 	if removeErr := RemoveDomainsWithRetry(ctx, sshClient, lgr, domains); removeErr != nil {
 		l := resolveLogger(lgr)
-		l.Log(logger.Warning, "domain remove failed, rolling back caddy config", removeErr.Error())
+		l.Log(logger.Warning, "deploy caddy: domain remove failed, rolling back caddy config", removeErr.Error())
 
 		if restoreErr := RestoreCaddyConfig(ctx, sshClient, lgr, snapshot); restoreErr != nil {
 			return fmt.Errorf("remove failed AND rollback failed: %w (original: %v)", restoreErr, removeErr)

--- a/api/internal/features/deploy/caddy/reconciler.go
+++ b/api/internal/features/deploy/caddy/reconciler.go
@@ -95,7 +95,7 @@ func (r *Reconciler) ReconcileOrganization(ctx context.Context, organizationID u
 
 	actual, err := GetCurrentDomains(orgCtx, nil, &r.Logger)
 	if err != nil {
-		r.Logger.Log(logger.Warning, "failed to read caddy state, attempting full rebuild", err.Error())
+		r.Logger.Log(logger.Warning, "deploy caddy: failed to read caddy state, attempting full rebuild", err.Error())
 		return r.fullRebuild(orgCtx, desired)
 	}
 
@@ -134,7 +134,7 @@ func (r *Reconciler) ReconcileOrganization(ctx context.Context, organizationID u
 	// deleted from the DB but whose Caddy removal failed at delete time.
 	pendingRemovals, pendingErr := GetPendingRemovals(orgCtx, organizationID)
 	if pendingErr != nil {
-		r.Logger.Log(logger.Warning, "failed to read pending removals", pendingErr.Error())
+		r.Logger.Log(logger.Warning, "deploy caddy: failed to read pending removals", pendingErr.Error())
 	}
 
 	needsReload := len(toAdd) > 0 || len(toUpdate) > 0 || len(pendingRemovals) > 0
@@ -167,7 +167,7 @@ func (r *Reconciler) ReconcileOrganization(ctx context.Context, organizationID u
 			} else {
 				result.Removed = append(result.Removed, domain)
 				if clearErr := ClearPendingRemoval(organizationID, domain); clearErr != nil {
-					r.Logger.Log(logger.Warning, "failed to clear pending removal for "+domain, clearErr.Error())
+					r.Logger.Log(logger.Warning, "deploy caddy: failed to clear pending removal for "+domain, clearErr.Error())
 				}
 			}
 		}
@@ -178,7 +178,7 @@ func (r *Reconciler) ReconcileOrganization(ctx context.Context, organizationID u
 	}
 
 	r.Logger.Log(logger.Info,
-		fmt.Sprintf("reconciliation complete: added=%d updated=%d removed=%d errors=%d",
+		fmt.Sprintf("deploy caddy: reconciliation complete: added=%d updated=%d removed=%d errors=%d",
 			len(result.Added), len(result.Updated), len(result.Removed), len(result.Errors)),
 		organizationID.String())
 
@@ -198,7 +198,7 @@ func (r *Reconciler) buildDesiredState(ctx context.Context, organizationID uuid.
 	// Source 2: extension-managed domains from Redis hash.
 	extRoutes, err := GetExtensionDomains(ctx, organizationID)
 	if err != nil {
-		r.Logger.Log(logger.Warning, "failed to read extension domains from redis", err.Error())
+		r.Logger.Log(logger.Warning, "deploy caddy: failed to read extension domains from redis", err.Error())
 	} else {
 		desired = append(desired, extRoutes...)
 	}
@@ -232,7 +232,7 @@ func (r *Reconciler) buildDeployDomains(ctx context.Context, organizationID uuid
 		} else {
 			port, err := r.getPublishedPort(ctx, app.Name)
 			if err != nil {
-				r.Logger.Log(logger.Warning, fmt.Sprintf("skipping %s: %v", app.Name, err), "")
+				r.Logger.Log(logger.Warning, fmt.Sprintf("deploy caddy: skipping %s: %v", app.Name, err), "")
 				continue
 			}
 			swarmRoutes := BuildMultiUpstreamRoutes(
@@ -351,7 +351,7 @@ func (r *Reconciler) fullRebuild(ctx context.Context, desired []DomainRoute) (*R
 	}
 
 	r.Logger.Log(logger.Info,
-		fmt.Sprintf("full rebuild complete: added=%d errors=%d", len(result.Added), len(result.Errors)), "")
+		fmt.Sprintf("deploy caddy: full rebuild complete: added=%d errors=%d", len(result.Added), len(result.Errors)), "")
 
 	return result, nil
 }
@@ -477,7 +477,7 @@ func (d *ReconcilerDaemon) handleReconcileTask(ctx context.Context, payload Cadd
 	}
 	if len(result.Errors) > 0 {
 		d.logger.Log(logger.Warning,
-			fmt.Sprintf("reconciliation for org %s had %d errors", orgID, len(result.Errors)),
+			fmt.Sprintf("deploy caddy: reconciliation for org %s had %d errors", orgID, len(result.Errors)),
 			fmt.Sprintf("%v", result.Errors))
 	}
 	return nil
@@ -505,10 +505,10 @@ func (d *ReconcilerDaemon) run(ctx context.Context) {
 	for {
 		select {
 		case <-d.stopCh:
-			d.logger.Log(logger.Info, "reconciler daemon stopped", "")
+			d.logger.Log(logger.Info, "deploy caddy: reconciler daemon stopped", "")
 			return
 		case <-ctx.Done():
-			d.logger.Log(logger.Info, "reconciler daemon context cancelled", "")
+			d.logger.Log(logger.Info, "deploy caddy: reconciler daemon context cancelled", "")
 			return
 		case <-ticker.C:
 			d.enqueueAll(ctx)
@@ -521,14 +521,14 @@ func (d *ReconcilerDaemon) run(ctx context.Context) {
 func (d *ReconcilerDaemon) enqueueAll(ctx context.Context) {
 	orgIDs, err := d.orgFetcher(ctx)
 	if err != nil {
-		d.logger.Log(logger.Error, "failed to fetch organizations for reconciliation", err.Error())
+		d.logger.Log(logger.Error, "deploy caddy: failed to fetch organizations for reconciliation", err.Error())
 		return
 	}
 
 	enqueued := 0
 	for _, orgID := range orgIDs {
 		if err := EnqueueReconcile(orgID); err != nil {
-			d.logger.Log(logger.Warning, "failed to enqueue reconcile for org "+orgID.String(), err.Error())
+			d.logger.Log(logger.Warning, "deploy caddy: failed to enqueue reconcile for org "+orgID.String(), err.Error())
 		} else {
 			enqueued++
 		}
@@ -536,7 +536,7 @@ func (d *ReconcilerDaemon) enqueueAll(ctx context.Context) {
 
 	if enqueued > 0 {
 		d.logger.Log(logger.Info,
-			fmt.Sprintf("enqueued %d/%d reconciliation jobs", enqueued, len(orgIDs)), "")
+			fmt.Sprintf("deploy caddy: enqueued %d/%d reconciliation jobs", enqueued, len(orgIDs)), "")
 	}
 }
 

--- a/api/internal/features/deploy/caddy/retry.go
+++ b/api/internal/features/deploy/caddy/retry.go
@@ -31,7 +31,7 @@ func WithRetry(op func() error, maxRetries int, lgr logger.Logger, onFailure fun
 				backoff = DefaultMaxDelay
 			}
 
-			lgr.Log(logger.Warning, fmt.Sprintf("caddy operation failed (attempt %d/%d), retrying in %s", i+1, maxRetries, backoff), err.Error())
+			lgr.Log(logger.Warning, fmt.Sprintf("deploy caddy: caddy operation failed (attempt %d/%d), retrying in %s", i+1, maxRetries, backoff), err.Error())
 
 			if onFailure != nil {
 				onFailure()

--- a/api/internal/features/deploy/caddy/route_builder.go
+++ b/api/internal/features/deploy/caddy/route_builder.go
@@ -57,7 +57,7 @@ func BuildMultiUpstreamRoutes(
 		}
 
 		if len(domainUpstreams) == 0 {
-			lgr.Log(logger.Warning, fmt.Sprintf("skipping domain %s: no valid upstreams", d.Domain), "")
+			lgr.Log(logger.Warning, fmt.Sprintf("deploy caddy: skipping domain %s: no valid upstreams", d.Domain), "")
 			continue
 		}
 

--- a/api/internal/features/deploy/caddy/tunnel.go
+++ b/api/internal/features/deploy/caddy/tunnel.go
@@ -64,7 +64,7 @@ func (t *CaddyTunnel) handleConnections(remotePort string, lgr logger.Logger) {
 	for {
 		localConn, err := t.listener.Accept()
 		if err != nil {
-			lgr.Log(logger.Error, "Caddy tunnel listener error", err.Error())
+			lgr.Log(logger.Error, "deploy caddy: tunnel listener error", err.Error())
 			return
 		}
 
@@ -117,7 +117,7 @@ func (t *CaddyTunnel) forwardConnection(localConn net.Conn, remotePort string, l
 
 	sshConn, err := t.getOrCreateSSH()
 	if err != nil {
-		lgr.Log(logger.Error, "Caddy tunnel: failed to establish SSH connection", t.tunnelErrLog(hostLabel, err.Error()))
+		lgr.Log(logger.Error, "deploy caddy: failed to establish SSH connection", t.tunnelErrLog(hostLabel, err.Error()))
 		return
 	}
 
@@ -138,12 +138,12 @@ func (t *CaddyTunnel) forwardConnection(localConn net.Conn, remotePort string, l
 
 		sshConn, err = t.getOrCreateSSH()
 		if err != nil {
-			lgr.Log(logger.Error, "Caddy tunnel: failed to reconnect SSH", t.tunnelErrLog(hostLabel, err.Error()))
+			lgr.Log(logger.Error, "deploy caddy: failed to reconnect SSH", t.tunnelErrLog(hostLabel, err.Error()))
 			return
 		}
 		remoteConn, err = sshConn.Dial("tcp", "127.0.0.1:"+remotePort)
 		if err != nil {
-			lgr.Log(logger.Error, "Caddy tunnel: failed to connect to remote Caddy after reconnect", t.tunnelErrLog(hostLabel, err.Error()))
+			lgr.Log(logger.Error, "deploy caddy: failed to connect to remote Caddy after reconnect", t.tunnelErrLog(hostLabel, err.Error()))
 			return
 		}
 	}

--- a/api/internal/features/deploy/controller/application_domains.go
+++ b/api/internal/features/deploy/controller/application_domains.go
@@ -41,7 +41,7 @@ func (c *DeployController) AddApplicationDomain(f fuego.ContextWithBody[AddAppli
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -133,7 +133,7 @@ func (c *DeployController) AddApplicationDomain(f fuego.ContextWithBody[AddAppli
 
 	err = c.storage.AddApplicationDomainWithService(appID, data.Domain, composeServiceID, data.Port)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to add domain", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to add domain", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -173,7 +173,7 @@ func (c *DeployController) RemoveApplicationDomain(f fuego.ContextWithBody[Remov
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -221,7 +221,7 @@ func (c *DeployController) RemoveApplicationDomain(f fuego.ContextWithBody[Remov
 	// Remove domain from database
 	err = c.storage.RemoveApplicationDomain(appID, data.Domain)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to remove domain", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to remove domain", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -231,9 +231,9 @@ func (c *DeployController) RemoveApplicationDomain(f fuego.ContextWithBody[Remov
 
 	orgCtx := context.WithValue(f.Request().Context(), shared_types.OrganizationIDKey, organizationID.String())
 	if err := caddy.RemoveDomainsWithRetry(orgCtx, nil, &c.logger, []string{data.Domain}); err != nil {
-		c.logger.Log(logger.Warning, "failed to remove domain from proxy, enqueueing for retry", err.Error())
+		c.logger.Log(logger.Warning, "deploy: failed to remove domain from proxy, enqueueing for retry", err.Error())
 		if enqErr := caddy.EnqueuePendingRemoval(organizationID, data.Domain); enqErr != nil {
-			c.logger.Log(logger.Error, "failed to enqueue pending removal", enqErr.Error())
+			c.logger.Log(logger.Error, "deploy: failed to enqueue pending removal", enqErr.Error())
 		}
 	}
 
@@ -284,9 +284,9 @@ func (c *DeployController) syncApplicationDomains(appID uuid.UUID, organizationI
 			}
 			orgCtx := context.WithValue(c.ctx, shared_types.OrganizationIDKey, organizationID.String())
 			if err := caddy.RemoveDomainsWithRetry(orgCtx, nil, &c.logger, []string{actualDomain}); err != nil {
-				c.logger.Log(logger.Warning, "failed to remove domain from proxy, enqueueing for retry", err.Error())
+				c.logger.Log(logger.Warning, "deploy: failed to remove domain from proxy, enqueueing for retry", err.Error())
 				if enqErr := caddy.EnqueuePendingRemoval(organizationID, actualDomain); enqErr != nil {
-					c.logger.Log(logger.Error, "failed to enqueue pending removal", enqErr.Error())
+					c.logger.Log(logger.Error, "deploy: failed to enqueue pending removal", enqErr.Error())
 				}
 			}
 		}
@@ -320,7 +320,7 @@ func (c *DeployController) syncApplicationDomains(appID uuid.UUID, organizationI
 				if app.BuildPack != shared_types.DockerCompose {
 					port, portErr = resolveDockerPublishedPort(orgCtx, app.Name)
 					if portErr != nil {
-						c.logger.Log(logger.Warning, fmt.Sprintf("failed to resolve port for %s, skipping domain routing: %v", app.Name, portErr), "")
+						c.logger.Log(logger.Warning, fmt.Sprintf("deploy: failed to resolve port for %s, skipping domain routing: %v", app.Name, portErr), "")
 					}
 				}
 				if port > 0 {
@@ -369,9 +369,9 @@ func (c *DeployController) syncComposeApplicationDomains(appID uuid.UUID, organi
 			}
 			orgCtx := context.WithValue(c.ctx, shared_types.OrganizationIDKey, organizationID.String())
 			if err := caddy.RemoveDomainsWithRetry(orgCtx, nil, &c.logger, []string{actualDomain}); err != nil {
-				c.logger.Log(logger.Warning, "failed to remove domain from proxy, enqueueing for retry", err.Error())
+				c.logger.Log(logger.Warning, "deploy: failed to remove domain from proxy, enqueueing for retry", err.Error())
 				if enqErr := caddy.EnqueuePendingRemoval(organizationID, actualDomain); enqErr != nil {
-					c.logger.Log(logger.Error, "failed to enqueue pending removal", enqErr.Error())
+					c.logger.Log(logger.Error, "deploy: failed to enqueue pending removal", enqErr.Error())
 				}
 			}
 		}
@@ -463,7 +463,7 @@ func (c *DeployController) tryAddRoutesToProxy(orgID uuid.UUID, routes []caddy.D
 	}
 	orgCtx := context.WithValue(c.ctx, shared_types.OrganizationIDKey, orgID.String())
 	if err := caddy.AddDomainsWithRetry(orgCtx, nil, &c.logger, routes); err != nil {
-		c.logger.Log(logger.Warning, "failed to add domains to proxy, will be synced on next deploy", err.Error())
+		c.logger.Log(logger.Warning, "deploy: failed to add domains to proxy, will be synced on next deploy", err.Error())
 	}
 }
 
@@ -472,7 +472,7 @@ func (c *DeployController) buildProxyRoutes(orgID uuid.UUID, app shared_types.Ap
 
 	upstreamHost, err := resolveSSHUpstreamHost(orgCtx)
 	if err != nil {
-		c.logger.Log(logger.Warning, "skipping proxy update: cannot resolve upstream host", err.Error())
+		c.logger.Log(logger.Warning, "deploy: skipping proxy update: cannot resolve upstream host", err.Error())
 		return nil
 	}
 
@@ -488,7 +488,7 @@ func (c *DeployController) buildProxyRoutes(orgID uuid.UUID, app shared_types.Ap
 	} else {
 		port, err = resolveDockerPublishedPort(orgCtx, app.Name)
 		if err != nil {
-			c.logger.Log(logger.Warning, "skipping proxy update: cannot resolve published port", err.Error())
+			c.logger.Log(logger.Warning, "deploy: skipping proxy update: cannot resolve published port", err.Error())
 			return nil
 		}
 	}
@@ -583,7 +583,7 @@ func (c *DeployController) GetComposeServices(f fuego.ContextNoBody) (*types.Com
 
 	services, err := c.storage.GetComposeServices(appID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to get compose services", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to get compose services", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/application_labels.go
+++ b/api/internal/features/deploy/controller/application_labels.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -17,7 +18,7 @@ type UpdateLabelsRequest struct {
 func (c *DeployController) UpdateApplicationLabels(f fuego.ContextWithBody[UpdateLabelsRequest]) (*types.LabelsResponse, error) {
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -26,7 +27,7 @@ func (c *DeployController) UpdateApplicationLabels(f fuego.ContextWithBody[Updat
 
 	applicationID := f.QueryParam("id")
 	if applicationID == "" {
-		c.logger.Log(logger.Error, "application id is required", "")
+		c.logger.Log(logger.Error, "deploy: application id is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: "application ID is required",
 		}
@@ -34,7 +35,7 @@ func (c *DeployController) UpdateApplicationLabels(f fuego.ContextWithBody[Updat
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -42,7 +43,7 @@ func (c *DeployController) UpdateApplicationLabels(f fuego.ContextWithBody[Updat
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
@@ -50,16 +51,23 @@ func (c *DeployController) UpdateApplicationLabels(f fuego.ContextWithBody[Updat
 
 	appID, err := uuid.Parse(applicationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "invalid application id", err.Error())
+		c.logger.Log(logger.Error, "deploy: invalid application id", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
+	logData := deployRequestData(f.Request(), user)
+	if logData == "" {
+		logData = fmt.Sprintf("application_id=%s", appID.String())
+	} else {
+		logData = fmt.Sprintf("%s application_id=%s", logData, appID.String())
+	}
+
 	err = c.service.UpdateApplicationLabels(appID, data.Labels, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: UpdateApplicationLabels: %v", err), logData)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/application_servers.go
+++ b/api/internal/features/deploy/controller/application_servers.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,7 +16,7 @@ import (
 func (c *DeployController) GetApplicationServers(f fuego.ContextNoBody) (*types.ApplicationServersResponse, error) {
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -23,7 +24,7 @@ func (c *DeployController) GetApplicationServers(f fuego.ContextNoBody) (*types.
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
@@ -32,7 +33,7 @@ func (c *DeployController) GetApplicationServers(f fuego.ContextNoBody) (*types.
 	appIDStr := f.QueryParam("id")
 	appID, err := uuid.Parse(appIDStr)
 	if err != nil {
-		c.logger.Log(logger.Error, "invalid application id", err.Error())
+		c.logger.Log(logger.Error, "deploy: invalid application id", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: "invalid application id",
 			Err:    err,
@@ -40,15 +41,22 @@ func (c *DeployController) GetApplicationServers(f fuego.ContextNoBody) (*types.
 	}
 
 	if _, err := c.storage.GetApplicationById(appID.String(), organizationID); err != nil {
-		c.logger.Log(logger.Error, "application not found or not authorized", err.Error())
+		c.logger.Log(logger.Error, "deploy: application not found or not authorized", err.Error())
 		return nil, fuego.NotFoundError{
 			Detail: "application not found",
 		}
 	}
 
+	logData := deployRequestData(f.Request(), user)
+	if logData == "" {
+		logData = fmt.Sprintf("application_id=%s", appID.String())
+	} else {
+		logData = fmt.Sprintf("%s application_id=%s", logData, appID.String())
+	}
+
 	servers, err := c.storage.GetApplicationServers(appID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: GetApplicationServers: %v", err), logData)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -67,7 +75,7 @@ func (c *DeployController) GetApplicationServers(f fuego.ContextNoBody) (*types.
 func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.SetApplicationServersRequest]) (*types.ApplicationServersResponse, error) {
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -75,7 +83,7 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
@@ -83,7 +91,7 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -91,7 +99,7 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 	}
 
 	if len(data.ServerIDs) == 0 {
-		c.logger.Log(logger.Error, "server_ids is required", "")
+		c.logger.Log(logger.Error, "deploy: server_ids is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrAtLeastOneServerRequired.Error(),
 			Err:    types.ErrAtLeastOneServerRequired,
@@ -107,7 +115,7 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 			}
 		}
 		if !found {
-			c.logger.Log(logger.Error, "primary_server_id must be in server_ids", "")
+			c.logger.Log(logger.Error, "deploy: primary_server_id must be in server_ids", "")
 			return nil, fuego.BadRequestError{
 				Detail: "primary_server_id must be one of the provided server_ids",
 			}
@@ -115,14 +123,22 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 	}
 
 	if _, err := c.storage.GetApplicationById(data.ApplicationID.String(), organizationID); err != nil {
-		c.logger.Log(logger.Error, "application not found or not authorized", err.Error())
+		c.logger.Log(logger.Error, "deploy: application not found or not authorized", err.Error())
 		return nil, fuego.NotFoundError{
 			Detail: "application not found",
 		}
 	}
 
+	setServersLogCtx := deployRequestData(f.Request(), user)
+	appIDStr := data.ApplicationID.String()
+	if setServersLogCtx == "" {
+		setServersLogCtx = fmt.Sprintf("application_id=%s", appIDStr)
+	} else {
+		setServersLogCtx = fmt.Sprintf("%s application_id=%s", setServersLogCtx, appIDStr)
+	}
+
 	if err := c.storage.SetApplicationServers(data.ApplicationID, data.ServerIDs, data.PrimaryServerID, data.RoutingStrategy); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: SetApplicationServers: %v", err), setServersLogCtx)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -131,7 +147,7 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 	}
 
 	if reconcileErr := caddy.EnqueueReconcile(organizationID); reconcileErr != nil {
-		c.logger.Log(logger.Error, "failed to enqueue route sync after server change", reconcileErr.Error())
+		c.logger.Log(logger.Error, "deploy: failed to enqueue route sync after server change", reconcileErr.Error())
 		return nil, fuego.HTTPError{
 			Err:    reconcileErr,
 			Detail: "failed to enqueue route synchronization: " + reconcileErr.Error(),
@@ -141,7 +157,7 @@ func (c *DeployController) SetApplicationServers(f fuego.ContextWithBody[types.S
 
 	servers, err := c.storage.GetApplicationServers(data.ApplicationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to reload application servers", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to reload application servers", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/artifacts.go
+++ b/api/internal/features/deploy/controller/artifacts.go
@@ -29,7 +29,7 @@ func (c *DeployController) ListArtifacts(f fuego.ContextNoBody) (*types.Artifact
 
 	artifacts, err := c.service.ListArtifacts(appID, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, "Failed to list artifacts: "+err.Error(), "")
+		c.logger.Log(logger.Error, "deploy: Failed to list artifacts: "+err.Error(), "")
 		if errors.Is(err, types.ErrPermissionDenied) {
 			return nil, fuego.ForbiddenError{Detail: "permission denied"}
 		}
@@ -64,7 +64,7 @@ func (c *DeployController) GetArtifactDownloadURL(f fuego.ContextNoBody) (*types
 
 	url, err := c.service.GetArtifactDownloadURL(f.Context(), deploymentID, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, "Failed to get artifact download URL: "+err.Error(), "")
+		c.logger.Log(logger.Error, "deploy: Failed to get artifact download URL: "+err.Error(), "")
 		if errors.Is(err, types.ErrPermissionDenied) {
 			return nil, fuego.ForbiddenError{Detail: "permission denied"}
 		}
@@ -109,7 +109,7 @@ func (c *DeployController) DeleteArtifact(f fuego.ContextNoBody) (*types.Artifac
 	}
 
 	if err := c.service.DeleteArtifact(f.Context(), deploymentID, orgID); err != nil {
-		c.logger.Log(logger.Error, "Failed to delete artifact: "+err.Error(), "")
+		c.logger.Log(logger.Error, "deploy: Failed to delete artifact: "+err.Error(), "")
 		if errors.Is(err, types.ErrPermissionDenied) {
 			return nil, fuego.ForbiddenError{Detail: "permission denied"}
 		}

--- a/api/internal/features/deploy/controller/cancel_deployment.go
+++ b/api/internal/features/deploy/controller/cancel_deployment.go
@@ -14,18 +14,18 @@ import (
 )
 
 func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.CancelDeploymentRequest]) (*types.MessageResponse, error) {
-	c.logger.Log(logger.Info, "starting deployment cancellation", "")
+	c.logger.Log(logger.Info, "deploy: starting deployment cancellation", "")
 
 	data, err := f.Body()
 	if err != nil {
 		if err == io.EOF {
-			c.logger.Log(logger.Error, "empty request body received", "deployment_id is required")
+			c.logger.Log(logger.Error, "deploy: empty request body received", "deployment_id is required")
 			return nil, fuego.BadRequestError{
 				Detail: types.ErrMissingID.Error(),
 				Err:    types.ErrMissingID,
 			}
 		}
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -33,7 +33,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 	}
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -42,7 +42,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "")
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -50,7 +50,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
@@ -58,7 +58,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 
 	deployment, err := c.storage.GetApplicationDeploymentById(data.DeploymentID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, "deployment not found", err.Error())
+		c.logger.Log(logger.Error, "deploy: deployment not found", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrDeploymentNotRunning.Error(),
 			Err:    types.ErrDeploymentNotRunning,
@@ -66,7 +66,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 	}
 
 	if deployment.Application == nil || deployment.Application.OrganizationID != organizationID {
-		c.logger.Log(logger.Error, "deployment not owned by caller", fmt.Sprintf("deployment=%s org=%s", deployment.ID, organizationID))
+		c.logger.Log(logger.Error, "deploy: deployment not owned by caller", fmt.Sprintf("deployment=%s org=%s", deployment.ID, organizationID))
 		return nil, fuego.ForbiddenError{
 			Detail: "you do not have permission to cancel this deployment",
 			Err:    types.ErrPermissionDenied,
@@ -74,7 +74,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 	}
 
 	if deployment.Status == nil {
-		c.logger.Log(logger.Error, "deployment status missing", data.DeploymentID.String())
+		c.logger.Log(logger.Error, "deploy: deployment status missing", data.DeploymentID.String())
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrDeploymentNotCancellable.Error(),
 			Err:    types.ErrDeploymentNotCancellable,
@@ -83,7 +83,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 
 	status := deployment.Status.Status
 	if status != shared_types.Cloning && status != shared_types.Building && status != shared_types.Deploying && status != shared_types.Started {
-		c.logger.Log(logger.Error, "deployment not in cancellable state", string(status))
+		c.logger.Log(logger.Error, "deploy: deployment not in cancellable state", string(status))
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrDeploymentNotCancellable.Error(),
 			Err:    types.ErrDeploymentNotCancellable,
@@ -91,7 +91,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 	}
 
 	if err := c.taskService.CancelDeployment(data.DeploymentID.String()); err != nil {
-		c.logger.Log(logger.Error, "failed to cancel deployment", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to cancel deployment", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -99,7 +99,7 @@ func (c *DeployController) CancelDeployment(f fuego.ContextWithBody[types.Cancel
 		}
 	}
 
-	c.logger.Log(logger.Info, "deployment cancelled successfully", data.DeploymentID.String())
+	c.logger.Log(logger.Info, "deploy: deployment cancelled successfully", data.DeploymentID.String())
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Deployment cancellation initiated",

--- a/api/internal/features/deploy/controller/delete_application.go
+++ b/api/internal/features/deploy/controller/delete_application.go
@@ -12,28 +12,28 @@ import (
 )
 
 func (c *DeployController) DeleteApplication(f fuego.ContextWithBody[types.DeleteDeploymentRequest]) (*types.MessageResponse, error) {
-	c.logger.Log(logger.Info, "starting application deletion process", "")
+	c.logger.Log(logger.Info, "deploy: starting application deletion process", "")
 
 	data, err := f.Body()
 	if err != nil {
 		if err == io.EOF {
-			c.logger.Log(logger.Error, "empty request body received", "id is required for deletion")
+			c.logger.Log(logger.Error, "deploy: empty request body received", "id is required for deletion")
 			return nil, fuego.BadRequestError{
 				Detail: types.ErrMissingID.Error(),
 				Err:    types.ErrMissingID,
 			}
 		}
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "id: "+data.ID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -42,7 +42,7 @@ func (c *DeployController) DeleteApplication(f fuego.ContextWithBody[types.Delet
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -50,17 +50,17 @@ func (c *DeployController) DeleteApplication(f fuego.ContextWithBody[types.Delet
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to delete application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to delete application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
 
 	// err = c.service.DeleteDeployment(&data, user.ID, organizationID)
 	// if err != nil {
-	// 	c.logger.Log(logger.Error, "failed to delete application", "id: "+data.ID.String()+", error: "+err.Error())
+	// 	c.logger.Log(logger.Error, "deploy: failed to delete application", "id: "+data.ID.String()+", error: "+err.Error())
 	// 	return nil, fuego.HTTPError{
 	// 		Err:    err,
 	// 		Status: http.StatusInternalServerError,
@@ -69,7 +69,7 @@ func (c *DeployController) DeleteApplication(f fuego.ContextWithBody[types.Delet
 
 	err = c.taskService.DeleteDeployment(f.Request().Context(), &data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to delete application", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to delete application", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -77,7 +77,7 @@ func (c *DeployController) DeleteApplication(f fuego.ContextWithBody[types.Delet
 		}
 	}
 
-	c.logger.Log(logger.Info, "application deleted successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: application deleted successfully", "id: "+data.ID.String())
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Application deleted successfully",

--- a/api/internal/features/deploy/controller/deploy_log.go
+++ b/api/internal/features/deploy/controller/deploy_log.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+)
+
+func (c *DeployController) logDeployDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("deploy: %s: %s", handler, reason), data)
+}
+
+func deployRequestData(r *http.Request, user *shared_types.User) string {
+	orgID := utils.GetOrganizationID(r)
+	if user != nil && orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+	}
+	if user != nil {
+		return fmt.Sprintf("user_id=%s", user.ID)
+	}
+	if orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s", orgID)
+	}
+	return ""
+}

--- a/api/internal/features/deploy/controller/get_application.go
+++ b/api/internal/features/deploy/controller/get_application.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,7 +16,7 @@ func (c *DeployController) GetApplicationById(f fuego.ContextNoBody) (*types.App
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -23,15 +24,24 @@ func (c *DeployController) GetApplicationById(f fuego.ContextNoBody) (*types.App
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
+	data := deployRequestData(f.Request(), user)
+	if id != "" {
+		if data == "" {
+			data = fmt.Sprintf("id=%s", id)
+		} else {
+			data = fmt.Sprintf("%s id=%s", data, id)
+		}
+	}
+
 	application, err := c.service.GetApplicationById(id, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: GetApplicationById: %v", err), data)
 		if err.Error() == "application not found" {
 			return nil, fuego.NotFoundError{
 				Detail: err.Error(),

--- a/api/internal/features/deploy/controller/get_application_deployments.go
+++ b/api/internal/features/deploy/controller/get_application_deployments.go
@@ -20,7 +20,7 @@ func (c *DeployController) GetApplicationDeployments(f fuego.ContextNoBody) (*ty
 	}
 
 	if id == "" {
-		c.logger.Log(logger.Error, "application ID is required", "")
+		c.logger.Log(logger.Error, "deploy: application ID is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: "application ID is required",
 		}
@@ -36,7 +36,7 @@ func (c *DeployController) GetApplicationDeployments(f fuego.ContextNoBody) (*ty
 
 	applicationID, err := uuid.Parse(id)
 	if err != nil {
-		c.logger.Log(logger.Error, "Invalid application ID", err.Error())
+		c.logger.Log(logger.Error, "deploy: Invalid application ID", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -55,7 +55,7 @@ func (c *DeployController) GetApplicationDeployments(f fuego.ContextNoBody) (*ty
 
 	deployments, totalCount, err := c.service.GetApplicationDeployments(applicationID, pageInt, pageSizeInt)
 	if err != nil {
-		c.logger.Log(logger.Error, "Failed to get application deployments", err.Error())
+		c.logger.Log(logger.Error, "deploy: Failed to get application deployments", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/get_applications.go
+++ b/api/internal/features/deploy/controller/get_applications.go
@@ -49,7 +49,7 @@ func (c *DeployController) GetApplications(f fuego.ContextNoBody) (*types.ListAp
 		}
 	}
 
-	logData := deployRequestData(w, r, user)
+	logData := deployRequestData(r, user)
 
 	applications, totalCount, err := c.service.GetApplications(page, pageSize, sortBy, sortDirection, organizationID, serverID)
 	if err != nil {

--- a/api/internal/features/deploy/controller/get_applications.go
+++ b/api/internal/features/deploy/controller/get_applications.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -18,7 +19,7 @@ func (c *DeployController) GetApplications(f fuego.ContextNoBody) (*types.ListAp
 	sortDirection := r.URL.Query().Get("sort_direction")
 	organizationID := utils.GetOrganizationID(r)
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
@@ -35,7 +36,7 @@ func (c *DeployController) GetApplications(f fuego.ContextNoBody) (*types.ListAp
 	user := utils.GetUser(w, r)
 
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -48,9 +49,11 @@ func (c *DeployController) GetApplications(f fuego.ContextNoBody) (*types.ListAp
 		}
 	}
 
+	logData := deployRequestData(w, r, user)
+
 	applications, totalCount, err := c.service.GetApplications(page, pageSize, sortBy, sortDirection, organizationID, serverID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: GetApplications: %v", err), logData)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/get_deployment_by_id.go
+++ b/api/internal/features/deploy/controller/get_deployment_by_id.go
@@ -1,19 +1,28 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/utils"
 )
 
 func (c *DeployController) GetDeploymentById(f fuego.ContextNoBody) (*types.DeploymentResponse, error) {
 	deploymentID := f.PathParam("deployment_id")
+	w, r := f.Response(), f.Request()
+	data := deployRequestData(r, utils.GetUser(w, r))
+	if data == "" && deploymentID != "" {
+		data = fmt.Sprintf("deployment_id=%s", deploymentID)
+	} else if deploymentID != "" {
+		data = fmt.Sprintf("%s deployment_id=%s", data, deploymentID)
+	}
 
 	deployment, err := c.service.GetDeploymentById(deploymentID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: GetDeploymentById: %v", err), data)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/get_deployment_logs.go
+++ b/api/internal/features/deploy/controller/get_deployment_logs.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -63,7 +64,7 @@ func (c *DeployController) GetDeploymentLogs(f fuego.ContextNoBody) (*types.Logs
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -71,15 +72,24 @@ func (c *DeployController) GetDeploymentLogs(f fuego.ContextNoBody) (*types.Logs
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
+	logData := deployRequestData(f.Request(), user)
+	if deploymentID != "" {
+		if logData == "" {
+			logData = fmt.Sprintf("deployment_id=%s", deploymentID)
+		} else {
+			logData = fmt.Sprintf("%s deployment_id=%s", logData, deploymentID)
+		}
+	}
+
 	logs, totalCount, err := c.service.GetDeploymentLogs(f.Request().Context(), deploymentID, page, pageSize, level, startTime, endTime, searchTerm)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: GetDeploymentLogs: %v", err), logData)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/get_logs.go
+++ b/api/internal/features/deploy/controller/get_logs.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -63,7 +64,7 @@ func (c *DeployController) GetLogs(f fuego.ContextNoBody) (*types.LogsResponse, 
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user not found", "")
+		c.logger.Log(logger.Error, "deploy: user not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -71,15 +72,24 @@ func (c *DeployController) GetLogs(f fuego.ContextNoBody) (*types.LogsResponse, 
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
+	logData := deployRequestData(f.Request(), user)
+	if applicationID != "" {
+		if logData == "" {
+			logData = fmt.Sprintf("application_id=%s", applicationID)
+		} else {
+			logData = fmt.Sprintf("%s application_id=%s", logData, applicationID)
+		}
+	}
+
 	logs, totalCount, err := c.service.GetLogs(applicationID, page, pageSize, level, startTime, endTime, searchTerm)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: GetLogs: %v", err), logData)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/handle_create_project.go
+++ b/api/internal/features/deploy/controller/handle_create_project.go
@@ -13,21 +13,21 @@ import (
 // HandleCreateProject creates a new project (application) without triggering deployment.
 // This allows users to save configuration as a draft and deploy later.
 func (c *DeployController) HandleCreateProject(f fuego.ContextWithBody[types.CreateProjectRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "creating project without deployment", "")
+	c.logger.Log(logger.Info, "deploy: creating project without deployment", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "name: "+data.Name)
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "name: "+data.Name)
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "name: "+data.Name+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "name: "+data.Name+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -36,7 +36,7 @@ func (c *DeployController) HandleCreateProject(f fuego.ContextWithBody[types.Cre
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "name: "+data.Name)
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "name: "+data.Name)
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -44,17 +44,17 @@ func (c *DeployController) HandleCreateProject(f fuego.ContextWithBody[types.Cre
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "name: "+data.Name)
+		c.logger.Log(logger.Error, "deploy: organization not found", "name: "+data.Name)
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to create project", "name: "+data.Name+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to create project", "name: "+data.Name+", user_id: "+user.ID.String())
 
 	application, err := c.service.CreateProject(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to create project", "name: "+data.Name+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to create project", "name: "+data.Name+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -62,7 +62,7 @@ func (c *DeployController) HandleCreateProject(f fuego.ContextWithBody[types.Cre
 		}
 	}
 
-	c.logger.Log(logger.Info, "project created successfully", "name: "+data.Name)
+	c.logger.Log(logger.Info, "deploy: project created successfully", "name: "+data.Name)
 	return &types.ApplicationResponse{
 		Status:  "success",
 		Message: "Project created successfully. You can deploy it when ready.",

--- a/api/internal/features/deploy/controller/handle_deploy.go
+++ b/api/internal/features/deploy/controller/handle_deploy.go
@@ -11,21 +11,21 @@ import (
 )
 
 func (c *DeployController) HandleDeploy(f fuego.ContextWithBody[types.CreateDeploymentRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "starting deployment process", "")
+	c.logger.Log(logger.Info, "deploy: starting deployment process", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "name: "+data.Name)
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "name: "+data.Name)
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "name: "+data.Name+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "name: "+data.Name+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -34,7 +34,7 @@ func (c *DeployController) HandleDeploy(f fuego.ContextWithBody[types.CreateDepl
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "name: "+data.Name)
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "name: "+data.Name)
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -42,17 +42,17 @@ func (c *DeployController) HandleDeploy(f fuego.ContextWithBody[types.CreateDepl
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "name: "+data.Name)
+		c.logger.Log(logger.Error, "deploy: organization not found", "name: "+data.Name)
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to create deployment", "name: "+data.Name+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to create deployment", "name: "+data.Name+", user_id: "+user.ID.String())
 
 	application, err := c.taskService.CreateDeploymentTask(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to create deployment", "name: "+data.Name+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to create deployment", "name: "+data.Name+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -62,14 +62,14 @@ func (c *DeployController) HandleDeploy(f fuego.ContextWithBody[types.CreateDepl
 
 	// application, err := c.service.CreateDeployment(&data, user.ID, organizationID)
 	// if err != nil {
-	// 	c.logger.Log(logger.Error, "failed to create deployment", "name: "+data.Name+", error: "+err.Error())
+	// 	c.logger.Log(logger.Error, "deploy: failed to create deployment", "name: "+data.Name+", error: "+err.Error())
 	// 	return nil, fuego.HTTPError{
 	// 		Err:    err,
 	// 		Status: http.StatusInternalServerError,
 	// 	}
 	// }
 
-	c.logger.Log(logger.Info, "deployment created successfully", "name: "+data.Name)
+	c.logger.Log(logger.Info, "deploy: deployment created successfully", "name: "+data.Name)
 	return &types.ApplicationResponse{
 		Status:  "success",
 		Message: "Deployment created successfully",

--- a/api/internal/features/deploy/controller/handle_deploy_project.go
+++ b/api/internal/features/deploy/controller/handle_deploy_project.go
@@ -12,21 +12,21 @@ import (
 
 // HandleDeployProject triggers deployment of an existing project (application) that was saved as a draft.
 func (c *DeployController) HandleDeployProject(f fuego.ContextWithBody[types.DeployProjectRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "deploying existing project", "")
+	c.logger.Log(logger.Info, "deploy: deploying existing project", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "id: "+data.ID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -35,7 +35,7 @@ func (c *DeployController) HandleDeployProject(f fuego.ContextWithBody[types.Dep
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -43,17 +43,17 @@ func (c *DeployController) HandleDeployProject(f fuego.ContextWithBody[types.Dep
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: organization not found", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to deploy project", "id: "+data.ID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to deploy project", "id: "+data.ID.String()+", user_id: "+user.ID.String())
 
 	application, err := c.taskService.DeployProject(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to deploy project", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to deploy project", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -61,7 +61,7 @@ func (c *DeployController) HandleDeployProject(f fuego.ContextWithBody[types.Dep
 		}
 	}
 
-	c.logger.Log(logger.Info, "project deployment started successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: project deployment started successfully", "id: "+data.ID.String())
 	return &types.ApplicationResponse{
 		Status:  "success",
 		Message: "Deployment started successfully",

--- a/api/internal/features/deploy/controller/handle_duplicate_project.go
+++ b/api/internal/features/deploy/controller/handle_duplicate_project.go
@@ -13,21 +13,21 @@ import (
 // HandleDuplicateProject duplicates an existing project with a different environment.
 // All configurations are copied and a new project is created in draft status.
 func (c *DeployController) HandleDuplicateProject(f fuego.ContextWithBody[types.DuplicateProjectRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "duplicating project", "")
+	c.logger.Log(logger.Info, "deploy: duplicating project", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "source_id: "+data.SourceProjectID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "source_id: "+data.SourceProjectID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -36,7 +36,7 @@ func (c *DeployController) HandleDuplicateProject(f fuego.ContextWithBody[types.
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "")
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -44,17 +44,17 @@ func (c *DeployController) HandleDuplicateProject(f fuego.ContextWithBody[types.
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to duplicate project", "source_id: "+data.SourceProjectID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to duplicate project", "source_id: "+data.SourceProjectID.String()+", user_id: "+user.ID.String())
 
 	application, err := c.service.DuplicateProject(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to duplicate project", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to duplicate project", err.Error())
 
 		if err == types.ErrApplicationNotFound {
 			return nil, fuego.NotFoundError{
@@ -75,7 +75,7 @@ func (c *DeployController) HandleDuplicateProject(f fuego.ContextWithBody[types.
 		}
 	}
 
-	c.logger.Log(logger.Info, "project duplicated successfully", "new_id: "+application.ID.String())
+	c.logger.Log(logger.Info, "deploy: project duplicated successfully", "new_id: "+application.ID.String())
 
 	return &types.ApplicationResponse{
 		Status:  "success",
@@ -88,7 +88,7 @@ func (c *DeployController) HandleDuplicateProject(f fuego.ContextWithBody[types.
 func (c *DeployController) HandleGetProjectFamily(f fuego.ContextNoBody) (*types.ProjectFamilyResponse, error) {
 	familyIDStr := f.QueryParam("family_id")
 	if familyIDStr == "" {
-		c.logger.Log(logger.Error, "family_id is required", "")
+		c.logger.Log(logger.Error, "deploy: family_id is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrMissingID.Error(),
 			Err:    types.ErrMissingID,
@@ -97,7 +97,7 @@ func (c *DeployController) HandleGetProjectFamily(f fuego.ContextNoBody) (*types
 
 	familyID, err := uuid.Parse(familyIDStr)
 	if err != nil {
-		c.logger.Log(logger.Error, "invalid family_id", err.Error())
+		c.logger.Log(logger.Error, "deploy: invalid family_id", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -106,7 +106,7 @@ func (c *DeployController) HandleGetProjectFamily(f fuego.ContextNoBody) (*types
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "")
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -114,17 +114,17 @@ func (c *DeployController) HandleGetProjectFamily(f fuego.ContextNoBody) (*types
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "getting project family", "family_id: "+familyID.String())
+	c.logger.Log(logger.Info, "deploy: getting project family", "family_id: "+familyID.String())
 
 	projects, err := c.service.GetProjectFamily(familyID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to get project family", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to get project family", err.Error())
 
 		if err == types.ErrProjectFamilyNotFound {
 			return nil, fuego.NotFoundError{
@@ -153,7 +153,7 @@ func (c *DeployController) HandleGetProjectFamily(f fuego.ContextNoBody) (*types
 func (c *DeployController) HandleGetEnvironmentsInFamily(f fuego.ContextNoBody) (*types.EnvironmentsInFamilyResponse, error) {
 	familyIDStr := f.QueryParam("family_id")
 	if familyIDStr == "" {
-		c.logger.Log(logger.Error, "family_id is required", "")
+		c.logger.Log(logger.Error, "deploy: family_id is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrMissingID.Error(),
 			Err:    types.ErrMissingID,
@@ -162,7 +162,7 @@ func (c *DeployController) HandleGetEnvironmentsInFamily(f fuego.ContextNoBody) 
 
 	familyID, err := uuid.Parse(familyIDStr)
 	if err != nil {
-		c.logger.Log(logger.Error, "invalid family_id", err.Error())
+		c.logger.Log(logger.Error, "deploy: invalid family_id", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -171,7 +171,7 @@ func (c *DeployController) HandleGetEnvironmentsInFamily(f fuego.ContextNoBody) 
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "")
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -179,17 +179,17 @@ func (c *DeployController) HandleGetEnvironmentsInFamily(f fuego.ContextNoBody) 
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "getting environments in family", "family_id: "+familyID.String())
+	c.logger.Log(logger.Info, "deploy: getting environments in family", "family_id: "+familyID.String())
 
 	environments, err := c.service.GetEnvironmentsInFamily(familyID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to get environments in family", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to get environments in family", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -209,21 +209,21 @@ func (c *DeployController) HandleGetEnvironmentsInFamily(f fuego.ContextNoBody) 
 // HandleAddApplicationToFamily adds a new application to an existing family (or creates a new family).
 // This is used for multi-application monorepo setups.
 func (c *DeployController) HandleAddApplicationToFamily(f fuego.ContextWithBody[types.AddApplicationToFamilyRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "adding application to family", "")
+	c.logger.Log(logger.Info, "deploy: adding application to family", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "name: "+data.Name)
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "name: "+data.Name)
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -233,7 +233,7 @@ func (c *DeployController) HandleAddApplicationToFamily(f fuego.ContextWithBody[
 	// Get user and organization from context (set by AuthMiddleware)
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "")
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -241,17 +241,17 @@ func (c *DeployController) HandleAddApplicationToFamily(f fuego.ContextWithBody[
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "")
+		c.logger.Log(logger.Error, "deploy: organization not found", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to add application to family", "name: "+data.Name+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to add application to family", "name: "+data.Name+", user_id: "+user.ID.String())
 
 	application, err := c.service.AddApplicationToFamily(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to add application to family", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to add application to family", err.Error())
 
 		if err == types.ErrProjectFamilyNotFound {
 			return nil, fuego.NotFoundError{
@@ -267,7 +267,7 @@ func (c *DeployController) HandleAddApplicationToFamily(f fuego.ContextWithBody[
 		}
 	}
 
-	c.logger.Log(logger.Info, "application added to family successfully", "id: "+application.ID.String())
+	c.logger.Log(logger.Info, "deploy: application added to family successfully", "id: "+application.ID.String())
 
 	return &types.ApplicationResponse{
 		Status:  "success",

--- a/api/internal/features/deploy/controller/handle_github_webhook.go
+++ b/api/internal/features/deploy/controller/handle_github_webhook.go
@@ -51,12 +51,12 @@ func verifyWebhookSignature(payload []byte, signature, secret string) bool {
 }
 
 func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.MessageResponse, error) {
-	c.logger.Log(logger.Info, "handling github webhook", "")
+	c.logger.Log(logger.Info, "deploy: handling github webhook", "")
 
 	deliveryID := f.Request().Header.Get("X-GitHub-Delivery")
 	if deliveryID != "" {
 		if _, loaded := processedDeliveries.LoadOrStore(deliveryID, time.Now()); loaded {
-			c.logger.Log(logger.Info, "duplicate webhook delivery, skipping", deliveryID)
+			c.logger.Log(logger.Info, "deploy: duplicate webhook delivery, skipping", deliveryID)
 			return &types.MessageResponse{
 				Status:  "success",
 				Message: "Duplicate delivery ignored",
@@ -66,7 +66,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	payload, err := io.ReadAll(f.Request().Body)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read webhook payload", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read webhook payload", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -75,7 +75,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	signature := f.Request().Header.Get("X-Hub-Signature-256")
 	if signature == "" {
-		c.logger.Log(logger.Error, "missing webhook signature", "")
+		c.logger.Log(logger.Error, "deploy: missing webhook signature", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "missing webhook signature",
 			Err:    fmt.Errorf("missing webhook signature"),
@@ -84,7 +84,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	webhookSecret := config.AppConfig.GitHub.WebhookSecret
 	if !verifyWebhookSignature(payload, signature, webhookSecret) {
-		c.logger.Log(logger.Error, "invalid webhook signature", "")
+		c.logger.Log(logger.Error, "deploy: invalid webhook signature", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "invalid webhook signature",
 			Err:    fmt.Errorf("invalid webhook signature"),
@@ -93,7 +93,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	eventType := f.Request().Header.Get("X-GitHub-Event")
 	if eventType != "push" {
-		c.logger.Log(logger.Info, "ignoring non-push event", eventType)
+		c.logger.Log(logger.Info, "deploy: ignoring non-push event", eventType)
 		return &types.MessageResponse{
 			Status:  "success",
 			Message: "Ignored non-push event",
@@ -102,7 +102,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	var webhookPayload shared_types.WebhookPayload
 	if err := json.Unmarshal(payload, &webhookPayload); err != nil {
-		c.logger.Log(logger.Error, "failed to parse webhook payload", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to parse webhook payload", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -111,7 +111,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	ref := webhookPayload.Ref
 	if !strings.HasPrefix(ref, "refs/heads/") {
-		c.logger.Log(logger.Info, "ignoring non-branch ref", ref)
+		c.logger.Log(logger.Info, "deploy: ignoring non-branch ref", ref)
 		return &types.MessageResponse{
 			Status:  "success",
 			Message: fmt.Sprintf("Ignored ref %s", ref),
@@ -120,7 +120,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 
 	err = c.taskService.EnqueueWebhookTask(webhookPayload)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to enqueue webhook task", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to enqueue webhook task", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -128,7 +128,7 @@ func (c *DeployController) HandleGithubWebhook(f fuego.ContextNoBody) (*types.Me
 		}
 	}
 
-	c.logger.Log(logger.Info, "github webhook handled successfully", webhookPayload.Repository.FullName)
+	c.logger.Log(logger.Info, "deploy: github webhook handled successfully", webhookPayload.Repository.FullName)
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Github webhook handled successfully",

--- a/api/internal/features/deploy/controller/handle_recover.go
+++ b/api/internal/features/deploy/controller/handle_recover.go
@@ -12,11 +12,11 @@ import (
 )
 
 func (c *DeployController) HandleRecover(f fuego.ContextWithBody[types.RecoverRequest]) (*types.RecoverResponse, error) {
-	c.logger.Log(logger.Info, "starting application recovery process", "")
+	c.logger.Log(logger.Info, "deploy: starting application recovery process", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -25,7 +25,7 @@ func (c *DeployController) HandleRecover(f fuego.ContextWithBody[types.RecoverRe
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed during recovery", "")
+		c.logger.Log(logger.Error, "deploy: user authentication failed during recovery", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -33,17 +33,17 @@ func (c *DeployController) HandleRecover(f fuego.ContextWithBody[types.RecoverRe
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found during recovery", "")
+		c.logger.Log(logger.Error, "deploy: organization not found during recovery", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "recovering applications", "org_id: "+organizationID.String())
+	c.logger.Log(logger.Info, "deploy: recovering applications", "org_id: "+organizationID.String())
 
 	result, err := c.taskService.RecoverApplications(f.Request().Context(), organizationID, data.ApplicationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "recovery failed", "error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: recovery failed", "error: "+err.Error())
 		if err == types.ErrS3NotConfigured {
 			return nil, fuego.BadRequestError{
 				Detail: err.Error(),
@@ -67,7 +67,7 @@ func (c *DeployController) HandleRecover(f fuego.ContextWithBody[types.RecoverRe
 		msg = "Some applications failed to recover"
 	}
 
-	c.logger.Log(logger.Info, "recovery process finished",
+	c.logger.Log(logger.Info, "deploy: recovery process finished",
 		fmt.Sprintf("recovered: %d, skipped: %d, failed: %d", len(result.Recovered), len(result.Skipped), len(result.Failed)))
 
 	return &types.RecoverResponse{

--- a/api/internal/features/deploy/controller/handle_restart.go
+++ b/api/internal/features/deploy/controller/handle_restart.go
@@ -12,28 +12,28 @@ import (
 )
 
 func (c *DeployController) HandleRestart(f fuego.ContextWithBody[types.RestartDeploymentRequest]) (*types.MessageResponse, error) {
-	c.logger.Log(logger.Info, "starting application restart process", "")
+	c.logger.Log(logger.Info, "deploy: starting application restart process", "")
 
 	data, err := f.Body()
 	if err != nil {
 		if err == io.EOF {
-			c.logger.Log(logger.Error, "empty request body received", "id is required for restart")
+			c.logger.Log(logger.Error, "deploy: empty request body received", "id is required for restart")
 			return nil, fuego.BadRequestError{
 				Detail: types.ErrMissingID.Error(),
 				Err:    types.ErrMissingID,
 			}
 		}
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "id: "+data.ID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -42,24 +42,24 @@ func (c *DeployController) HandleRestart(f fuego.ContextWithBody[types.RestartDe
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to restart application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to restart application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: organization not found", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 	err = c.taskService.RestartDeployment(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to restart application", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to restart application", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -67,7 +67,7 @@ func (c *DeployController) HandleRestart(f fuego.ContextWithBody[types.RestartDe
 		}
 	}
 
-	c.logger.Log(logger.Info, "application restarted successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: application restarted successfully", "id: "+data.ID.String())
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Application restarted successfully",

--- a/api/internal/features/deploy/controller/handle_rollback.go
+++ b/api/internal/features/deploy/controller/handle_rollback.go
@@ -12,28 +12,28 @@ import (
 )
 
 func (c *DeployController) HandleRollback(f fuego.ContextWithBody[types.RollbackDeploymentRequest]) (*types.MessageResponse, error) {
-	c.logger.Log(logger.Info, "starting application rollback process", "")
+	c.logger.Log(logger.Info, "deploy: starting application rollback process", "")
 
 	data, err := f.Body()
 	if err != nil {
 		if err == io.EOF {
-			c.logger.Log(logger.Error, "empty request body received", "id is required for rollback")
+			c.logger.Log(logger.Error, "deploy: empty request body received", "id is required for rollback")
 			return nil, fuego.BadRequestError{
 				Detail: types.ErrMissingID.Error(),
 				Err:    types.ErrMissingID,
 			}
 		}
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "id: "+data.ID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -42,7 +42,7 @@ func (c *DeployController) HandleRollback(f fuego.ContextWithBody[types.Rollback
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -50,17 +50,17 @@ func (c *DeployController) HandleRollback(f fuego.ContextWithBody[types.Rollback
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: organization not found", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to rollback application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to rollback application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
 
 	err = c.taskService.RollbackDeployment(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to rollback application", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to rollback application", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -68,7 +68,7 @@ func (c *DeployController) HandleRollback(f fuego.ContextWithBody[types.Rollback
 		}
 	}
 
-	c.logger.Log(logger.Info, "application rolled back successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: application rolled back successfully", "id: "+data.ID.String())
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Application rolled back successfully",

--- a/api/internal/features/deploy/controller/handle_template_deploy.go
+++ b/api/internal/features/deploy/controller/handle_template_deploy.go
@@ -14,16 +14,16 @@ import (
 )
 
 func (c *DeployController) HandleTemplateDeploy(f fuego.ContextWithBody[types.CreateTemplateDeploymentRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "starting template deployment", "")
+	c.logger.Log(logger.Info, "deploy: starting template deployment", "")
 
 	data, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "template deployment validation failed", err.Error())
+		c.logger.Log(logger.Error, "deploy: template deployment validation failed", err.Error())
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -88,7 +88,7 @@ func (c *DeployController) HandleTemplateDeploy(f fuego.ContextWithBody[types.Cr
 
 	application, err := c.taskService.CreateTemplateDeploymentTask(deployReq, user.ID, organizationID, data.TemplateID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to create template deployment", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to create template deployment", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/deploy/controller/init.go
+++ b/api/internal/features/deploy/controller/init.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -40,7 +41,7 @@ func NewDeployController(
 	notifier shared_types.Notifier,
 	extensionLoader shared_storage.ExtensionTemplateLoader,
 ) (*DeployController, error) {
-	deployStorage := storage.DeployStorage{DB: store.DB, Ctx: ctx}
+	deployStorage := storage.DeployStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	github_service := github_service.NewGithubConnectorService(store, ctx, l, &github_storage.GithubConnectorStorage{DB: store.DB, Ctx: ctx, Logger: &l})
 	taskService := tasks.NewTaskService(&deployStorage, l, github_service, store, notifier)
 	taskService.SetupCreateDeploymentQueue()
@@ -59,7 +60,7 @@ func NewDeployController(
 
 	return &DeployController{
 		store:           store,
-		validator:       validation.NewValidator(),
+		validator:       validation.NewValidatorWithLogger(&l),
 		service:         service.NewDeployService(store, ctx, l, &deployStorage),
 		storage:         &deployStorage,
 		ctx:             ctx,
@@ -112,22 +113,23 @@ func (c *DeployController) Service() *service.DeployService {
 //
 //	bool - true if parsing and validation succeed, false otherwise.
 func (c *DeployController) parseAndValidate(w http.ResponseWriter, r *http.Request, req interface{}) bool {
+	data := deployRequestData(r, utils.GetUser(w, r))
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		c.logger.Log(logger.Error, shared_types.ErrFailedToDecodeRequest.Error(), err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("deploy: parseAndValidate: read body: %v", err), data)
 		utils.SendErrorResponse(w, shared_types.ErrFailedToDecodeRequest.Error(), http.StatusBadRequest)
 		return false
 	}
 	defer r.Body.Close()
 
 	if err := c.validator.ParseRequestBody(r, io.NopCloser(bytes.NewReader(body)), req); err != nil {
-		c.logger.Log(logger.Error, shared_types.ErrFailedToDecodeRequest.Error(), err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("deploy: parseAndValidate: decode JSON: %v", err), data)
 		utils.SendErrorResponse(w, shared_types.ErrFailedToDecodeRequest.Error(), http.StatusBadRequest)
 		return false
 	}
 
 	if err := c.validator.ValidateRequest(req); err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("deploy: parseAndValidate: validation: %v", err), data)
 		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return false
 	}

--- a/api/internal/features/deploy/controller/init.go
+++ b/api/internal/features/deploy/controller/init.go
@@ -41,7 +41,7 @@ func NewDeployController(
 	extensionLoader shared_storage.ExtensionTemplateLoader,
 ) (*DeployController, error) {
 	deployStorage := storage.DeployStorage{DB: store.DB, Ctx: ctx}
-	github_service := github_service.NewGithubConnectorService(store, ctx, l, &github_storage.GithubConnectorStorage{DB: store.DB, Ctx: ctx})
+	github_service := github_service.NewGithubConnectorService(store, ctx, l, &github_storage.GithubConnectorStorage{DB: store.DB, Ctx: ctx, Logger: &l})
 	taskService := tasks.NewTaskService(&deployStorage, l, github_service, store, notifier)
 	taskService.SetupCreateDeploymentQueue()
 

--- a/api/internal/features/deploy/controller/preview_compose.go
+++ b/api/internal/features/deploy/controller/preview_compose.go
@@ -31,33 +31,33 @@ func (c *DeployController) PreviewComposeServices(f fuego.ContextWithBody[types.
 	}
 
 	filePath := composeFilePath(data.BasePath, data.DockerfilePath)
-	c.logger.Log(logger.Info, "preview-compose: resolved file path", fmt.Sprintf("repo=%s branch=%s basePath=%q dockerfilePath=%q -> filePath=%q", data.Repository, data.Branch, data.BasePath, data.DockerfilePath, filePath))
+	c.logger.Log(logger.Info, "deploy: preview-compose: resolved file path", fmt.Sprintf("repo=%s branch=%s basePath=%q dockerfilePath=%q -> filePath=%q", data.Repository, data.Branch, data.BasePath, data.DockerfilePath, filePath))
 
 	content, err := c.githubService.GetRepositoryFileContent(
 		user.ID.String(), data.Repository, data.Branch, filePath,
 	)
 	if err != nil {
-		c.logger.Log(logger.Warning, "preview-compose: failed to fetch from GitHub", err.Error())
+		c.logger.Log(logger.Warning, "deploy: preview-compose: failed to fetch from GitHub", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
 			Status: http.StatusUnprocessableEntity,
 		}
 	}
-	c.logger.Log(logger.Info, "preview-compose: fetched file", fmt.Sprintf("content length=%d bytes, first 200 chars: %s", len(content), truncate(string(content), 200)))
+	c.logger.Log(logger.Info, "deploy: preview-compose: fetched file", fmt.Sprintf("content length=%d bytes, first 200 chars: %s", len(content), truncate(string(content), 200)))
 
 	parsed, err := tasks.ParseComposeYAML(content)
 	if err != nil {
-		c.logger.Log(logger.Warning, "preview-compose: YAML parse error", err.Error())
+		c.logger.Log(logger.Warning, "deploy: preview-compose: YAML parse error", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
 			Status: http.StatusUnprocessableEntity,
 		}
 	}
-	c.logger.Log(logger.Info, "preview-compose: parsed services", fmt.Sprintf("count=%d", len(parsed)))
+	c.logger.Log(logger.Info, "deploy: preview-compose: parsed services", fmt.Sprintf("count=%d", len(parsed)))
 	for _, p := range parsed {
-		c.logger.Log(logger.Info, "preview-compose: service detail", fmt.Sprintf("name=%s ports=%v", p.ServiceName, p.Ports))
+		c.logger.Log(logger.Info, "deploy: preview-compose: service detail", fmt.Sprintf("name=%s ports=%v", p.ServiceName, p.Ports))
 	}
 
 	var services []types.PreviewComposeService
@@ -72,7 +72,7 @@ func (c *DeployController) PreviewComposeServices(f fuego.ContextWithBody[types.
 		})
 	}
 
-	c.logger.Log(logger.Info, "preview-compose: returning services", fmt.Sprintf("count=%d", len(services)))
+	c.logger.Log(logger.Info, "deploy: preview-compose: returning services", fmt.Sprintf("count=%d", len(services)))
 	return &types.PreviewComposeResponse{Services: services}, nil
 }
 

--- a/api/internal/features/deploy/controller/redeploy_application.go
+++ b/api/internal/features/deploy/controller/redeploy_application.go
@@ -12,28 +12,28 @@ import (
 )
 
 func (c *DeployController) ReDeployApplication(f fuego.ContextWithBody[types.ReDeployApplicationRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "starting application redeployment process", "")
+	c.logger.Log(logger.Info, "deploy: starting application redeployment process", "")
 
 	data, err := f.Body()
 	if err != nil {
 		if err == io.EOF {
-			c.logger.Log(logger.Error, "empty request body received", "id is required for redeployment")
+			c.logger.Log(logger.Error, "deploy: empty request body received", "id is required for redeployment")
 			return nil, fuego.BadRequestError{
 				Detail: types.ErrMissingID.Error(),
 				Err:    types.ErrMissingID,
 			}
 		}
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "id: "+data.ID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -42,7 +42,7 @@ func (c *DeployController) ReDeployApplication(f fuego.ContextWithBody[types.ReD
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -50,17 +50,17 @@ func (c *DeployController) ReDeployApplication(f fuego.ContextWithBody[types.ReD
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: organization not found", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to redeploy application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to redeploy application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
 
 	application, err := c.taskService.ReDeployApplication(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to redeploy application", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to redeploy application", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -68,7 +68,7 @@ func (c *DeployController) ReDeployApplication(f fuego.ContextWithBody[types.ReD
 		}
 	}
 
-	c.logger.Log(logger.Info, "application redeployed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: application redeployed successfully", "id: "+data.ID.String())
 	return &types.ApplicationResponse{
 		Status:  "success",
 		Message: "Application redeployed successfully",

--- a/api/internal/features/deploy/controller/update_application.go
+++ b/api/internal/features/deploy/controller/update_application.go
@@ -12,28 +12,28 @@ import (
 )
 
 func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.UpdateDeploymentRequest]) (*types.ApplicationResponse, error) {
-	c.logger.Log(logger.Info, "starting application update process", "")
+	c.logger.Log(logger.Info, "deploy: starting application update process", "")
 
 	data, err := f.Body()
 	if err != nil {
 		if err == io.EOF {
-			c.logger.Log(logger.Error, "empty request body received", "id is required for update")
+			c.logger.Log(logger.Error, "deploy: empty request body received", "id is required for update")
 			return nil, fuego.BadRequestError{
 				Detail: types.ErrMissingID.Error(),
 				Err:    types.ErrMissingID,
 			}
 		}
-		c.logger.Log(logger.Error, "failed to read request body", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to read request body", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
 		}
 	}
 
-	c.logger.Log(logger.Info, "request body parsed successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: request body parsed successfully", "id: "+data.ID.String())
 
 	if err := c.validator.ValidateRequest(&data); err != nil {
-		c.logger.Log(logger.Error, "request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: request validation failed", "id: "+data.ID.String()+", error: "+err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -42,7 +42,7 @@ func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.Updat
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
-		c.logger.Log(logger.Error, "user authentication failed", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: user authentication failed", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -50,18 +50,18 @@ func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.Updat
 
 	organizationID := utils.GetOrganizationID(f.Request())
 	if organizationID == uuid.Nil {
-		c.logger.Log(logger.Error, "organization not found", "id: "+data.ID.String())
+		c.logger.Log(logger.Error, "deploy: organization not found", "id: "+data.ID.String())
 		return nil, fuego.UnauthorizedError{
 			Detail: "organization not found",
 		}
 	}
 
-	c.logger.Log(logger.Info, "attempting to update application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
+	c.logger.Log(logger.Info, "deploy: attempting to update application", "id: "+data.ID.String()+", user_id: "+user.ID.String())
 
 	// Sync compose-specific domains if provided, otherwise sync plain domains
 	if len(data.ComposeDomains) > 0 {
 		if err := c.syncComposeApplicationDomains(data.ID, organizationID, data.ComposeDomains); err != nil {
-			c.logger.Log(logger.Error, "failed to sync compose application domains", err.Error())
+			c.logger.Log(logger.Error, "deploy: failed to sync compose application domains", err.Error())
 			return nil, fuego.BadRequestError{
 				Detail: err.Error(),
 				Err:    err,
@@ -69,7 +69,7 @@ func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.Updat
 		}
 	} else if data.Domains != nil {
 		if err := c.syncApplicationDomains(data.ID, organizationID, data.Domains); err != nil {
-			c.logger.Log(logger.Error, "failed to sync application domains", err.Error())
+			c.logger.Log(logger.Error, "deploy: failed to sync application domains", err.Error())
 			return nil, fuego.BadRequestError{
 				Detail: err.Error(),
 				Err:    err,
@@ -79,7 +79,7 @@ func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.Updat
 
 	application, err := c.taskService.UpdateDeployment(&data, user.ID, organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to create deployment", "name: "+data.Name+", error: "+err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to create deployment", "name: "+data.Name+", error: "+err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -90,7 +90,7 @@ func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.Updat
 	// Reload application with domains for response
 	application, err = c.service.GetApplicationById(data.ID.String(), organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to reload application", err.Error())
+		c.logger.Log(logger.Error, "deploy: failed to reload application", err.Error())
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -98,7 +98,7 @@ func (c *DeployController) UpdateApplication(f fuego.ContextWithBody[types.Updat
 		}
 	}
 
-	c.logger.Log(logger.Info, "application updated successfully", "id: "+data.ID.String())
+	c.logger.Log(logger.Info, "deploy: application updated successfully", "id: "+data.ID.String())
 	return &types.ApplicationResponse{
 		Status:  "success",
 		Message: "Application updated successfully",

--- a/api/internal/features/deploy/controller/validate_fields.go
+++ b/api/internal/features/deploy/controller/validate_fields.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
@@ -17,7 +18,8 @@ func (c *DeployController) IsNameAlreadyTaken(w http.ResponseWriter, r *http.Req
 	value, err := c.service.IsNameAlreadyTaken(request.Name)
 
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		data := deployRequestData(r, utils.GetUser(w, r))
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: IsNameAlreadyTaken: %v", err), data)
 		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -34,7 +36,8 @@ func (c *DeployController) IsDomainAlreadyTaken(w http.ResponseWriter, r *http.R
 	is_taken, err := c.service.IsDomainAlreadyTaken(request.Domain)
 
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		data := deployRequestData(r, utils.GetUser(w, r))
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: IsDomainAlreadyTaken taken: %v", err), data)
 		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -42,7 +45,8 @@ func (c *DeployController) IsDomainAlreadyTaken(w http.ResponseWriter, r *http.R
 	is_valid, err := c.service.IsDomainValid(request.Domain)
 
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		data := deployRequestData(r, utils.GetUser(w, r))
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: IsDomainAlreadyTaken valid: %v", err), data)
 		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -64,7 +68,8 @@ func (c *DeployController) IsPortAlreadyTaken(w http.ResponseWriter, r *http.Req
 	value, err := c.service.IsPortAlreadyTaken(request.Port)
 
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		data := deployRequestData(r, utils.GetUser(w, r))
+		c.logger.Log(logger.Error, fmt.Sprintf("deploy: IsPortAlreadyTaken: %v", err), data)
 		utils.SendErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/api/internal/features/deploy/docker/init.go
+++ b/api/internal/features/deploy/docker/init.go
@@ -129,7 +129,7 @@ func NewDockerServiceWithServer(db *bun.DB, ctx context.Context, organizationID 
 
 	// If SSH tunnel failed, cli will be nil
 	if cli == nil {
-		lgr.Log(logger.Error, "Failed to create Docker client via SSH tunnel", "")
+		lgr.Log(logger.Error, "deploy docker: failed to create Docker client via SSH tunnel", "")
 		return nil
 	}
 
@@ -146,12 +146,12 @@ func NewDockerServiceWithServer(db *bun.DB, ctx context.Context, organizationID 
 
 	if !isClusterInitialized(svc.Cli) {
 		if err := svc.InitCluster(); err != nil {
-			svc.logger.Log(logger.Warning, "Failed to initialize cluster", err.Error())
+			svc.logger.Log(logger.Warning, "deploy docker: failed to initialize cluster", err.Error())
 		} else {
-			svc.logger.Log(logger.Info, "Cluster initialized successfully", "")
+			svc.logger.Log(logger.Info, "deploy docker: cluster initialized successfully", "")
 		}
 	} else {
-		svc.logger.Log(logger.Info, "Cluster already initialized", "")
+		svc.logger.Log(logger.Info, "deploy docker: cluster already initialized", "")
 	}
 
 	return svc
@@ -159,27 +159,27 @@ func NewDockerServiceWithServer(db *bun.DB, ctx context.Context, organizationID 
 
 func newDockerClientWithSSHTunnel(lgr logger.Logger, ctx context.Context, organizationID uuid.UUID) (*client.Client, *SSHTunnel) {
 	if organizationID == uuid.Nil {
-		lgr.Log(logger.Error, "Organization ID is required", "")
+		lgr.Log(logger.Error, "deploy docker: organization ID is required", "")
 		return nil, nil
 	}
 
 	sshManager, err := ssh.GetSSHManagerFromContext(ctx)
 	if err != nil {
-		lgr.Log(logger.Error, "Failed to get SSH manager", err.Error())
+		lgr.Log(logger.Error, "deploy docker: failed to get SSH manager", err.Error())
 		return nil, nil
 	}
 
 	// Get SSH client struct (not the goph.Client connection)
 	sshClient, err := sshManager.GetOrganizationSSH()
 	if err != nil {
-		lgr.Log(logger.Error, "Failed to get SSH client", err.Error())
+		lgr.Log(logger.Error, "deploy docker: failed to get SSH client", err.Error())
 		return nil, nil
 	}
 
 	// Create SSH tunnel
 	tunnel, err := CreateSSHTunnel(sshClient, lgr)
 	if err != nil || tunnel == nil {
-		lgr.Log(logger.Error, "Failed to create SSH tunnel", err.Error())
+		lgr.Log(logger.Error, "deploy docker: failed to create SSH tunnel", err.Error())
 		return nil, nil
 	}
 
@@ -187,18 +187,18 @@ func newDockerClientWithSSHTunnel(lgr logger.Logger, ctx context.Context, organi
 	// Docker client requires unix:/// (three slashes) for absolute paths
 	// filepath.Join returns absolute paths, so tunnel.localSocket already starts with /
 	host := fmt.Sprintf("unix://%s", tunnel.localSocket)
-	lgr.Log(logger.Info, "SSH tunnel established; using tunneled docker socket", fmt.Sprintf("host=%s, socket=%s", host, tunnel.localSocket))
+	lgr.Log(logger.Info, "deploy docker: SSH tunnel established; using tunneled docker socket", fmt.Sprintf("host=%s, socket=%s", host, tunnel.localSocket))
 	cli, err := client.NewClientWithOpts(
 		client.WithHost(host),
 		client.WithAPIVersionNegotiation(),
 	)
 	if err != nil {
-		lgr.Log(logger.Error, "Failed to create docker client over SSH tunnel", err.Error())
+		lgr.Log(logger.Error, "deploy docker: failed to create docker client over SSH tunnel", err.Error())
 		tunnel.Close()
 		return nil, nil
 	}
 
-	lgr.Log(logger.Info, "Docker client created over SSH tunnel", "")
+	lgr.Log(logger.Info, "deploy docker: Docker client created over SSH tunnel", "")
 	return cli, tunnel
 }
 
@@ -436,7 +436,7 @@ func (s *DockerService) GetContainerById(containerID string) (container.InspectR
 func (s *DockerService) ListAllImages(opts image.ListOptions) []image.Summary {
 	images, err := s.Cli.ImageList(s.Ctx, opts)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to list images", err.Error())
+		s.logger.Log(logger.Error, "deploy docker: failed to list images", err.Error())
 		return []image.Summary{}
 	}
 	return images

--- a/api/internal/features/deploy/docker/tunnel.go
+++ b/api/internal/features/deploy/docker/tunnel.go
@@ -120,7 +120,7 @@ func (t *SSHTunnel) handleConnections(lgr logger.Logger) {
 			if errors.Is(err, net.ErrClosed) || isConnectionLevelError(err) {
 				return
 			}
-			lgr.Log(logger.Error, "SSH tunnel listener error", err.Error())
+			lgr.Log(logger.Error, "deploy docker: SSH tunnel listener error", err.Error())
 			return
 		}
 
@@ -137,26 +137,26 @@ func (t *SSHTunnel) forwardConnection(localConn net.Conn, lgr logger.Logger) {
 
 	conn, err := t.getConn()
 	if err != nil {
-		lgr.Log(logger.Error, "Failed to establish SSH connection", err.Error())
+		lgr.Log(logger.Error, "deploy docker: failed to establish SSH connection", err.Error())
 		return
 	}
 
 	remoteConn, err := conn.Dial("unix", remoteDockerSocket)
 	if err != nil {
 		if !isConnectionLevelError(err) {
-			lgr.Log(logger.Error, "Failed to connect to remote Docker socket", err.Error())
+			lgr.Log(logger.Error, "deploy docker: failed to connect to remote Docker socket", err.Error())
 			return
 		}
 		// Connection-level error: reset and retry once.
 		t.resetConn()
 		conn, err = t.getConn()
 		if err != nil {
-			lgr.Log(logger.Error, "Failed to re-establish SSH connection", err.Error())
+			lgr.Log(logger.Error, "deploy docker: failed to re-establish SSH connection", err.Error())
 			return
 		}
 		remoteConn, err = conn.Dial("unix", remoteDockerSocket)
 		if err != nil {
-			lgr.Log(logger.Error, "Failed to connect to remote Docker socket", err.Error())
+			lgr.Log(logger.Error, "deploy docker: failed to connect to remote Docker socket", err.Error())
 			return
 		}
 	}

--- a/api/internal/features/deploy/service/artifacts.go
+++ b/api/internal/features/deploy/service/artifacts.go
@@ -21,13 +21,13 @@ func (s *DeployService) ListArtifacts(applicationID uuid.UUID, organizationID uu
 		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "not found") {
 			return nil, types.ErrPermissionDenied
 		}
-		s.logger.Log(logger.Error, "failed to get application for artifact listing", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to get application for artifact listing", err.Error())
 		return nil, err
 	}
 
 	deployments, err := s.storage.GetApplicationDeployments(applicationID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to list deployments", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to list deployments", err.Error())
 		return nil, fmt.Errorf("failed to list deployments: %w", err)
 	}
 
@@ -54,7 +54,7 @@ func (s *DeployService) GetArtifactDownloadURL(ctx context.Context, deploymentID
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", fmt.Errorf("deployment not found")
 		}
-		s.logger.Log(logger.Error, "failed to get deployment for download", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to get deployment for download", err.Error())
 		return "", err
 	}
 
@@ -63,7 +63,7 @@ func (s *DeployService) GetArtifactDownloadURL(ctx context.Context, deploymentID
 		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "not found") {
 			return "", types.ErrPermissionDenied
 		}
-		s.logger.Log(logger.Error, "failed to verify app ownership for download", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to verify app ownership for download", err.Error())
 		return "", err
 	}
 
@@ -77,13 +77,13 @@ func (s *DeployService) GetArtifactDownloadURL(ctx context.Context, deploymentID
 
 	store, err := s3store.NewImageStore(config.AppConfig.S3)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to create S3 client", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create S3 client", err.Error())
 		return "", fmt.Errorf("failed to create S3 client: %w", err)
 	}
 
 	exists, err := store.ObjectExists(ctx, deployment.ImageS3Key)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to check artifact existence", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to check artifact existence", err.Error())
 		return "", fmt.Errorf("failed to check artifact existence: %w", err)
 	}
 	if !exists {
@@ -92,7 +92,7 @@ func (s *DeployService) GetArtifactDownloadURL(ctx context.Context, deploymentID
 
 	url, err := store.PresignedDownloadURL(ctx, deployment.ImageS3Key, 15*time.Minute)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to generate download URL", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to generate download URL", err.Error())
 		return "", fmt.Errorf("failed to generate download URL: %w", err)
 	}
 	return url, nil
@@ -104,7 +104,7 @@ func (s *DeployService) DeleteArtifact(ctx context.Context, deploymentID string,
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("deployment not found")
 		}
-		s.logger.Log(logger.Error, "failed to get deployment for delete", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to get deployment for delete", err.Error())
 		return err
 	}
 
@@ -113,7 +113,7 @@ func (s *DeployService) DeleteArtifact(ctx context.Context, deploymentID string,
 		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "not found") {
 			return types.ErrPermissionDenied
 		}
-		s.logger.Log(logger.Error, "failed to verify app ownership for delete", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to verify app ownership for delete", err.Error())
 		return err
 	}
 
@@ -127,17 +127,17 @@ func (s *DeployService) DeleteArtifact(ctx context.Context, deploymentID string,
 
 	store, err := s3store.NewImageStore(config.AppConfig.S3)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to create S3 client", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create S3 client", err.Error())
 		return fmt.Errorf("failed to create S3 client: %w", err)
 	}
 
 	if err := store.DeleteImage(ctx, deployment.ImageS3Key); err != nil {
-		s.logger.Log(logger.Error, "failed to delete artifact from S3", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to delete artifact from S3", err.Error())
 		return fmt.Errorf("failed to delete artifact from S3: %w", err)
 	}
 
 	if err := s.storage.ClearDeploymentArtifactFields(deployment.ID); err != nil {
-		s.logger.Log(logger.Error, "failed to clear artifact metadata", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to clear artifact metadata", err.Error())
 		return fmt.Errorf("failed to clear artifact metadata: %w", err)
 	}
 	return nil

--- a/api/internal/features/deploy/service/create_project.go
+++ b/api/internal/features/deploy/service/create_project.go
@@ -14,7 +14,7 @@ import (
 // CreateProject creates a new application without triggering deployment.
 // The application is saved with a "draft" status and can be deployed later.
 func (s *DeployService) CreateProject(req *types.CreateProjectRequest, userID uuid.UUID, organizationID uuid.UUID) (shared_types.Application, error) {
-	s.logger.Log(logger.Info, "creating project without deployment", "name: "+req.Name)
+	s.logger.Log(logger.Info, "deploy service: creating project without deployment", "name: "+req.Name)
 
 	now := time.Now()
 
@@ -70,14 +70,14 @@ func (s *DeployService) CreateProject(req *types.CreateProjectRequest, userID uu
 	// Begin transaction for atomicity
 	tx, err := s.store.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to begin transaction", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to begin transaction", err.Error())
 		return shared_types.Application{}, err
 	}
 	defer tx.Rollback()
 
 	// Save the application to the database
 	if _, err := tx.NewInsert().Model(&application).Exec(s.Ctx); err != nil {
-		s.logger.Log(logger.Error, "failed to create application", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create application", err.Error())
 		return shared_types.Application{}, err
 	}
 
@@ -95,7 +95,7 @@ func (s *DeployService) CreateProject(req *types.CreateProjectRequest, userID uu
 				CreatedAt:     now,
 			}
 			if _, err := tx.NewInsert().Model(appDomain).Exec(s.Ctx); err != nil {
-				s.logger.Log(logger.Error, "failed to add domain", err.Error())
+				s.logger.Log(logger.Error, "deploy service: failed to add domain", err.Error())
 				return shared_types.Application{}, err
 			}
 		}
@@ -111,13 +111,13 @@ func (s *DeployService) CreateProject(req *types.CreateProjectRequest, userID uu
 	}
 
 	if _, err := tx.NewInsert().Model(&appStatus).Exec(s.Ctx); err != nil {
-		s.logger.Log(logger.Error, "failed to create application status", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create application status", err.Error())
 		return shared_types.Application{}, err
 	}
 
 	// Commit transaction
 	if err := tx.Commit(); err != nil {
-		s.logger.Log(logger.Error, "failed to commit transaction", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to commit transaction", err.Error())
 		return shared_types.Application{}, err
 	}
 
@@ -128,23 +128,23 @@ func (s *DeployService) CreateProject(req *types.CreateProjectRequest, userID uu
 			req.PrimaryServerID,
 			req.RoutingStrategy,
 		); err != nil {
-			s.logger.Log(logger.Warning, "failed to set application servers", err.Error())
+			s.logger.Log(logger.Warning, "deploy service: failed to set application servers", err.Error())
 		}
 	} else {
 		if err := s.storage.EnsureApplicationServers(application.ID, organizationID); err != nil {
-			s.logger.Log(logger.Warning, "failed to ensure application servers", err.Error())
+			s.logger.Log(logger.Warning, "deploy service: failed to ensure application servers", err.Error())
 		}
 	}
 
 	if len(req.ComposeServices) > 0 {
 		if err := s.persistComposeServicesAndLinkDomains(application.ID, req.ComposeServices, req.ComposeDomains); err != nil {
-			s.logger.Log(logger.Error, "failed to persist compose services", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to persist compose services", err.Error())
 		}
 	}
 
 	domainsList, err := s.storage.GetApplicationDomains(application.ID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to load domains after creation", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to load domains after creation", err.Error())
 		return shared_types.Application{}, err
 	}
 	domainPtrs := make([]*shared_types.ApplicationDomain, len(domainsList))
@@ -154,7 +154,7 @@ func (s *DeployService) CreateProject(req *types.CreateProjectRequest, userID uu
 	application.Domains = domainPtrs
 	application.Status = &appStatus
 
-	s.logger.Log(logger.Info, "project created successfully", "id: "+application.ID.String())
+	s.logger.Log(logger.Info, "deploy service: project created successfully", "id: "+application.ID.String())
 	return application, nil
 }
 
@@ -197,7 +197,7 @@ func (s *DeployService) persistComposeServicesAndLinkDomains(appID uuid.UUID, pr
 			port = svc.Port
 		}
 		if err := s.storage.UpdateApplicationDomainService(appID, domain, &svc.ID, &port); err != nil {
-			s.logger.Log(logger.Warning, "failed to link domain "+domain+" to service "+cd.ServiceName, err.Error())
+			s.logger.Log(logger.Warning, "deploy service: failed to link domain "+domain+" to service "+cd.ServiceName, err.Error())
 		}
 	}
 

--- a/api/internal/features/deploy/service/duplicate_project.go
+++ b/api/internal/features/deploy/service/duplicate_project.go
@@ -16,18 +16,18 @@ import (
 // It copies all configurations from the source project and creates a new project in draft status.
 // Both projects are linked via a shared family_id.
 func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, userID uuid.UUID, organizationID uuid.UUID) (shared_types.Application, error) {
-	s.logger.Log(logger.Info, "duplicating project", "source_id: "+req.SourceProjectID.String())
+	s.logger.Log(logger.Info, "deploy service: duplicating project", "source_id: "+req.SourceProjectID.String())
 
 	// Get the source project
 	sourceProject, err := s.storage.GetApplicationById(req.SourceProjectID.String(), organizationID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get source project", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to get source project", err.Error())
 		return shared_types.Application{}, types.ErrApplicationNotFound
 	}
 
 	// Check if trying to duplicate with the same environment
 	if sourceProject.Environment == req.Environment {
-		s.logger.Log(logger.Error, "cannot duplicate with same environment", "")
+		s.logger.Log(logger.Error, "deploy service: cannot duplicate with same environment", "")
 		return shared_types.Application{}, types.ErrSameEnvironmentAsDuplicate
 	}
 
@@ -39,11 +39,11 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 		// Check if the environment already exists in the family
 		exists, err := s.storage.IsEnvironmentInFamily(familyID, req.Environment)
 		if err != nil {
-			s.logger.Log(logger.Error, "failed to check environment in family", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to check environment in family", err.Error())
 			return shared_types.Application{}, err
 		}
 		if exists {
-			s.logger.Log(logger.Error, "environment already exists in family", "")
+			s.logger.Log(logger.Error, "deploy service: environment already exists in family", "")
 			return shared_types.Application{}, types.ErrEnvironmentAlreadyExistsInFamily
 		}
 	} else {
@@ -52,7 +52,7 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 
 		// Update the source project with the new family_id
 		if err := s.storage.UpdateApplicationFamilyID(sourceProject.ID, &familyID); err != nil {
-			s.logger.Log(logger.Error, "failed to update source project family_id", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to update source project family_id", err.Error())
 			return shared_types.Application{}, err
 		}
 	}
@@ -93,7 +93,7 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 
 	// Save the new project
 	if err := s.storage.AddApplication(&newProject); err != nil {
-		s.logger.Log(logger.Error, "failed to create duplicate project", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create duplicate project", err.Error())
 		return shared_types.Application{}, err
 	}
 
@@ -110,11 +110,11 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 			req.PrimaryServerID,
 			routingStrategy,
 		); err != nil {
-			s.logger.Log(logger.Warning, "failed to set application servers for duplicate", err.Error())
+			s.logger.Log(logger.Warning, "deploy service: failed to set application servers for duplicate", err.Error())
 		}
 	} else {
 		if err := s.storage.CopyApplicationServers(sourceProject.ID, newProject.ID); err != nil {
-			s.logger.Log(logger.Warning, "failed to copy application servers to duplicate", err.Error())
+			s.logger.Log(logger.Warning, "deploy service: failed to copy application servers to duplicate", err.Error())
 		}
 	}
 
@@ -128,7 +128,7 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 	}
 
 	if err := s.storage.AddApplicationStatus(&appStatus); err != nil {
-		s.logger.Log(logger.Error, "failed to create application status", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create application status", err.Error())
 		return shared_types.Application{}, err
 	}
 
@@ -138,7 +138,7 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 	// metadata available for domain-to-service assignment in the UI.
 	sourceServices, err := s.storage.GetComposeServices(sourceProject.ID)
 	if err != nil {
-		s.logger.Log(logger.Warning, "failed to load source compose services", err.Error())
+		s.logger.Log(logger.Warning, "deploy service: failed to load source compose services", err.Error())
 	} else if len(sourceServices) > 0 {
 		var newServices []shared_types.ComposeService
 		for _, svc := range sourceServices {
@@ -148,7 +148,7 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 			})
 		}
 		if err := s.storage.UpsertComposeServices(newProject.ID, newServices); err != nil {
-			s.logger.Log(logger.Warning, "failed to copy compose services to duplicate", err.Error())
+			s.logger.Log(logger.Warning, "deploy service: failed to copy compose services to duplicate", err.Error())
 		}
 	}
 
@@ -158,12 +158,12 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 		// Load domains from source project
 		sourceDomains, err := s.storage.GetApplicationDomains(sourceProject.ID)
 		if err != nil {
-			s.logger.Log(logger.Error, "failed to load source domains", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to load source domains", err.Error())
 			return shared_types.Application{}, err
 		}
 		// When duplicating across environments, require explicit domains to avoid routing conflicts
 		if sourceProject.Environment != req.Environment {
-			s.logger.Log(logger.Error, "domains required when duplicating across environments", "")
+			s.logger.Log(logger.Error, "deploy service: domains required when duplicating across environments", "")
 			return shared_types.Application{}, types.ErrMissingDomain
 		}
 		// Same environment: copy domains from source
@@ -175,13 +175,13 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 	// Add domains to new project
 	if len(domains) > 0 {
 		if err := s.storage.AddApplicationDomains(newProject.ID, domains); err != nil {
-			s.logger.Log(logger.Error, "failed to add domains to duplicate project", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to add domains to duplicate project", err.Error())
 			return shared_types.Application{}, err
 		}
 		// Load domains into newProject for response
 		domainsList, err := s.storage.GetApplicationDomains(newProject.ID)
 		if err != nil {
-			s.logger.Log(logger.Error, "failed to load domains after duplication", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to load domains after duplication", err.Error())
 			return shared_types.Application{}, err
 		}
 		domainPtrs := make([]*shared_types.ApplicationDomain, len(domainsList))
@@ -191,17 +191,17 @@ func (s *DeployService) DuplicateProject(req *types.DuplicateProjectRequest, use
 		newProject.Domains = domainPtrs
 	}
 
-	s.logger.Log(logger.Info, "project duplicated successfully", "new_id: "+newProject.ID.String())
+	s.logger.Log(logger.Info, "deploy service: project duplicated successfully", "new_id: "+newProject.ID.String())
 	return newProject, nil
 }
 
 // GetProjectFamily retrieves all projects that belong to a family.
 func (s *DeployService) GetProjectFamily(familyID uuid.UUID, organizationID uuid.UUID) ([]shared_types.Application, error) {
-	s.logger.Log(logger.Info, "getting project family", "family_id: "+familyID.String())
+	s.logger.Log(logger.Info, "deploy service: getting project family", "family_id: "+familyID.String())
 
 	projects, err := s.storage.GetProjectsByFamilyID(familyID, organizationID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get project family", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to get project family", err.Error())
 		return nil, err
 	}
 
@@ -214,11 +214,11 @@ func (s *DeployService) GetProjectFamily(familyID uuid.UUID, organizationID uuid
 
 // GetEnvironmentsInFamily retrieves all environments that exist in a project family.
 func (s *DeployService) GetEnvironmentsInFamily(familyID uuid.UUID, organizationID uuid.UUID) ([]shared_types.Environment, error) {
-	s.logger.Log(logger.Info, "getting environments in family", "family_id: "+familyID.String())
+	s.logger.Log(logger.Info, "deploy service: getting environments in family", "family_id: "+familyID.String())
 
 	environments, err := s.storage.GetEnvironmentsInFamily(familyID, organizationID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get environments in family", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to get environments in family", err.Error())
 		return nil, err
 	}
 
@@ -228,7 +228,7 @@ func (s *DeployService) GetEnvironmentsInFamily(familyID uuid.UUID, organization
 // AddApplicationToFamily adds a new application to an existing family (or creates a new family).
 // This is used for multi-application monorepo setups where multiple apps share the same repository.
 func (s *DeployService) AddApplicationToFamily(req *types.AddApplicationToFamilyRequest, userID uuid.UUID, organizationID uuid.UUID) (shared_types.Application, error) {
-	s.logger.Log(logger.Info, "adding application to family", "name: "+req.Name)
+	s.logger.Log(logger.Info, "deploy service: adding application to family", "name: "+req.Name)
 
 	// Determine family_id
 	var familyID *uuid.UUID
@@ -237,11 +237,11 @@ func (s *DeployService) AddApplicationToFamily(req *types.AddApplicationToFamily
 		// Validate that the family exists and belongs to the organization
 		existingApps, err := s.storage.GetProjectsByFamilyID(*familyID, organizationID)
 		if err != nil {
-			s.logger.Log(logger.Error, "failed to validate family", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to validate family", err.Error())
 			return shared_types.Application{}, err
 		}
 		if len(existingApps) == 0 {
-			s.logger.Log(logger.Error, "family not found", "")
+			s.logger.Log(logger.Error, "deploy service: family not found", "")
 			return shared_types.Application{}, types.ErrProjectFamilyNotFound
 		}
 	} else {
@@ -305,7 +305,7 @@ func (s *DeployService) AddApplicationToFamily(req *types.AddApplicationToFamily
 
 	// Save the application
 	if err := s.storage.AddApplication(&application); err != nil {
-		s.logger.Log(logger.Error, "failed to create application", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create application", err.Error())
 		return shared_types.Application{}, err
 	}
 
@@ -319,26 +319,26 @@ func (s *DeployService) AddApplicationToFamily(req *types.AddApplicationToFamily
 	}
 
 	if err := s.storage.AddApplicationStatus(&appStatus); err != nil {
-		s.logger.Log(logger.Error, "failed to create application status", err.Error())
+		s.logger.Log(logger.Error, "deploy service: failed to create application status", err.Error())
 		return shared_types.Application{}, err
 	}
 
 	application.Status = &appStatus
 
 	if err := s.storage.EnsureApplicationServers(application.ID, organizationID); err != nil {
-		s.logger.Log(logger.Warning, "failed to ensure application servers for family app", err.Error())
+		s.logger.Log(logger.Warning, "deploy service: failed to ensure application servers for family app", err.Error())
 	}
 
 	// Add domains if provided
 	if len(req.Domains) > 0 {
 		if err := s.storage.AddApplicationDomains(application.ID, req.Domains); err != nil {
-			s.logger.Log(logger.Error, "failed to add domains", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to add domains", err.Error())
 			return shared_types.Application{}, err
 		}
 		// Load domains into application for response
 		domainsList, err := s.storage.GetApplicationDomains(application.ID)
 		if err != nil {
-			s.logger.Log(logger.Error, "failed to load domains after creation", err.Error())
+			s.logger.Log(logger.Error, "deploy service: failed to load domains after creation", err.Error())
 			return shared_types.Application{}, err
 		}
 		domainPtrs := make([]*shared_types.ApplicationDomain, len(domainsList))
@@ -348,7 +348,7 @@ func (s *DeployService) AddApplicationToFamily(req *types.AddApplicationToFamily
 		application.Domains = domainPtrs
 	}
 
-	s.logger.Log(logger.Info, "application added to family successfully", "id: "+application.ID.String())
+	s.logger.Log(logger.Info, "deploy service: application added to family successfully", "id: "+application.ID.String())
 	return application, nil
 }
 

--- a/api/internal/features/deploy/service/get_deployment_logs.go
+++ b/api/internal/features/deploy/service/get_deployment_logs.go
@@ -11,7 +11,7 @@ import (
 func (s *DeployService) GetDeploymentLogs(ctx context.Context, deploymentID string, page, pageSize int, level string, startTime, endTime time.Time, searchTerm string) ([]shared_types.ApplicationLogs, int64, error) {
 	logs, totalCount, err := s.storage.GetDeploymentLogs(deploymentID, page, pageSize, level, startTime, endTime, searchTerm)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to get deployment logs", err.Error())
+		s.logger.Log(logger.Error, "deploy service: Failed to get deployment logs", err.Error())
 		return nil, 0, err
 	}
 

--- a/api/internal/features/deploy/service/get_logs.go
+++ b/api/internal/features/deploy/service/get_logs.go
@@ -10,7 +10,7 @@ import (
 func (s *DeployService) GetLogs(applicationID string, page, pageSize int, level string, startTime, endTime time.Time, searchTerm string) ([]shared_types.ApplicationLogs, int, error) {
 	logs, totalCount, err := s.storage.GetLogs(applicationID, page, pageSize, level, startTime, endTime, searchTerm)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to get logs", err.Error())
+		s.logger.Log(logger.Error, "deploy service: Failed to get logs", err.Error())
 		return nil, 0, err
 	}
 

--- a/api/internal/features/deploy/storage/init.go
+++ b/api/internal/features/deploy/storage/init.go
@@ -13,13 +13,15 @@ import (
 	"github.com/uptrace/bun/dialect/pgdialect"
 
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	sshstorage "github.com/nixopus/nixopus/api/internal/features/ssh/storage"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
 type DeployStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage debug/error hooks
 }
 
 type DeployRepository interface {
@@ -79,14 +81,20 @@ type DeployRepository interface {
 func (s *DeployStorage) RunInTransaction(fn func(tx bun.Tx) error) error {
 	tx, err := s.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("deploy storage: RunInTransaction begin: %v", err), "")
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback()
 
 	if err := fn(tx); err != nil {
+		storageLog(s.Logger, logger.Debug, fmt.Sprintf("deploy storage: RunInTransaction fn: %v", err), "")
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("deploy storage: RunInTransaction commit: %v", err), "")
+		return err
+	}
+	return nil
 }
 
 func (s *DeployStorage) AddApplicationLogsBatch(logs []shared_types.ApplicationLogs) error {

--- a/api/internal/features/deploy/storage/log.go
+++ b/api/internal/features/deploy/storage/log.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func storageLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}

--- a/api/internal/features/deploy/tasks/build.go
+++ b/api/internal/features/deploy/tasks/build.go
@@ -295,7 +295,7 @@ func (s *TaskService) processBuildOutput(logReader *LogReader) error {
 	if logReader.PlainOutput {
 		_, err := io.Copy(io.Discard, logReader)
 		if err != nil {
-			errorMsg := fmt.Sprintf("Build output processing failed: %v", err)
+			errorMsg := fmt.Sprintf("deploy tasks: Build output processing failed: %v", err)
 			s.Logger.Log(logger.Error, errorMsg, logReader.deployment_config.ID.String())
 			logReader.TaskContext.AddLog(errorMsg)
 			return err
@@ -305,7 +305,7 @@ func (s *TaskService) processBuildOutput(logReader *LogReader) error {
 	termFd, isTerm := term.GetFdInfo(os.Stdout)
 	err := jsonmessage.DisplayJSONMessagesStream(logReader, io.Discard, termFd, isTerm, nil)
 	if err != nil {
-		errorMsg := fmt.Sprintf("Build output processing failed: %v", err)
+		errorMsg := fmt.Sprintf("deploy tasks: Build output processing failed: %v", err)
 		s.Logger.Log(logger.Error, errorMsg, logReader.deployment_config.ID.String())
 		logReader.TaskContext.AddLog(errorMsg)
 		return err
@@ -364,17 +364,17 @@ func (r *LogReader) Read(p []byte) (n int, err error) {
 // the error message. This helps in tracking the build process and diagnosing issues.
 func (r *LogReader) processJSONMessage(jsonMsg jsonmessage.JSONMessage) {
 	if jsonMsg.Stream != "" {
-		r.DeployService.Logger.Log(logger.Info, "Build: "+jsonMsg.Stream, r.deployment_config.ID.String())
+		r.DeployService.Logger.Log(logger.Info, "deploy tasks: Build: "+jsonMsg.Stream, r.deployment_config.ID.String())
 		r.TaskContext.AddLog("Build: " + jsonMsg.Stream)
 	} else if jsonMsg.Status != "" {
 		status := jsonMsg.Status
 		if jsonMsg.Progress != nil {
 			status += " " + jsonMsg.Progress.String()
 		}
-		r.DeployService.Logger.Log(logger.Info, "Build: "+status, r.deployment_config.ID.String())
+		r.DeployService.Logger.Log(logger.Info, "deploy tasks: Build: "+status, r.deployment_config.ID.String())
 		r.TaskContext.AddLog("Build: " + status)
 	} else if jsonMsg.Error != nil {
-		r.DeployService.Logger.Log(logger.Error, "Build error: "+jsonMsg.Error.Message, r.deployment_config.ID.String())
+		r.DeployService.Logger.Log(logger.Error, "deploy tasks: Build error: "+jsonMsg.Error.Message, r.deployment_config.ID.String())
 		r.TaskContext.AddLog("Build error: " + jsonMsg.Error.Message)
 	}
 }

--- a/api/internal/features/deploy/tasks/context.go
+++ b/api/internal/features/deploy/tasks/context.go
@@ -99,11 +99,11 @@ func (c *ContextTask) PersistCreateApplicationDeploymentData(application shared_
 	return c.TaskService.Storage.RunInTransaction(func(tx bun.Tx) error {
 		ctx := context.Background()
 		if _, err := tx.NewInsert().Model(&application).Exec(ctx); err != nil {
-			c.TaskService.Logger.Log(logger.Error, types.LogFailedToCreateApplicationRecord+err.Error(), "")
+			c.TaskService.Logger.Log(logger.Error, "deploy tasks: "+types.LogFailedToCreateApplicationRecord+err.Error(), "")
 			return err
 		}
 		if _, err := tx.NewInsert().Model(&applicationDeployment).Exec(ctx); err != nil {
-			c.TaskService.Logger.Log(logger.Error, types.LogFailedToCreateApplicationDeployment+err.Error(), "")
+			c.TaskService.Logger.Log(logger.Error, "deploy tasks: "+types.LogFailedToCreateApplicationDeployment+err.Error(), "")
 			return err
 		}
 		return nil
@@ -114,11 +114,11 @@ func (c *ContextTask) PersistUpdateApplicationDeploymentData(application shared_
 	return c.TaskService.Storage.RunInTransaction(func(tx bun.Tx) error {
 		ctx := context.Background()
 		if _, err := tx.NewUpdate().Model(&application).OmitZero().WherePK().Exec(ctx); err != nil {
-			c.TaskService.Logger.Log(logger.Error, types.LogFailedToUpdateApplicationRecord+err.Error(), "")
+			c.TaskService.Logger.Log(logger.Error, "deploy tasks: "+types.LogFailedToUpdateApplicationRecord+err.Error(), "")
 			return err
 		}
 		if _, err := tx.NewInsert().Model(&applicationDeployment).Exec(ctx); err != nil {
-			c.TaskService.Logger.Log(logger.Error, types.LogFailedToUpdateApplicationDeployment+err.Error(), "")
+			c.TaskService.Logger.Log(logger.Error, "deploy tasks: "+types.LogFailedToUpdateApplicationDeployment+err.Error(), "")
 			return err
 		}
 		return nil
@@ -176,11 +176,11 @@ func (c *ContextTask) PrepareCreateDeploymentContext() (shared_types.TaskPayload
 			deployment.PrimaryServerID,
 			deployment.RoutingStrategy,
 		); err != nil {
-			c.TaskService.Logger.Log(logger.Warning, "failed to set application servers", err.Error())
+			c.TaskService.Logger.Log(logger.Warning, "deploy tasks: failed to set application servers", err.Error())
 		}
 	} else {
 		if err := c.TaskService.Storage.EnsureApplicationServers(application.ID, c.OrganizationId); err != nil {
-			c.TaskService.Logger.Log(logger.Warning, "failed to ensure application servers", err.Error())
+			c.TaskService.Logger.Log(logger.Warning, "deploy tasks: failed to ensure application servers", err.Error())
 		}
 	}
 

--- a/api/internal/features/deploy/tasks/delete.go
+++ b/api/internal/features/deploy/tasks/delete.go
@@ -37,19 +37,19 @@ func (s *TaskService) DeleteDeployment(ctx context.Context, deployment *types.De
 
 	dockerService, err := s.getDockerService(ctx)
 	if err != nil {
-		s.Logger.Log(logger.Error, "Failed to get docker service", err.Error())
+		s.Logger.Log(logger.Error, "deploy tasks: Failed to get docker service", err.Error())
 	} else {
 		services, err := dockerService.GetClusterServices()
 		if err != nil {
-			s.Logger.Log(logger.Error, "Failed to get services", err.Error())
+			s.Logger.Log(logger.Error, "deploy tasks: Failed to get services", err.Error())
 		} else {
 			for _, service := range services {
 				if service.Spec.Annotations.Name == application.Name {
-					s.Logger.Log(logger.Info, "Deleting service", service.ID)
+					s.Logger.Log(logger.Info, "deploy tasks: Deleting service", service.ID)
 					if err := dockerService.DeleteService(service.ID); err != nil {
-						s.Logger.Log(logger.Error, "Failed to delete service", err.Error())
+						s.Logger.Log(logger.Error, "deploy tasks: Failed to delete service", err.Error())
 					} else {
-						s.Logger.Log(logger.Info, "Service deleted successfully", service.ID)
+						s.Logger.Log(logger.Info, "deploy tasks: Service deleted successfully", service.ID)
 					}
 					break
 				}
@@ -58,13 +58,13 @@ func (s *TaskService) DeleteDeployment(ctx context.Context, deployment *types.De
 
 		deployments, err := s.Storage.GetApplicationDeployments(application.ID)
 		if err != nil {
-			s.Logger.Log(logger.Error, "Failed to get application deployments", err.Error())
+			s.Logger.Log(logger.Error, "deploy tasks: Failed to get application deployments", err.Error())
 		} else {
 			for _, dep := range deployments {
 				if dep.ContainerImage != "" {
-					s.Logger.Log(logger.Info, "Removing image", dep.ContainerImage)
+					s.Logger.Log(logger.Info, "deploy tasks: Removing image", dep.ContainerImage)
 					if err := dockerService.RemoveImage(dep.ContainerImage, image.RemoveOptions{Force: true}); err != nil {
-						s.Logger.Log(logger.Error, "Failed to remove image", err.Error())
+						s.Logger.Log(logger.Error, "deploy tasks: Failed to remove image", err.Error())
 					}
 				}
 			}
@@ -72,13 +72,13 @@ func (s *TaskService) DeleteDeployment(ctx context.Context, deployment *types.De
 			if s3store.IsConfigured(config.AppConfig.S3) {
 				store, err := s3store.NewImageStore(config.AppConfig.S3)
 				if err != nil {
-					s.Logger.Log(logger.Error, "Failed to create S3 store for cleanup", err.Error())
+					s.Logger.Log(logger.Error, "deploy tasks: Failed to create S3 store for cleanup", err.Error())
 				} else {
 					for _, dep := range deployments {
 						if dep.ImageS3Key != "" {
-							s.Logger.Log(logger.Info, "Removing S3 image", dep.ImageS3Key)
+							s.Logger.Log(logger.Info, "deploy tasks: Removing S3 image", dep.ImageS3Key)
 							if err := store.DeleteImage(ctx, dep.ImageS3Key); err != nil {
-								s.Logger.Log(logger.Error, "Failed to remove S3 image", err.Error())
+								s.Logger.Log(logger.Error, "deploy tasks: Failed to remove S3 image", err.Error())
 							}
 						}
 					}
@@ -92,13 +92,13 @@ func (s *TaskService) DeleteDeployment(ctx context.Context, deployment *types.De
 	// Get repository path using the same method as cloning (on tenant's SSH server)
 	repoPath, _, err := s.Github_service.GetClonePath(orgCtx, userID.String(), string(application.Environment), application.ID.String())
 	if err != nil {
-		s.Logger.Log(logger.Error, fmt.Sprintf("Failed to get repository path: %s", err.Error()), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("deploy tasks: Failed to get repository path: %s", err.Error()), "")
 	} else {
-		s.Logger.Log(logger.Info, "Cleaning up repository directory", repoPath)
+		s.Logger.Log(logger.Info, "deploy tasks: Cleaning up repository directory", repoPath)
 		err = s.Github_service.RemoveRepository(orgCtx, repoPath)
 	}
 	if err != nil {
-		s.Logger.Log(logger.Error, "Failed to remove repository", err.Error())
+		s.Logger.Log(logger.Error, "deploy tasks: Failed to remove repository", err.Error())
 	}
 
 	if len(application.Domains) > 0 {
@@ -109,9 +109,9 @@ func (s *TaskService) DeleteDeployment(ctx context.Context, deployment *types.De
 			}
 		}
 		if err := caddy.RemoveDomainsWithRetry(orgCtx, nil, &s.Logger, domainNames); err != nil {
-			s.Logger.Log(logger.Warning, "failed to remove domains from proxy, enqueueing for retry", err.Error())
+			s.Logger.Log(logger.Warning, "deploy tasks: failed to remove domains from proxy, enqueueing for retry", err.Error())
 			if enqErr := caddy.EnqueuePendingRemoval(organizationID, domainNames...); enqErr != nil {
-				s.Logger.Log(logger.Error, "failed to enqueue pending removal", enqErr.Error())
+				s.Logger.Log(logger.Error, "deploy tasks: failed to enqueue pending removal", enqErr.Error())
 			}
 		}
 	}
@@ -119,9 +119,9 @@ func (s *TaskService) DeleteDeployment(ctx context.Context, deployment *types.De
 	// Handle family cleanup: if this project belongs to a family,
 	// check if only one member remains and clear its family_id
 	if application.FamilyID != nil {
-		s.Logger.Log(logger.Info, "Checking family cleanup", application.FamilyID.String())
+		s.Logger.Log(logger.Info, "deploy tasks: Checking family cleanup", application.FamilyID.String())
 		if err := s.Storage.ClearFamilyIDIfSingleMember(*application.FamilyID); err != nil {
-			s.Logger.Log(logger.Error, "Failed to cleanup family", err.Error())
+			s.Logger.Log(logger.Error, "deploy tasks: Failed to cleanup family", err.Error())
 		}
 	}
 

--- a/api/internal/features/deploy/tasks/fanout.go
+++ b/api/internal/features/deploy/tasks/fanout.go
@@ -78,7 +78,7 @@ func (t *TaskService) updateParentStatus(ctx context.Context, parentDepID uuid.U
 		UpdatedAt:               now,
 	}
 	if err := t.Storage.AddApplicationDeploymentStatus(appStatus); err != nil {
-		t.Logger.Log(logger.Error, "failed to update parent deployment status", err.Error())
+		t.Logger.Log(logger.Error, "deploy tasks: failed to update parent deployment status", err.Error())
 	}
 }
 
@@ -117,7 +117,7 @@ func (t *TaskService) fanOut(
 
 			child, err := t.addChildDeployment(d.ApplicationDeployment, serverID)
 			if err != nil {
-				t.Logger.Log(logger.Error, "failed to create child deployment", err.Error())
+				t.Logger.Log(logger.Error, "deploy tasks: failed to create child deployment", err.Error())
 				errs[idx] = err
 				return
 			}

--- a/api/internal/features/deploy/tasks/init.go
+++ b/api/internal/features/deploy/tasks/init.go
@@ -68,12 +68,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 				t.RegisterCancellation(deploymentID, cancel)
 				defer t.DeregisterCancellation(deploymentID)
 
-				t.Logger.Log(logger.Info, "starting create deployment", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: starting create deployment", data.CorrelationID)
 				if err := t.BuildPack(ctx, data); err != nil {
-					t.Logger.Log(logger.Error, "create deployment failed: "+err.Error(), data.CorrelationID)
+					t.Logger.Log(logger.Error, "deploy tasks: create deployment failed: "+err.Error(), data.CorrelationID)
 					return err
 				}
-				t.Logger.Log(logger.Info, "create deployment completed", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: create deployment completed", data.CorrelationID)
 				return nil
 			},
 		})
@@ -99,12 +99,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 				t.RegisterCancellation(deploymentID, cancel)
 				defer t.DeregisterCancellation(deploymentID)
 
-				t.Logger.Log(logger.Info, "starting update deployment", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: starting update deployment", data.CorrelationID)
 				if err := t.HandleUpdateDeployment(ctx, data); err != nil {
-					t.Logger.Log(logger.Error, "update deployment failed: "+err.Error(), data.CorrelationID)
+					t.Logger.Log(logger.Error, "deploy tasks: update deployment failed: "+err.Error(), data.CorrelationID)
 					return err
 				}
-				t.Logger.Log(logger.Info, "update deployment completed", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: update deployment completed", data.CorrelationID)
 				return nil
 			},
 		})
@@ -130,12 +130,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 				t.RegisterCancellation(deploymentID, cancel)
 				defer t.DeregisterCancellation(deploymentID)
 
-				t.Logger.Log(logger.Info, "starting redeploy", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: starting redeploy", data.CorrelationID)
 				if err := t.HandleReDeploy(ctx, data); err != nil {
-					t.Logger.Log(logger.Error, "redeploy failed: "+err.Error(), data.CorrelationID)
+					t.Logger.Log(logger.Error, "deploy tasks: redeploy failed: "+err.Error(), data.CorrelationID)
 					return err
 				}
-				t.Logger.Log(logger.Info, "redeploy completed", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: redeploy completed", data.CorrelationID)
 				return nil
 			},
 		})
@@ -155,12 +155,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 			Name:       TASK_ROLLBACK,
 			RetryLimit: 1,
 			Handler: func(ctx context.Context, data shared_types.TaskPayload) error {
-				t.Logger.Log(logger.Info, "starting rollback", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: starting rollback", data.CorrelationID)
 				if err := t.HandleRollback(ctx, data); err != nil {
-					t.Logger.Log(logger.Error, "rollback failed: "+err.Error(), data.CorrelationID)
+					t.Logger.Log(logger.Error, "deploy tasks: rollback failed: "+err.Error(), data.CorrelationID)
 					return err
 				}
-				t.Logger.Log(logger.Info, "rollback completed", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: rollback completed", data.CorrelationID)
 				return nil
 			},
 		})
@@ -180,12 +180,12 @@ func (t *TaskService) SetupCreateDeploymentQueue() {
 			Name:       TASK_RESTART,
 			RetryLimit: 1,
 			Handler: func(ctx context.Context, data shared_types.TaskPayload) error {
-				t.Logger.Log(logger.Info, "starting restart", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: starting restart", data.CorrelationID)
 				if err := t.HandleRestart(ctx, data); err != nil {
-					t.Logger.Log(logger.Error, "restart failed: "+err.Error(), data.CorrelationID)
+					t.Logger.Log(logger.Error, "deploy tasks: restart failed: "+err.Error(), data.CorrelationID)
 					return err
 				}
-				t.Logger.Log(logger.Info, "restart completed", data.CorrelationID)
+				t.Logger.Log(logger.Info, "deploy tasks: restart completed", data.CorrelationID)
 				return nil
 			},
 		})

--- a/api/internal/features/deploy/tasks/redeploy.go
+++ b/api/internal/features/deploy/tasks/redeploy.go
@@ -11,14 +11,14 @@ import (
 
 // HandleReDeploy fans out redeployment across all configured servers (or org default for single-server apps).
 func (s *TaskService) HandleReDeploy(ctx context.Context, TaskPayload shared_types.TaskPayload) error {
-	s.Logger.Log(logger.Info, fmt.Sprintf("redeploy: fetching servers for app %s (buildpack=%s)", TaskPayload.Application.ID, TaskPayload.Application.BuildPack), "")
+	s.Logger.Log(logger.Info, fmt.Sprintf("deploy tasks: redeploy: fetching servers for app %s (buildpack=%s)", TaskPayload.Application.ID, TaskPayload.Application.BuildPack), "")
 	allServers, err := s.Storage.GetApplicationServers(TaskPayload.Application.ID)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve application servers: %w", err)
 	}
-	s.Logger.Log(logger.Info, fmt.Sprintf("redeploy: got %d servers for app %s", len(allServers), TaskPayload.Application.ID), "")
+	s.Logger.Log(logger.Info, fmt.Sprintf("deploy tasks: redeploy: got %d servers for app %s", len(allServers), TaskPayload.Application.ID), "")
 	if len(allServers) == 0 {
-		s.Logger.Log(logger.Info, "redeploy: no application_servers rows, falling back to org default", "")
+		s.Logger.Log(logger.Info, "deploy tasks: redeploy: no application_servers rows, falling back to org default", "")
 		return s.handleReDeploySingle(ctx, TaskPayload)
 	}
 	servers := filterServers(allServers, TaskPayload.TargetServerIDs)

--- a/api/internal/features/deploy/tasks/run.go
+++ b/api/internal/features/deploy/tasks/run.go
@@ -31,10 +31,10 @@ func (s *TaskService) formatLog(
 ) {
 	if len(args) > 0 {
 		formattedMessage := fmt.Sprintf(message, args...)
-		s.Logger.Log(logger.Info, formattedMessage, taskContext.GetDeploymentID().String())
+		s.Logger.Log(logger.Info, "deploy tasks: "+formattedMessage, taskContext.GetDeploymentID().String())
 		taskContext.AddLog(formattedMessage)
 	} else {
-		s.Logger.Log(logger.Info, message, taskContext.GetDeploymentID().String())
+		s.Logger.Log(logger.Info, "deploy tasks: "+message, taskContext.GetDeploymentID().String())
 		taskContext.AddLog(message)
 	}
 }
@@ -103,7 +103,7 @@ func (s *TaskService) AtomicUpdateContainer(ctx context.Context, r shared_types.
 
 	taskContext.LogAndUpdateStatus("Starting container update", shared_types.Deploying)
 
-	s.Logger.Log(logger.Info, types.LogUpdatingContainer, r.Application.Name)
+	s.Logger.Log(logger.Info, "deploy tasks: "+types.LogUpdatingContainer, r.Application.Name)
 	s.formatLog(taskContext, types.LogPreparingToUpdateContainer, r.Application.Name)
 
 	// Check if service already exists

--- a/api/internal/features/deploy/tasks/s3_export.go
+++ b/api/internal/features/deploy/tasks/s3_export.go
@@ -105,7 +105,7 @@ func (s *TaskService) ExportAndRecordImage(ctx context.Context, payload shared_t
 
 	orgSettings, err := utils.GetOrganizationSettings(ctx, s.Store.DB, payload.Application.OrganizationID)
 	if err != nil {
-		s.Logger.Log(logger.Warning, "Failed to get organization settings for S3 export: "+err.Error(), payload.ApplicationDeployment.ID.String())
+		s.Logger.Log(logger.Warning, "deploy tasks: Failed to get organization settings for S3 export: "+err.Error(), payload.ApplicationDeployment.ID.String())
 		return
 	}
 	if orgSettings.S3ArtifactUploadEnabled == nil || !*orgSettings.S3ArtifactUploadEnabled {
@@ -120,7 +120,7 @@ func (s *TaskService) ExportAndRecordImage(ctx context.Context, payload shared_t
 			bgCtx = context.WithValue(bgCtx, shared_types.ServerIDKey, serverID)
 		}
 
-		s.Logger.Log(logger.Info, "Starting async S3 image export", deploymentCopy.ID.String())
+		s.Logger.Log(logger.Info, "deploy tasks: Starting async S3 image export", deploymentCopy.ID.String())
 		key, size, err := s.ExportImageToS3(bgCtx, ExportConfig{
 			ImageTag:     commitTag,
 			OrgID:        payload.Application.OrganizationID,
@@ -128,14 +128,14 @@ func (s *TaskService) ExportAndRecordImage(ctx context.Context, payload shared_t
 			DeploymentID: deploymentCopy.ID,
 		}, taskCtx)
 		if err != nil {
-			s.Logger.Log(logger.Warning, "Failed to export image to S3 (non-fatal): "+err.Error(), deploymentCopy.ID.String())
+			s.Logger.Log(logger.Warning, "deploy tasks: Failed to export image to S3 (non-fatal): "+err.Error(), deploymentCopy.ID.String())
 			return
 		}
 
 		deploymentCopy.ImageS3Key = key
 		deploymentCopy.ImageSize = size
 		if err := s.Storage.UpdateApplicationDeployment(&deploymentCopy); err != nil {
-			s.Logger.Log(logger.Warning, "Failed to record S3 image metadata: "+err.Error(), deploymentCopy.ID.String())
+			s.Logger.Log(logger.Warning, "deploy tasks: Failed to record S3 image metadata: "+err.Error(), deploymentCopy.ID.String())
 		}
 		taskCtx.FlushLogs()
 	}()
@@ -150,7 +150,7 @@ func (s *TaskService) ExportComposeImagesToS3(ctx context.Context, payload share
 
 	orgSettings, err := utils.GetOrganizationSettings(ctx, s.Store.DB, payload.Application.OrganizationID)
 	if err != nil {
-		s.Logger.Log(logger.Warning, "Failed to get organization settings for S3 export: "+err.Error(), payload.ApplicationDeployment.ID.String())
+		s.Logger.Log(logger.Warning, "deploy tasks: Failed to get organization settings for S3 export: "+err.Error(), payload.ApplicationDeployment.ID.String())
 		return
 	}
 	if orgSettings.S3ArtifactUploadEnabled == nil || !*orgSettings.S3ArtifactUploadEnabled {
@@ -162,15 +162,15 @@ func (s *TaskService) ExportComposeImagesToS3(ctx context.Context, payload share
 	// then run the S3 upload in a background goroutine with a detached context.
 	imageTags, err := s.listComposeImages(ctx, composeFilePath, envVars)
 	if err != nil {
-		s.Logger.Log(logger.Warning, "Failed to list compose images (non-fatal): "+err.Error(), deploymentCopy.ID.String())
+		s.Logger.Log(logger.Warning, "deploy tasks: Failed to list compose images (non-fatal): "+err.Error(), deploymentCopy.ID.String())
 		return
 	}
 	if len(imageTags) == 0 {
-		s.Logger.Log(logger.Warning, "No compose images found to export", deploymentCopy.ID.String())
+		s.Logger.Log(logger.Warning, "deploy tasks: No compose images found to export", deploymentCopy.ID.String())
 		return
 	}
 
-	s.Logger.Log(logger.Info, fmt.Sprintf("Found %d compose image(s) to export: %s", len(imageTags), strings.Join(imageTags, ", ")), deploymentCopy.ID.String())
+	s.Logger.Log(logger.Info, fmt.Sprintf("deploy tasks: Found %d compose image(s) to export: %s", len(imageTags), strings.Join(imageTags, ", ")), deploymentCopy.ID.String())
 
 	go func() {
 		defer func() {
@@ -193,14 +193,14 @@ func (s *TaskService) ExportComposeImagesToS3(ctx context.Context, payload share
 			DeploymentID: deploymentCopy.ID,
 		}, taskCtx)
 		if err != nil {
-			s.Logger.Log(logger.Warning, "Failed to export compose images to S3 (non-fatal): "+err.Error(), deploymentCopy.ID.String())
+			s.Logger.Log(logger.Warning, "deploy tasks: Failed to export compose images to S3 (non-fatal): "+err.Error(), deploymentCopy.ID.String())
 			return
 		}
 
 		deploymentCopy.ImageS3Key = key
 		deploymentCopy.ImageSize = size
 		if err := s.Storage.UpdateApplicationDeployment(&deploymentCopy); err != nil {
-			s.Logger.Log(logger.Warning, "Failed to record S3 image metadata: "+err.Error(), deploymentCopy.ID.String())
+			s.Logger.Log(logger.Warning, "deploy tasks: Failed to record S3 image metadata: "+err.Error(), deploymentCopy.ID.String())
 		}
 		taskCtx.FlushLogs()
 	}()

--- a/api/internal/features/deploy/tasks/util.go
+++ b/api/internal/features/deploy/tasks/util.go
@@ -87,7 +87,7 @@ func (s *TaskService) NewTaskContext(result shared_types.TaskPayload) *TaskConte
 func (tc *TaskContext) UpdateDeployment(deployment *shared_types.ApplicationDeployment) {
 	err := tc.service.Storage.UpdateApplicationDeployment(deployment)
 	if err != nil {
-		tc.service.Logger.Log(logger.Error, "Failed to update application deployment: "+err.Error(), "")
+		tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to update application deployment: "+err.Error(), "")
 	}
 }
 
@@ -101,7 +101,7 @@ func (tc *TaskContext) UpdateStatus(status shared_types.Status) {
 
 	err := tc.service.Storage.UpdateApplicationDeploymentStatus(&appStatus)
 	if err != nil {
-		tc.service.Logger.Log(logger.Error, "Failed to update application deployment status: "+err.Error(), "")
+		tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to update application deployment status: "+err.Error(), "")
 	}
 }
 
@@ -141,10 +141,10 @@ func (tc *TaskContext) FlushLogs() {
 	tc.mu.Unlock()
 
 	if err := tc.service.Storage.AddApplicationLogsBatch(batch); err != nil {
-		tc.service.Logger.Log(logger.Error, "Failed to flush log batch: "+err.Error(), "")
+		tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to flush log batch: "+err.Error(), "")
 		for _, log := range batch {
 			if singleErr := tc.service.Storage.AddApplicationLogs(&log); singleErr != nil {
-				tc.service.Logger.Log(logger.Error, "Failed to add individual log: "+singleErr.Error(), "")
+				tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to add individual log: "+singleErr.Error(), "")
 			}
 		}
 	}
@@ -199,7 +199,7 @@ func (s *TaskService) NewLiveDevTaskContext(config LiveDevConfig) (*LiveDevTaskC
 	}
 
 	if err := s.Storage.AddApplicationDeployment(deployment); err != nil {
-		s.Logger.Log(logger.Error, "Failed to create live dev deployment record: "+err.Error(), "")
+		s.Logger.Log(logger.Error, "deploy tasks: Failed to create live dev deployment record: "+err.Error(), "")
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func (s *TaskService) NewLiveDevTaskContext(config LiveDevConfig) (*LiveDevTaskC
 	}
 
 	if err := s.Storage.AddApplicationDeploymentStatus(initialStatus); err != nil {
-		s.Logger.Log(logger.Error, "Failed to create live dev deployment status: "+err.Error(), "")
+		s.Logger.Log(logger.Error, "deploy tasks: Failed to create live dev deployment status: "+err.Error(), "")
 		return nil, err
 	}
 
@@ -241,7 +241,7 @@ func (tc *LiveDevTaskContext) AddLog(logMessage string) {
 
 	err := tc.service.Storage.AddApplicationLogs(&appLog)
 	if err != nil {
-		tc.service.Logger.Log(logger.Error, "Failed to add live dev log: "+err.Error(), "")
+		tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to add live dev log: "+err.Error(), "")
 	}
 	if tc.OnBuildLog != nil {
 		tc.OnBuildLog(tc.applicationID, logMessage)
@@ -259,7 +259,7 @@ func (tc *LiveDevTaskContext) UpdateStatus(status shared_types.Status) {
 
 	err := tc.service.Storage.UpdateApplicationDeploymentStatus(&appStatus)
 	if err != nil {
-		tc.service.Logger.Log(logger.Error, "Failed to update live dev deployment status: "+err.Error(), "")
+		tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to update live dev deployment status: "+err.Error(), "")
 	}
 }
 
@@ -291,7 +291,7 @@ func (tc *LiveDevTaskContext) UpdateDeployment(updates map[string]interface{}) {
 
 	err := tc.service.Storage.UpdateApplicationDeployment(deployment)
 	if err != nil {
-		tc.service.Logger.Log(logger.Error, "Failed to update live dev deployment: "+err.Error(), "")
+		tc.service.Logger.Log(logger.Error, "deploy tasks: Failed to update live dev deployment: "+err.Error(), "")
 	}
 }
 

--- a/api/internal/features/deploy/tasks/webhook.go
+++ b/api/internal/features/deploy/tasks/webhook.go
@@ -50,7 +50,7 @@ func (t *TaskService) EnqueueWebhookTask(payload shared_types.WebhookPayload) er
 
 		if commitHash != "" {
 			if isDup, _ := t.isWebhookDuplicate(application.ID.String(), commitHash); isDup {
-				t.Logger.Log(logger.Info, "skipping duplicate webhook for app "+application.Name+" commit "+commitHash, "")
+				t.Logger.Log(logger.Info, "deploy tasks: skipping duplicate webhook for app "+application.Name+" commit "+commitHash, "")
 				continue
 			}
 		}
@@ -69,11 +69,11 @@ func (t *TaskService) EnqueueWebhookTask(payload shared_types.WebhookPayload) er
 
 		_, err := t.UpdateDeploymentWithTrigger(deployment, application.UserID, application.OrganizationID)
 		if err != nil {
-			t.Logger.Log(logger.Error, "failed to update deployment for webhook", err.Error())
+			t.Logger.Log(logger.Error, "deploy tasks: failed to update deployment for webhook", err.Error())
 			continue
 		}
 
-		t.Logger.Log(logger.Info, types.LogDeploymentStarted, "")
+		t.Logger.Log(logger.Info, "deploy tasks: "+types.LogDeploymentStarted, "")
 	}
 
 	return nil

--- a/api/internal/features/deploy/validation/validator.go
+++ b/api/internal/features/deploy/validation/validator.go
@@ -10,14 +10,20 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/deploy/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
 type Validator struct {
+	Logger *logger.Logger // optional; nil skips validation debug logs
 }
 
 func NewValidator() *Validator {
 	return &Validator{}
+}
+
+func NewValidatorWithLogger(l *logger.Logger) *Validator {
+	return &Validator{Logger: l}
 }
 
 func (v *Validator) ParseRequestBody(req interface{}, body io.ReadCloser, decoded interface{}) error {
@@ -53,6 +59,9 @@ func (v *Validator) ValidateRequest(req interface{}) error {
 	case *types.CancelDeploymentRequest:
 		return validateCancelDeploymentRequest(*r)
 	default:
+		if v.Logger != nil {
+			v.Logger.Log(logger.Debug, fmt.Sprintf("deploy validation: invalid request type %T", req), "")
+		}
 		return types.ErrInvalidRequestType
 	}
 }

--- a/api/internal/features/domain/controller/custom_domains.go
+++ b/api/internal/features/domain/controller/custom_domains.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -14,24 +15,32 @@ import (
 func (c *DomainsController) HandleAddCustomDomain(f fuego.ContextWithBody[types.AddCustomDomainRequest]) (*types.DNSSetupResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("add custom domain: invalid request body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logger.Log(logger.Error, "add custom domain: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logger.Log(logger.Error, "add custom domain: organization ID is required", user.ID.String())
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
+	ctx := fmt.Sprintf("user_id=%s org_id=%s name=%s", user.ID, orgID, req.Name)
+	c.logger.Log(logger.Info, "add custom domain: submitting", ctx)
+
 	domain, instructions, dnsProvider, err := c.service.AddCustomDomain(f.Context(), user.ID, orgID, req.Name)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("add custom domain: %v", err), ctx)
 		return nil, mapCustomDomainError(err)
 	}
+
+	c.logger.Log(logger.Info, "add custom domain: success", fmt.Sprintf("%s domain_id=%s", ctx, domain.ID))
 
 	return &types.DNSSetupResponse{
 		Status:       "success",
@@ -45,19 +54,26 @@ func (c *DomainsController) HandleAddCustomDomain(f fuego.ContextWithBody[types.
 func (c *DomainsController) HandleListCustomDomains(f fuego.ContextNoBody) (*types.CustomDomainListResponse, error) {
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logger.Log(logger.Error, "list custom domains: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logger.Log(logger.Error, "list custom domains: organization ID is required", user.ID.String())
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
+	ctx := fmt.Sprintf("user_id=%s org_id=%s", user.ID, orgID)
+	c.logger.Log(logger.Info, "list custom domains: fetching", ctx)
+
 	domains, err := c.service.ListCustomDomains(f.Context(), orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("list custom domains: %v", err), ctx)
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
+
+	c.logger.Log(logger.Info, "list custom domains: success", fmt.Sprintf("%s count=%d", ctx, len(domains)))
 
 	return &types.CustomDomainListResponse{
 		Status:  "success",
@@ -69,29 +85,38 @@ func (c *DomainsController) HandleListCustomDomains(f fuego.ContextNoBody) (*typ
 func (c *DomainsController) HandleVerifyCustomDomain(f fuego.ContextWithBody[types.VerifyCustomDomainRequest]) (*types.CustomDomainResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("verify custom domain: invalid request body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logger.Log(logger.Error, "verify custom domain: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logger.Log(logger.Error, "verify custom domain: organization ID is required", user.ID.String())
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	domainID, err := uuid.Parse(req.ID)
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("verify custom domain: invalid domain id: %v", err), user.ID.String())
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
+	ctx := fmt.Sprintf("user_id=%s org_id=%s domain_id=%s", user.ID, orgID, domainID)
+	c.logger.Log(logger.Info, "verify custom domain: submitting", ctx)
+
 	domain, err := c.service.VerifyCustomDomain(f.Context(), domainID, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("verify custom domain: %v", err), ctx)
 		return nil, mapCustomDomainError(err)
 	}
+
+	c.logger.Log(logger.Info, "verify custom domain: success", ctx)
 
 	return &types.CustomDomainResponse{
 		Status:  "success",
@@ -103,28 +128,37 @@ func (c *DomainsController) HandleVerifyCustomDomain(f fuego.ContextWithBody[typ
 func (c *DomainsController) HandleRemoveCustomDomain(f fuego.ContextWithBody[types.RemoveCustomDomainRequest]) (*types.MessageResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("remove custom domain: invalid request body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logger.Log(logger.Error, "remove custom domain: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logger.Log(logger.Error, "remove custom domain: organization ID is required", user.ID.String())
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	domainID, err := uuid.Parse(req.ID)
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("remove custom domain: invalid domain id: %v", err), user.ID.String())
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
+	ctx := fmt.Sprintf("user_id=%s org_id=%s domain_id=%s", user.ID, orgID, domainID)
+	c.logger.Log(logger.Info, "remove custom domain: submitting", ctx)
+
 	if err := c.service.RemoveCustomDomain(f.Context(), domainID, orgID); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("remove custom domain: %v", err), ctx)
 		return nil, mapCustomDomainError(err)
 	}
+
+	c.logger.Log(logger.Info, "remove custom domain: success", ctx)
 
 	return &types.MessageResponse{
 		Status:  "success",
@@ -135,16 +169,19 @@ func (c *DomainsController) HandleRemoveCustomDomain(f fuego.ContextWithBody[typ
 func (c *DomainsController) HandleCheckDNSStatus(f fuego.ContextNoBody) (*types.DNSCheckResponse, error) {
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logger.Log(logger.Error, "check DNS status: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logger.Log(logger.Error, "check DNS status: organization ID is required", user.ID.String())
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	domainIDStr := f.QueryParam("id")
 	if domainIDStr == "" {
+		c.logger.Log(logger.Debug, "check DNS status: missing id query parameter", user.ID.String())
 		return nil, fuego.BadRequestError{
 			Detail: shared_types.ErrFailedToGetUserFromContext.Error(),
 			Err:    shared_types.ErrFailedToGetUserFromContext,
@@ -153,14 +190,20 @@ func (c *DomainsController) HandleCheckDNSStatus(f fuego.ContextNoBody) (*types.
 
 	domainID, err := uuid.Parse(domainIDStr)
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("check DNS status: invalid domain id: %v", err), user.ID.String())
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
+	ctx := fmt.Sprintf("user_id=%s org_id=%s domain_id=%s", user.ID, orgID, domainID)
+	c.logger.Log(logger.Debug, "check DNS status: checking", ctx)
+
 	verified, dnsStatus, err := c.service.CheckDNSStatus(f.Context(), domainID, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("check DNS status: %v", err), ctx)
 		return nil, mapCustomDomainError(err)
 	}
+
+	c.logger.Log(logger.Debug, fmt.Sprintf("check DNS status: done verified=%v dns_status=%s", verified, dnsStatus), ctx)
 
 	message := "DNS is not yet configured"
 	if verified {

--- a/api/internal/features/domain/controller/get_domains.go
+++ b/api/internal/features/domain/controller/get_domains.go
@@ -19,7 +19,7 @@ func (c *DomainsController) GetDomains(f fuego.ContextNoBody) (*types.ListDomain
 
 	organization_id := utils.GetOrganizationID(r)
 	if organization_id == uuid.Nil {
-		c.logger.Log(logger.Error, "invalid organization id", "")
+		c.logger.Log(logger.Error, "get domains: organization ID is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrMissingID.Error(),
 			Err:    types.ErrMissingID,
@@ -28,7 +28,7 @@ func (c *DomainsController) GetDomains(f fuego.ContextNoBody) (*types.ListDomain
 
 	user := utils.GetUser(w, r)
 	if user == nil {
-		c.logger.Log(logger.Error, "unauthorized user", "")
+		c.logger.Log(logger.Error, "get domains: authentication required", fmt.Sprintf("org_id=%s", organization_id))
 		return nil, fuego.UnauthorizedError{
 			Detail: types.ErrAccessDenied.Error(),
 			Err:    types.ErrAccessDenied,
@@ -36,12 +36,17 @@ func (c *DomainsController) GetDomains(f fuego.ContextNoBody) (*types.ListDomain
 	}
 
 	domainType := f.QueryParam("type")
+	ctx := fmt.Sprintf("user_id=%s org_id=%s", user.ID, organization_id)
+	if domainType != "" {
+		ctx = fmt.Sprintf("%s type=%s", ctx, domainType)
+		c.logger.Log(logger.Debug, "get domains: filtering by type", ctx)
+	}
 
-	c.logger.Log(logger.Info, "fetching domains", fmt.Sprintf("organization_id: %s", organization_id))
+	c.logger.Log(logger.Info, "get domains: fetching", ctx)
 
 	domains, err := c.service.GetDomains(organization_id.String(), user.ID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("get domains: %v", err), ctx)
 
 		if isPermissionError(err) {
 			return nil, fuego.ForbiddenError{
@@ -74,6 +79,8 @@ func (c *DomainsController) GetDomains(f fuego.ContextNoBody) (*types.ListDomain
 		domains = filtered
 	}
 
+	c.logger.Log(logger.Info, "get domains: success", fmt.Sprintf("%s count=%d", ctx, len(domains)))
+
 	return &types.ListDomainsResponse{
 		Status:  "success",
 		Message: "Domains fetched successfully",
@@ -86,7 +93,7 @@ func (c *DomainsController) GenerateRandomSubDomain(f fuego.ContextNoBody) (*typ
 
 	organization_id := utils.GetOrganizationID(r)
 	if organization_id == uuid.Nil {
-		c.logger.Log(logger.Error, "invalid organization id", "")
+		c.logger.Log(logger.Error, "generate random subdomain: organization ID is required", "")
 		return nil, fuego.BadRequestError{
 			Detail: types.ErrMissingID.Error(),
 			Err:    types.ErrMissingID,
@@ -95,16 +102,19 @@ func (c *DomainsController) GenerateRandomSubDomain(f fuego.ContextNoBody) (*typ
 
 	user := utils.GetUser(w, r)
 	if user == nil {
-		c.logger.Log(logger.Error, "unauthorized user", "")
+		c.logger.Log(logger.Error, "generate random subdomain: authentication required", fmt.Sprintf("org_id=%s", organization_id))
 		return nil, fuego.UnauthorizedError{
 			Detail: types.ErrAccessDenied.Error(),
 			Err:    types.ErrAccessDenied,
 		}
 	}
 
+	ctx := fmt.Sprintf("user_id=%s org_id=%s", user.ID, organization_id)
+	c.logger.Log(logger.Info, "generate random subdomain: fetching domains", ctx)
+
 	domains, err := c.service.GetDomains(organization_id.String(), user.ID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("generate random subdomain: %v", err), ctx)
 
 		if isPermissionError(err) {
 			return nil, fuego.ForbiddenError{
@@ -128,7 +138,7 @@ func (c *DomainsController) GenerateRandomSubDomain(f fuego.ContextNoBody) (*typ
 	}
 
 	if len(domains) == 0 {
-		c.logger.Log(logger.Error, "no domains available for subdomain generation", "")
+		c.logger.Log(logger.Error, "generate random subdomain: no domains available for organization", ctx)
 		return nil, fuego.NotFoundError{
 			Detail: types.ErrDomainNotFound.Error(),
 			Err:    types.ErrDomainNotFound,
@@ -155,7 +165,7 @@ func (c *DomainsController) GenerateRandomSubDomain(f fuego.ContextNoBody) (*typ
 		Domain:    randomDomain.Name,
 	}
 
-	c.logger.Log(logger.Info, "Generated random subdomain", subdomain)
+	c.logger.Log(logger.Info, "generate random subdomain: success", fmt.Sprintf("%s subdomain=%s base_domain=%s", ctx, subdomain, randomDomain.Name))
 
 	return &types.RandomSubdomainResponseWrapper{
 		Status:  "success",

--- a/api/internal/features/domain/controller/init.go
+++ b/api/internal/features/domain/controller/init.go
@@ -24,7 +24,7 @@ func NewDomainsController(
 	l logger.Logger,
 	notifier shared_types.Notifier,
 ) *DomainsController {
-	domainStorage := storage.DomainStorage{DB: store.DB, Ctx: ctx}
+	domainStorage := storage.DomainStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	return &DomainsController{
 		store:    store,
 		service:  service.NewDomainsService(ctx, l, &domainStorage),

--- a/api/internal/features/domain/service/custom_domains.go
+++ b/api/internal/features/domain/service/custom_domains.go
@@ -15,15 +15,21 @@ import (
 )
 
 func (s *DomainsService) AddCustomDomain(ctx context.Context, userID, orgID uuid.UUID, name string) (*shared_types.Domain, []types.DNSInstruction, string, error) {
-	s.logger.Log(logger.Info, "add custom domain request", fmt.Sprintf("domain=%s, org_id=%s", name, orgID))
+	ctxStr := fmt.Sprintf("user_id=%s org_id=%s name=%s", userID, orgID, name)
+	s.logger.Log(logger.Info, "add custom domain: start", ctxStr)
 
 	if err := s.validateDomainName(name); err != nil {
+		if err == types.ErrDomainAlreadyExists {
+			s.logger.Log(logger.Debug, "add custom domain: domain already exists", ctxStr)
+		} else {
+			s.logger.Log(logger.Error, fmt.Sprintf("add custom domain: validate name: %v", err), ctxStr)
+		}
 		return nil, nil, "", err
 	}
 
 	defaultKey, err := s.storage.GetDefaultSSHKeyByOrg(orgID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get default server for org", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("add custom domain: get default SSH key for org: %v", err), ctxStr)
 		return nil, nil, "", fmt.Errorf("no default server configured for organization")
 	}
 
@@ -38,6 +44,7 @@ func (s *DomainsService) AddCustomDomain(ctx context.Context, userID, orgID uuid
 
 	dnsProvider, _ := s.dns.DetectProvider(name)
 	verificationToken := s.dns.GenerateToken()
+	s.logger.Log(logger.Debug, fmt.Sprintf("add custom domain: detected dns_provider=%s is_byos=%v", dnsProvider, isBYOS), ctxStr)
 
 	if isBYOS {
 		machineIP := ""
@@ -45,37 +52,43 @@ func (s *DomainsService) AddCustomDomain(ctx context.Context, userID, orgID uuid
 			machineIP = *defaultKey.Host
 		}
 		if machineIP == "" {
+			s.logger.Log(logger.Error, "add custom domain: BYOS default server has no IP", ctxStr)
 			return nil, nil, "", fmt.Errorf("default server has no IP configured")
 		}
 		targetSubdomain = machineIP
 
 		domain := buildDomain(userID, orgID, name, verificationToken, dnsProvider, targetSubdomain)
 		if err := s.storage.CreateCustomDomain(domain); err != nil {
-			s.logger.Log(logger.Error, "failed to create custom domain", err.Error())
+			s.logger.Log(logger.Error, fmt.Sprintf("add custom domain: create (BYOS): %v", err), ctxStr)
 			return nil, nil, "", err
 		}
 		instructions := s.dns.GenerateDNSInstructionsBYOS(name, machineIP, dnsProvider)
+		s.logger.Log(logger.Info, "add custom domain: success (BYOS)", fmt.Sprintf("%s domain_id=%s", ctxStr, domain.ID))
 		return domain, instructions, dnsProvider, nil
 	}
 
 	if targetSubdomain == "" {
+		s.logger.Log(logger.Error, "add custom domain: no subdomain configured for organization", ctxStr)
 		return nil, nil, "", fmt.Errorf("no subdomain configured for this organization")
 	}
 
 	domain := buildDomain(userID, orgID, name, verificationToken, dnsProvider, targetSubdomain)
 	if err := s.storage.CreateCustomDomain(domain); err != nil {
-		s.logger.Log(logger.Error, "failed to create custom domain", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("add custom domain: create: %v", err), ctxStr)
 		return nil, nil, "", err
 	}
 	instructions := s.dns.GenerateDNSInstructions(name, targetSubdomain, dnsProvider)
+	s.logger.Log(logger.Info, "add custom domain: success", fmt.Sprintf("%s domain_id=%s target_subdomain=%s", ctxStr, domain.ID, targetSubdomain))
 	return domain, instructions, dnsProvider, nil
 }
 
 func (s *DomainsService) VerifyCustomDomain(ctx context.Context, domainID, orgID uuid.UUID) (*shared_types.Domain, error) {
-	s.logger.Log(logger.Info, "verify custom domain request", fmt.Sprintf("domain_id=%s", domainID))
+	ctxStr := fmt.Sprintf("org_id=%s domain_id=%s", orgID, domainID)
+	s.logger.Log(logger.Info, "verify custom domain: start", ctxStr)
 
 	domain, err := s.storage.GetCustomDomainByID(domainID, orgID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("verify custom domain: load domain: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -94,14 +107,16 @@ func (s *DomainsService) VerifyCustomDomain(ctx context.Context, domainID, orgID
 	}
 
 	if verifyErr != nil {
-		s.logger.Log(logger.Error, "DNS verification failed", verifyErr.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("verify custom domain: DNS check error: %v", verifyErr), fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 		return nil, verifyErr
 	}
 	if !verified {
+		s.logger.Log(logger.Debug, "verify custom domain: DNS not verified yet", fmt.Sprintf("%s name=%s target=%s", ctxStr, domain.Name, targetSubdomain))
 		return nil, types.ErrDNSNotVerified
 	}
 
 	if err := s.storage.UpdateCustomDomainVerification(domainID, "dns_verified", domain.DNSProvider); err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("verify custom domain: update verification status: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -123,22 +138,26 @@ func (s *DomainsService) VerifyCustomDomain(ctx context.Context, domainID, orgID
 	}
 
 	if err := s.queue.EnqueueRegisterCustomDomain(ctx, payload); err != nil {
-		s.logger.Log(logger.Error, "failed to enqueue domain registration", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("verify custom domain: enqueue registration: %v", err), ctxStr)
 	}
 
 	domain.Status = "dns_verified"
+	s.logger.Log(logger.Info, "verify custom domain: success", fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 	return domain, nil
 }
 
 func (s *DomainsService) RemoveCustomDomain(ctx context.Context, domainID, orgID uuid.UUID) error {
-	s.logger.Log(logger.Info, "remove custom domain request", fmt.Sprintf("domain_id=%s", domainID))
+	ctxStr := fmt.Sprintf("org_id=%s domain_id=%s", orgID, domainID)
+	s.logger.Log(logger.Info, "remove custom domain: start", ctxStr)
 
 	domain, err := s.storage.GetCustomDomainByID(domainID, orgID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("remove custom domain: load domain: %v", err), ctxStr)
 		return err
 	}
 
 	if err := s.storage.UpdateCustomDomainStatus(domainID, "removing"); err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("remove custom domain: set status removing: %v", err), ctxStr)
 		return err
 	}
 
@@ -154,19 +173,37 @@ func (s *DomainsService) RemoveCustomDomain(ctx context.Context, domainID, orgID
 	}
 
 	if err := s.queue.EnqueueRemoveCustomDomain(ctx, removePayload); err != nil {
-		s.logger.Log(logger.Error, "failed to enqueue domain removal", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("remove custom domain: enqueue removal: %v", err), ctxStr)
 	}
 
-	return s.storage.DeleteCustomDomain(domainID)
+	if err := s.storage.DeleteCustomDomain(domainID); err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("remove custom domain: delete: %v", err), ctxStr)
+		return err
+	}
+	s.logger.Log(logger.Info, "remove custom domain: success", fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
+	return nil
 }
 
 func (s *DomainsService) ListCustomDomains(ctx context.Context, orgID uuid.UUID) ([]shared_types.Domain, error) {
-	return s.storage.GetCustomDomainsByOrg(orgID)
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	s.logger.Log(logger.Debug, "list custom domains: storage lookup", ctxStr)
+
+	domains, err := s.storage.GetCustomDomainsByOrg(orgID)
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("list custom domains: %v", err), ctxStr)
+		return nil, err
+	}
+	s.logger.Log(logger.Info, "list custom domains: success", fmt.Sprintf("%s count=%d", ctxStr, len(domains)))
+	return domains, nil
 }
 
 func (s *DomainsService) CheckDNSStatus(ctx context.Context, domainID, orgID uuid.UUID) (bool, string, error) {
+	ctxStr := fmt.Sprintf("org_id=%s domain_id=%s", orgID, domainID)
+	s.logger.Log(logger.Debug, "check DNS status: start", ctxStr)
+
 	domain, err := s.storage.GetCustomDomainByID(domainID, orgID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("check DNS status: load domain: %v", err), ctxStr)
 		return false, "", err
 	}
 
@@ -178,26 +215,31 @@ func (s *DomainsService) CheckDNSStatus(ctx context.Context, domainID, orgID uui
 	if net.ParseIP(targetSubdomain) != nil {
 		verified, _ := s.dns.VerifyARecord(domain.Name, targetSubdomain)
 		if verified {
+			s.logger.Log(logger.Debug, "check DNS status: BYOS A record verified", fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 			return true, "verified", nil
 		}
 		propagationStatus, _ := s.dns.CheckPropagationBYOS(domain.Name, targetSubdomain)
+		s.logger.Log(logger.Debug, fmt.Sprintf("check DNS status: BYOS result status=%s", propagationStatus), fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 		return false, propagationStatus, nil
 	}
 
 	verified, err := s.dns.VerifyDNSConfig(domain.Name, targetSubdomain)
 	if err != nil {
+		s.logger.Log(logger.Debug, fmt.Sprintf("check DNS status: verify config error (treating as not configured): %v", err), fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 		return false, "not_configured", nil
 	}
 	if verified {
+		s.logger.Log(logger.Debug, "check DNS status: DNS config verified", fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 		return true, "verified", nil
 	}
 	propagationStatus, _ := s.dns.CheckPropagation(domain.Name)
+	s.logger.Log(logger.Debug, fmt.Sprintf("check DNS status: propagation status=%s", propagationStatus), fmt.Sprintf("%s name=%s", ctxStr, domain.Name))
 	return false, propagationStatus, nil
 }
 
 // validateDomainName checks format then uniqueness before creating a domain.
 func (s *DomainsService) validateDomainName(name string) error {
-	if err := validation.NewValidator(s.storage).ValidateName(name); err != nil {
+	if err := validation.NewValidatorWithLogger(s.storage, &s.logger).ValidateName(name); err != nil {
 		return err
 	}
 	existing, err := s.storage.GetCustomDomainByName(name)

--- a/api/internal/features/domain/service/dns_detection.go
+++ b/api/internal/features/domain/service/dns_detection.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/nixopus/nixopus/api/internal/features/domain/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 // randReadFn is the source of randomness for GenerateVerificationToken.
@@ -78,11 +79,13 @@ func matchNSToProvider(nsRecords []*net.NS) string {
 
 // detectDNSProvider determines the DNS provider for a domain using the supplied
 // NetLookup. Falls back to "other" when no provider can be identified.
-func detectDNSProvider(resolver NetLookup, domain string) (string, error) {
+func detectDNSProvider(resolver NetLookup, domain string, log *logger.Logger) (string, error) {
 	rootDomain := extractRootDomain(domain)
+	dnsLog(log, logger.Debug, "dns: detect provider start", fmt.Sprintf("domain=%s root=%s", domain, rootDomain))
 
 	if nsRecords, err := resolver.LookupNS(rootDomain); err == nil && len(nsRecords) > 0 {
 		if provider := matchNSToProvider(nsRecords); provider != "" {
+			dnsLog(log, logger.Debug, "dns: detect provider done", fmt.Sprintf("domain=%s provider=%s via=root_ns", domain, provider))
 			return provider, nil
 		}
 	}
@@ -90,6 +93,7 @@ func detectDNSProvider(resolver NetLookup, domain string) (string, error) {
 	if domain != rootDomain {
 		if nsRecords, err := resolver.LookupNS(domain); err == nil && len(nsRecords) > 0 {
 			if provider := matchNSToProvider(nsRecords); provider != "" {
+				dnsLog(log, logger.Debug, "dns: detect provider done", fmt.Sprintf("domain=%s provider=%s via=fqdn_ns", domain, provider))
 				return provider, nil
 			}
 		}
@@ -100,18 +104,20 @@ func detectDNSProvider(resolver NetLookup, domain string) (string, error) {
 			host := strings.ToLower(strings.TrimSuffix(ns.Host, "."))
 			for pattern, provider := range nsProviderMap {
 				if strings.Contains(host, pattern) {
+					dnsLog(log, logger.Debug, "dns: detect provider done", fmt.Sprintf("domain=%s provider=%s via=root_ns_pattern", domain, provider))
 					return provider, nil
 				}
 			}
 		}
 	}
 
+	dnsLog(log, logger.Debug, "dns: detect provider done", fmt.Sprintf("domain=%s provider=other", domain))
 	return "other", nil
 }
 
 // DetectDNSProvider is the exported entry point backed by defaultResolver.
 func DetectDNSProvider(domain string) (string, error) {
-	return detectDNSProvider(defaultResolver, domain)
+	return detectDNSProvider(defaultResolver, domain, nil)
 }
 
 // GenerateDNSInstructions returns CNAME + TXT setup instructions for a managed domain.
@@ -163,9 +169,14 @@ func GenerateDNSInstructions(domain, targetSubdomain, provider string) []types.D
 
 // GenerateVerificationToken produces a 32-character hex verification token.
 func GenerateVerificationToken() string {
+	return generateVerificationToken(nil)
+}
+
+func generateVerificationToken(log *logger.Logger) string {
 	bytes := make([]byte, 16)
 	_, err := randReadFn(bytes)
 	if err != nil {
+		dnsLog(log, logger.Warning, "dns: verification token crypto/rand failed, using zero fallback", err.Error())
 		return hex.EncodeToString(make([]byte, 16))
 	}
 	return hex.EncodeToString(bytes)

--- a/api/internal/features/domain/service/dns_detection_test.go
+++ b/api/internal/features/domain/service/dns_detection_test.go
@@ -119,7 +119,7 @@ func TestMatchNSToProvider_Empty(t *testing.T) {
 
 func TestDetectDNSProvider_RootDomainNSMatch(t *testing.T) {
 	mock := &mockNetLookup{nsRecords: []*net.NS{ns("ns1.cloudflare.com.")}}
-	provider, err := detectDNSProvider(mock, "app.example.com")
+	provider, err := detectDNSProvider(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestDetectDNSProvider_SubdomainNSMatch(t *testing.T) {
 			"app.example.com": {ns("ns1.cloudflare.com.")},
 		},
 	}
-	provider, err := detectDNSProvider(mock, "app.example.com")
+	provider, err := detectDNSProvider(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestDetectDNSProvider_SubdomainSkippedWhenSameAsRoot(t *testing.T) {
 	mock.nsErr = errors.New("no NS")
 	_ = callCount
 
-	provider, err := detectDNSProvider(mock, "example.com")
+	provider, err := detectDNSProvider(mock, "example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestDetectDNSProvider_SubdomainSkippedWhenSameAsRoot(t *testing.T) {
 
 func TestDetectDNSProvider_FallbackToOther(t *testing.T) {
 	mock := &mockNetLookup{nsErr: errors.New("no NS records")}
-	provider, err := detectDNSProvider(mock, "app.example.com")
+	provider, err := detectDNSProvider(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestDetectDNSProvider_FallbackToOther(t *testing.T) {
 
 func TestDetectDNSProvider_Route53(t *testing.T) {
 	mock := &mockNetLookup{nsRecords: []*net.NS{ns("ns1.awsdns-01.com.")}}
-	provider, _ := detectDNSProvider(mock, "example.com")
+	provider, _ := detectDNSProvider(mock, "example.com", nil)
 	if provider != "route53" {
 		t.Errorf("expected route53, got %s", provider)
 	}
@@ -327,7 +327,7 @@ func TestDetectDNSProvider_ThirdBlock_Match(t *testing.T) {
 		},
 		errs: []error{nil, nil},
 	}
-	provider, err := detectDNSProvider(mock, "example.com")
+	provider, err := detectDNSProvider(mock, "example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/internal/features/domain/service/dns_verification.go
+++ b/api/internal/features/domain/service/dns_verification.go
@@ -3,15 +3,19 @@ package service
 import (
 	"fmt"
 	"strings"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 // verifyDNSConfiguration checks whether domain's DNS points to targetSubdomain
 // via CNAME, matching A records, or a TXT ownership record.
-func verifyDNSConfiguration(resolver NetLookup, domain, targetSubdomain string) (bool, error) {
+func verifyDNSConfiguration(resolver NetLookup, domain, targetSubdomain string, log *logger.Logger) (bool, error) {
+	dnsLog(log, logger.Debug, "dns: verify config start", fmt.Sprintf("domain=%s target=%s", domain, targetSubdomain))
 	expectedTarget := fmt.Sprintf("%s.nixopus.ai.", targetSubdomain)
 
 	cname, err := resolver.LookupCNAME(domain)
 	if err == nil && strings.EqualFold(cname, expectedTarget) {
+		dnsLog(log, logger.Debug, "dns: verify config ok", fmt.Sprintf("domain=%s match=cname", domain))
 		return true, nil
 	}
 
@@ -22,6 +26,7 @@ func verifyDNSConfiguration(resolver NetLookup, domain, targetSubdomain string) 
 			for _, h := range hosts {
 				for _, th := range targetHosts {
 					if h == th {
+						dnsLog(log, logger.Debug, "dns: verify config ok", fmt.Sprintf("domain=%s match=a_same_ip", domain))
 						return true, nil
 					}
 				}
@@ -34,24 +39,28 @@ func verifyDNSConfiguration(resolver NetLookup, domain, targetSubdomain string) 
 	if err == nil {
 		for _, txt := range txtRecords {
 			if strings.EqualFold(strings.TrimSpace(txt), expectedTXT) {
+				dnsLog(log, logger.Debug, "dns: verify config ok", fmt.Sprintf("domain=%s match=txt", domain))
 				return true, nil
 			}
 		}
 	}
 
+	dnsLog(log, logger.Debug, "dns: verify config no match", fmt.Sprintf("domain=%s target=%s", domain, targetSubdomain))
 	return false, nil
 }
 
 // VerifyDNSConfiguration is the exported entry point backed by defaultResolver.
 func VerifyDNSConfiguration(domain, targetSubdomain string) (bool, error) {
-	return verifyDNSConfiguration(defaultResolver, domain, targetSubdomain)
+	return verifyDNSConfiguration(defaultResolver, domain, targetSubdomain, nil)
 }
 
 // checkDNSPropagation returns the propagation state of the domain's DNS records.
-func checkDNSPropagation(resolver NetLookup, domain string) (string, error) {
+func checkDNSPropagation(resolver NetLookup, domain string, log *logger.Logger) (string, error) {
+	dnsLog(log, logger.Debug, "dns: check propagation start", fmt.Sprintf("domain=%s", domain))
 	cname, err := resolver.LookupCNAME(domain)
 	if err == nil && cname != "" && cname != domain+"." {
 		if strings.Contains(strings.ToLower(cname), "nixopus.ai") {
+			dnsLog(log, logger.Debug, "dns: check propagation done", "domain="+domain+" status=verified via=cname")
 			return "verified", nil
 		}
 	}
@@ -61,6 +70,7 @@ func checkDNSPropagation(resolver NetLookup, domain string) (string, error) {
 	if err == nil {
 		for _, txt := range txtRecords {
 			if strings.EqualFold(strings.TrimSpace(txt), expectedTXT) {
+				dnsLog(log, logger.Debug, "dns: check propagation done", "domain="+domain+" status=verified via=txt")
 				return "verified", nil
 			}
 		}
@@ -68,55 +78,66 @@ func checkDNSPropagation(resolver NetLookup, domain string) (string, error) {
 
 	_, err = resolver.LookupHost(domain)
 	if err != nil {
+		dnsLog(log, logger.Debug, "dns: check propagation done", "domain="+domain+" status=not_configured")
 		return "not_configured", nil
 	}
 
+	dnsLog(log, logger.Debug, "dns: check propagation done", "domain="+domain+" status=propagating")
 	return "propagating", nil
 }
 
 // CheckDNSPropagation is the exported entry point backed by defaultResolver.
 func CheckDNSPropagation(domain string) (string, error) {
-	return checkDNSPropagation(defaultResolver, domain)
+	return checkDNSPropagation(defaultResolver, domain, nil)
 }
 
 // verifyARecordMatchesMachineIP checks that the domain resolves to machineIP.
-func verifyARecordMatchesMachineIP(resolver NetLookup, domain, machineIP string) (bool, error) {
+func verifyARecordMatchesMachineIP(resolver NetLookup, domain, machineIP string, log *logger.Logger) (bool, error) {
+	dnsLog(log, logger.Debug, "dns: verify A record start", fmt.Sprintf("domain=%s", domain))
 	if machineIP == "" {
+		dnsLog(log, logger.Error, "dns: verify A record", "machine IP is not configured")
 		return false, fmt.Errorf("machine IP is not configured")
 	}
 	hosts, err := resolver.LookupHost(domain)
 	if err != nil {
+		dnsLog(log, logger.Debug, "dns: verify A record lookup failed", fmt.Sprintf("domain=%s err=%v", domain, err))
 		return false, nil
 	}
 	for _, h := range hosts {
 		if h == machineIP {
+			dnsLog(log, logger.Debug, "dns: verify A record ok", fmt.Sprintf("domain=%s ip=%s", domain, machineIP))
 			return true, nil
 		}
 	}
+	dnsLog(log, logger.Debug, "dns: verify A record no match", fmt.Sprintf("domain=%s expected_ip=%s got=%v", domain, machineIP, hosts))
 	return false, nil
 }
 
 // VerifyARecordMatchesMachineIP is the exported entry point backed by defaultResolver.
 func VerifyARecordMatchesMachineIP(domain, machineIP string) (bool, error) {
-	return verifyARecordMatchesMachineIP(defaultResolver, domain, machineIP)
+	return verifyARecordMatchesMachineIP(defaultResolver, domain, machineIP, nil)
 }
 
 // checkDNSPropagationBYOS returns the propagation state for a BYOS domain that
 // should resolve to machineIP via an A record.
-func checkDNSPropagationBYOS(resolver NetLookup, domain, machineIP string) (string, error) {
+func checkDNSPropagationBYOS(resolver NetLookup, domain, machineIP string, log *logger.Logger) (string, error) {
+	dnsLog(log, logger.Debug, "dns: check propagation BYOS start", fmt.Sprintf("domain=%s", domain))
 	hosts, err := resolver.LookupHost(domain)
 	if err != nil {
+		dnsLog(log, logger.Debug, "dns: check propagation BYOS done", fmt.Sprintf("domain=%s status=not_configured err=%v", domain, err))
 		return "not_configured", nil
 	}
 	for _, h := range hosts {
 		if h == machineIP {
+			dnsLog(log, logger.Debug, "dns: check propagation BYOS done", fmt.Sprintf("domain=%s status=verified ip=%s", domain, machineIP))
 			return "verified", nil
 		}
 	}
+	dnsLog(log, logger.Debug, "dns: check propagation BYOS done", fmt.Sprintf("domain=%s status=propagating hosts=%v", domain, hosts))
 	return "propagating", nil
 }
 
 // CheckDNSPropagationBYOS is the exported entry point backed by defaultResolver.
 func CheckDNSPropagationBYOS(domain, machineIP string) (string, error) {
-	return checkDNSPropagationBYOS(defaultResolver, domain, machineIP)
+	return checkDNSPropagationBYOS(defaultResolver, domain, machineIP, nil)
 }

--- a/api/internal/features/domain/service/dns_verification_test.go
+++ b/api/internal/features/domain/service/dns_verification_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestVerifyDNSConfiguration_CNAMEMatch(t *testing.T) {
 	mock := &mockNetLookup{cname: "myorg.nixopus.ai."}
-	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -22,7 +22,7 @@ func TestVerifyDNSConfiguration_CNAMEMatch(t *testing.T) {
 
 func TestVerifyDNSConfiguration_CNAMECaseInsensitive(t *testing.T) {
 	mock := &mockNetLookup{cname: "MYORG.NIXOPUS.AI."}
-	ok, _ := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, _ := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if !ok {
 		t.Error("CNAME match should be case-insensitive")
 	}
@@ -38,7 +38,7 @@ func TestVerifyDNSConfiguration_HostIPMatch(t *testing.T) {
 			"myorg.nixopus.ai": {"1.2.3.4"},
 		},
 	}
-	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestVerifyDNSConfiguration_HostIPNoMatch(t *testing.T) {
 			"myorg.nixopus.ai": {"5.6.7.8"},
 		},
 	}
-	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestVerifyDNSConfiguration_TXTMatch(t *testing.T) {
 		hostErr:    errors.New("no host"),
 		txtRecords: []string{"nixopus-domain-verify=app.example.com"},
 	}
-	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestVerifyDNSConfiguration_TXTMatchCaseInsensitive(t *testing.T) {
 		hostErr:    errors.New("no host"),
 		txtRecords: []string{"  NIXOPUS-DOMAIN-VERIFY=app.example.com  "},
 	}
-	ok, _ := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, _ := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if !ok {
 		t.Error("TXT match should be case-insensitive and trim spaces")
 	}
@@ -97,7 +97,7 @@ func TestVerifyDNSConfiguration_NothingMatches(t *testing.T) {
 		hostErr:  errors.New("no host"),
 		txtErr:   errors.New("no txt"),
 	}
-	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestVerifyDNSConfiguration_TargetHostLookupFails(t *testing.T) {
 		},
 		txtErr: errors.New("no txt"),
 	}
-	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg")
+	ok, err := verifyDNSConfiguration(mock, "app.example.com", "myorg", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestVerifyDNSConfiguration_TargetHostLookupFails(t *testing.T) {
 
 func TestCheckDNSPropagation_CNAMEVerified(t *testing.T) {
 	mock := &mockNetLookup{cname: "myorg.nixopus.ai."}
-	status, err := checkDNSPropagation(mock, "app.example.com")
+	status, err := checkDNSPropagation(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCheckDNSPropagation_CNAMESelfPointing(t *testing.T) {
 		hosts:  []string{"1.2.3.4"},
 		txtErr: errors.New("no txt"),
 	}
-	status, _ := checkDNSPropagation(mock, "app.example.com")
+	status, _ := checkDNSPropagation(mock, "app.example.com", nil)
 	if status != "propagating" {
 		t.Errorf("self-pointing CNAME should be propagating, got %s", status)
 	}
@@ -161,7 +161,7 @@ func TestCheckDNSPropagation_TXTVerified(t *testing.T) {
 		txtRecords: []string{"nixopus-domain-verify=app.example.com"},
 		hosts:      []string{"1.2.3.4"},
 	}
-	status, err := checkDNSPropagation(mock, "app.example.com")
+	status, err := checkDNSPropagation(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestCheckDNSPropagation_NotConfigured(t *testing.T) {
 		txtErr:   errors.New("no txt"),
 		hostErr:  errors.New("no host"),
 	}
-	status, err := checkDNSPropagation(mock, "app.example.com")
+	status, err := checkDNSPropagation(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestCheckDNSPropagation_Propagating(t *testing.T) {
 		txtErr:   errors.New("no txt"),
 		hosts:    []string{"1.2.3.4"},
 	}
-	status, err := checkDNSPropagation(mock, "app.example.com")
+	status, err := checkDNSPropagation(mock, "app.example.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestCheckDNSPropagation_CNAMEDoesNotContainNixopus(t *testing.T) {
 		txtErr:  errors.New("no txt"),
 		hostErr: errors.New("no host"),
 	}
-	status, _ := checkDNSPropagation(mock, "app.example.com")
+	status, _ := checkDNSPropagation(mock, "app.example.com", nil)
 	if status != "not_configured" {
 		t.Errorf("CNAME without nixopus.ai should not be verified, got %s", status)
 	}
@@ -219,7 +219,7 @@ func TestCheckDNSPropagation_CNAMEDoesNotContainNixopus(t *testing.T) {
 
 func TestVerifyARecord_EmptyMachineIP(t *testing.T) {
 	mock := &mockNetLookup{}
-	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "")
+	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "", nil)
 	if err == nil {
 		t.Fatal("expected error for empty machineIP")
 	}
@@ -230,7 +230,7 @@ func TestVerifyARecord_EmptyMachineIP(t *testing.T) {
 
 func TestVerifyARecord_LookupFails(t *testing.T) {
 	mock := &mockNetLookup{hostErr: errors.New("nxdomain")}
-	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "1.2.3.4")
+	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "1.2.3.4", nil)
 	if err != nil {
 		t.Fatalf("lookup failure should not produce an error, got %v", err)
 	}
@@ -241,7 +241,7 @@ func TestVerifyARecord_LookupFails(t *testing.T) {
 
 func TestVerifyARecord_Match(t *testing.T) {
 	mock := &mockNetLookup{hosts: []string{"1.2.3.4", "5.6.7.8"}}
-	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "5.6.7.8")
+	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "5.6.7.8", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestVerifyARecord_Match(t *testing.T) {
 
 func TestVerifyARecord_NoMatch(t *testing.T) {
 	mock := &mockNetLookup{hosts: []string{"1.2.3.4"}}
-	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "9.9.9.9")
+	ok, err := verifyARecordMatchesMachineIP(mock, "app.example.com", "9.9.9.9", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestVerifyARecord_NoMatch(t *testing.T) {
 
 func TestCheckDNSPropagationBYOS_LookupFails(t *testing.T) {
 	mock := &mockNetLookup{hostErr: errors.New("nxdomain")}
-	status, err := checkDNSPropagationBYOS(mock, "app.example.com", "1.2.3.4")
+	status, err := checkDNSPropagationBYOS(mock, "app.example.com", "1.2.3.4", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestCheckDNSPropagationBYOS_LookupFails(t *testing.T) {
 
 func TestCheckDNSPropagationBYOS_Match(t *testing.T) {
 	mock := &mockNetLookup{hosts: []string{"1.2.3.4"}}
-	status, err := checkDNSPropagationBYOS(mock, "app.example.com", "1.2.3.4")
+	status, err := checkDNSPropagationBYOS(mock, "app.example.com", "1.2.3.4", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestCheckDNSPropagationBYOS_Match(t *testing.T) {
 
 func TestCheckDNSPropagationBYOS_NoMatch(t *testing.T) {
 	mock := &mockNetLookup{hosts: []string{"5.5.5.5"}}
-	status, err := checkDNSPropagationBYOS(mock, "app.example.com", "1.2.3.4")
+	status, err := checkDNSPropagationBYOS(mock, "app.example.com", "1.2.3.4", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/internal/features/domain/service/get_domains.go
+++ b/api/internal/features/domain/service/get_domains.go
@@ -1,7 +1,10 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
@@ -14,5 +17,15 @@ import (
 //
 //	([]shared_types.Domain, error) - A slice of Domain objects and an error if any occurred.
 func (s *DomainsService) GetDomains(organization_id string, UserID uuid.UUID) ([]shared_types.Domain, error) {
-	return s.storage.GetDomains(organization_id, UserID)
+	ctx := fmt.Sprintf("user_id=%s org_id=%s", UserID, organization_id)
+	s.logger.Log(logger.Debug, "get domains: storage lookup", ctx)
+
+	domains, err := s.storage.GetDomains(organization_id, UserID)
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("get domains: %v", err), ctx)
+		return nil, err
+	}
+
+	s.logger.Log(logger.Info, "get domains: storage success", fmt.Sprintf("%s count=%d", ctx, len(domains)))
+	return domains, nil
 }

--- a/api/internal/features/domain/service/init.go
+++ b/api/internal/features/domain/service/init.go
@@ -17,7 +17,7 @@ type DomainsService struct {
 
 // NewDomainsService creates a service wired to the real DNS and queue backends.
 func NewDomainsService(ctx context.Context, l logger.Logger, repo storage.DomainStorageInterface) *DomainsService {
-	return NewDomainsServiceWith(ctx, l, repo, NewRealDNSResolver(), &RealQueueClient{})
+	return NewDomainsServiceWith(ctx, l, repo, NewRealDNSResolver(&l), &RealQueueClient{})
 }
 
 // NewDomainsServiceWith creates a service with explicit DNS and queue implementations.

--- a/api/internal/features/domain/service/interfaces.go
+++ b/api/internal/features/domain/service/interfaces.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nixopus/nixopus/api/internal/features/domain/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/queue"
 )
 
@@ -54,6 +55,14 @@ func (r *realNetLookup) LookupTXT(name string) ([]string, error) {
 // Tests can swap it via restoreDefaultResolver to avoid real network calls.
 var defaultResolver NetLookup = &realNetLookup{}
 
+// dnsLog emits a log line when log is non-nil (used by DNS helper functions).
+func dnsLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}
+
 // DNSResolver abstracts all DNS network operations and instruction generation
 // so that service logic can be tested without real network calls.
 type DNSResolver interface {
@@ -76,35 +85,37 @@ type QueueClient interface {
 // RealDNSResolver delegates to the package-level DNS functions backed by net.Lookup*.
 type RealDNSResolver struct {
 	net NetLookup
+	log *logger.Logger
 }
 
 // NewRealDNSResolver creates a RealDNSResolver backed by the stdlib net package.
-func NewRealDNSResolver() *RealDNSResolver {
-	return &RealDNSResolver{net: &realNetLookup{}}
+// Pass non-nil log for Debug/Error detail on DNS lookups; tests typically pass nil.
+func NewRealDNSResolver(log *logger.Logger) *RealDNSResolver {
+	return &RealDNSResolver{net: &realNetLookup{}, log: log}
 }
 
 func (r *RealDNSResolver) DetectProvider(domain string) (string, error) {
-	return detectDNSProvider(r.net, domain)
+	return detectDNSProvider(r.net, domain, r.log)
 }
 
 func (r *RealDNSResolver) GenerateToken() string {
-	return GenerateVerificationToken()
+	return generateVerificationToken(r.log)
 }
 
 func (r *RealDNSResolver) VerifyDNSConfig(domain, target string) (bool, error) {
-	return verifyDNSConfiguration(r.net, domain, target)
+	return verifyDNSConfiguration(r.net, domain, target, r.log)
 }
 
 func (r *RealDNSResolver) VerifyARecord(domain, machineIP string) (bool, error) {
-	return verifyARecordMatchesMachineIP(r.net, domain, machineIP)
+	return verifyARecordMatchesMachineIP(r.net, domain, machineIP, r.log)
 }
 
 func (r *RealDNSResolver) CheckPropagation(domain string) (string, error) {
-	return checkDNSPropagation(r.net, domain)
+	return checkDNSPropagation(r.net, domain, r.log)
 }
 
 func (r *RealDNSResolver) CheckPropagationBYOS(domain, machineIP string) (string, error) {
-	return checkDNSPropagationBYOS(r.net, domain, machineIP)
+	return checkDNSPropagationBYOS(r.net, domain, machineIP, r.log)
 }
 
 func (r *RealDNSResolver) GenerateDNSInstructions(domain, targetSubdomain, provider string) []types.DNSInstruction {

--- a/api/internal/features/domain/service/interfaces_test.go
+++ b/api/internal/features/domain/service/interfaces_test.go
@@ -27,7 +27,7 @@ func TestNewDomainsService_NonNil(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNewRealDNSResolver_NonNil(t *testing.T) {
-	r := NewRealDNSResolver()
+	r := NewRealDNSResolver(nil)
 	if r == nil {
 		t.Fatal("expected non-nil RealDNSResolver")
 	}

--- a/api/internal/features/domain/storage/custom_domains.go
+++ b/api/internal/features/domain/storage/custom_domains.go
@@ -3,14 +3,19 @@ package storage
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/domain/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
 func (s *DomainStorage) GetDefaultSSHKeyByOrg(orgID uuid.UUID) (*shared_types.SSHKey, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	s.storageLog(logger.Debug, "storage: GetDefaultSSHKeyByOrg", ctxStr)
+
 	var key shared_types.SSHKey
 	err := s.getDB().NewSelect().
 		Model(&key).
@@ -21,12 +26,16 @@ func (s *DomainStorage) GetDefaultSSHKeyByOrg(orgID uuid.UUID) (*shared_types.SS
 		Limit(1).
 		Scan(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetDefaultSSHKeyByOrg: %v", err), ctxStr)
 		return nil, err
 	}
 	return &key, nil
 }
 
 func (s *DomainStorage) GetProvisionDetailsBySSHKeyAndOrg(sshKeyID, orgID uuid.UUID) (*shared_types.UserProvisionDetails, error) {
+	ctxStr := fmt.Sprintf("ssh_key_id=%s org_id=%s", sshKeyID, orgID)
+	s.storageLog(logger.Debug, "storage: GetProvisionDetailsBySSHKeyAndOrg", ctxStr)
+
 	var details shared_types.UserProvisionDetails
 	err := s.getDB().NewSelect().
 		Model(&details).
@@ -36,14 +45,19 @@ func (s *DomainStorage) GetProvisionDetailsBySSHKeyAndOrg(sshKeyID, orgID uuid.U
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetProvisionDetailsBySSHKeyAndOrg not found", ctxStr)
 			return nil, nil
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetProvisionDetailsBySSHKeyAndOrg: %v", err), ctxStr)
 		return nil, err
 	}
 	return &details, nil
 }
 
 func (s *DomainStorage) GetProvisionDetailsBySubdomain(subdomain string) (*shared_types.UserProvisionDetails, error) {
+	ctxStr := fmt.Sprintf("subdomain=%s", subdomain)
+	s.storageLog(logger.Debug, "storage: GetProvisionDetailsBySubdomain", ctxStr)
+
 	var details shared_types.UserProvisionDetails
 	err := s.getDB().NewSelect().
 		Model(&details).
@@ -52,20 +66,33 @@ func (s *DomainStorage) GetProvisionDetailsBySubdomain(subdomain string) (*share
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetProvisionDetailsBySubdomain not found", ctxStr)
 			return nil, nil
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetProvisionDetailsBySubdomain: %v", err), ctxStr)
 		return nil, err
 	}
 	return &details, nil
 }
 
 func (s *DomainStorage) CreateCustomDomain(domain *shared_types.Domain) error {
+	ctxStr := fmt.Sprintf("org_id=%s name=%s", domain.OrganizationID, domain.Name)
+	s.storageLog(logger.Debug, "storage: CreateCustomDomain", ctxStr)
+
 	domain.Type = "custom"
 	_, err := s.getDB().NewInsert().Model(domain).Exec(s.Ctx)
-	return err
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateCustomDomain: %v", err), fmt.Sprintf("%s id=%s", ctxStr, domain.ID))
+		return err
+	}
+	s.storageLog(logger.Info, "storage: CreateCustomDomain ok", fmt.Sprintf("id=%s %s", domain.ID, ctxStr))
+	return nil
 }
 
 func (s *DomainStorage) GetCustomDomainsByOrg(orgID uuid.UUID) ([]shared_types.Domain, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	s.storageLog(logger.Debug, "storage: GetCustomDomainsByOrg", ctxStr)
+
 	var domains []shared_types.Domain
 	err := s.getDB().NewSelect().Model(&domains).
 		Where("type = ?", "custom").
@@ -73,12 +100,17 @@ func (s *DomainStorage) GetCustomDomainsByOrg(orgID uuid.UUID) ([]shared_types.D
 		Where("deleted_at IS NULL").
 		Scan(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetCustomDomainsByOrg: %v", err), ctxStr)
 		return nil, err
 	}
+	s.storageLog(logger.Debug, "storage: GetCustomDomainsByOrg ok", fmt.Sprintf("%s count=%d", ctxStr, len(domains)))
 	return domains, nil
 }
 
 func (s *DomainStorage) GetCustomDomainByID(id uuid.UUID, orgID uuid.UUID) (*shared_types.Domain, error) {
+	ctxStr := fmt.Sprintf("id=%s org_id=%s", id, orgID)
+	s.storageLog(logger.Debug, "storage: GetCustomDomainByID", ctxStr)
+
 	var domain shared_types.Domain
 	err := s.getDB().NewSelect().Model(&domain).
 		Where("id = ?", id).
@@ -88,14 +120,19 @@ func (s *DomainStorage) GetCustomDomainByID(id uuid.UUID, orgID uuid.UUID) (*sha
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetCustomDomainByID not found", ctxStr)
 			return nil, types.ErrCustomDomainNotFound
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetCustomDomainByID: %v", err), ctxStr)
 		return nil, err
 	}
 	return &domain, nil
 }
 
 func (s *DomainStorage) GetCustomDomainByName(name string) (*shared_types.Domain, error) {
+	ctxStr := fmt.Sprintf("name=%s", name)
+	s.storageLog(logger.Debug, "storage: GetCustomDomainByName", ctxStr)
+
 	var domain shared_types.Domain
 	err := s.getDB().NewSelect().Model(&domain).
 		Where("name = ?", name).
@@ -104,14 +141,19 @@ func (s *DomainStorage) GetCustomDomainByName(name string) (*shared_types.Domain
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetCustomDomainByName not found", ctxStr)
 			return nil, nil
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetCustomDomainByName: %v", err), ctxStr)
 		return nil, err
 	}
 	return &domain, nil
 }
 
 func (s *DomainStorage) UpdateCustomDomainStatus(id uuid.UUID, status string) error {
+	ctxStr := fmt.Sprintf("id=%s status=%s", id, status)
+	s.storageLog(logger.Debug, "storage: UpdateCustomDomainStatus", ctxStr)
+
 	_, err := s.getDB().NewUpdate().
 		Model((*shared_types.Domain)(nil)).
 		Set("status = ?", status).
@@ -119,10 +161,22 @@ func (s *DomainStorage) UpdateCustomDomainStatus(id uuid.UUID, status string) er
 		Where("id = ?", id).
 		Where("deleted_at IS NULL").
 		Exec(s.Ctx)
-	return err
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateCustomDomainStatus: %v", err), ctxStr)
+		return err
+	}
+	s.storageLog(logger.Info, "storage: UpdateCustomDomainStatus ok", ctxStr)
+	return nil
 }
 
 func (s *DomainStorage) UpdateCustomDomainVerification(id uuid.UUID, status string, dnsProvider *string) error {
+	dnsStr := ""
+	if dnsProvider != nil {
+		dnsStr = *dnsProvider
+	}
+	ctxStr := fmt.Sprintf("id=%s status=%s dns_provider=%s", id, status, dnsStr)
+	s.storageLog(logger.Debug, "storage: UpdateCustomDomainVerification", ctxStr)
+
 	_, err := s.getDB().NewUpdate().
 		Model((*shared_types.Domain)(nil)).
 		Set("status = ?", status).
@@ -131,26 +185,38 @@ func (s *DomainStorage) UpdateCustomDomainVerification(id uuid.UUID, status stri
 		Where("id = ?", id).
 		Where("deleted_at IS NULL").
 		Exec(s.Ctx)
-	return err
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateCustomDomainVerification: %v", err), ctxStr)
+		return err
+	}
+	s.storageLog(logger.Info, "storage: UpdateCustomDomainVerification ok", ctxStr)
+	return nil
 }
 
 func (s *DomainStorage) DeleteCustomDomain(id uuid.UUID) error {
+	ctxStr := fmt.Sprintf("id=%s", id)
+	s.storageLog(logger.Debug, "storage: DeleteCustomDomain", ctxStr)
+
 	result, err := s.getDB().NewDelete().
 		Model((*shared_types.Domain)(nil)).
 		Where("id = ?", id).
 		Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteCustomDomain: %v", err), ctxStr)
 		return err
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteCustomDomain RowsAffected: %v", err), ctxStr)
 		return err
 	}
 
 	if rowsAffected == 0 {
+		s.storageLog(logger.Debug, "storage: DeleteCustomDomain no row deleted", ctxStr)
 		return types.ErrCustomDomainNotFound
 	}
 
+	s.storageLog(logger.Info, "storage: DeleteCustomDomain ok", ctxStr)
 	return nil
 }

--- a/api/internal/features/domain/storage/init.go
+++ b/api/internal/features/domain/storage/init.go
@@ -2,15 +2,25 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type DomainStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; when nil, storage emits no logs
+}
+
+func (s *DomainStorage) storageLog(sev logger.Severity, msg, data string) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Log(sev, msg, data)
 }
 
 type DomainStorageInterface interface {
@@ -33,12 +43,17 @@ func (s *DomainStorage) getDB() bun.IDB {
 }
 
 func (s *DomainStorage) GetDomains(OrganizationID string, UserID uuid.UUID) ([]shared_types.Domain, error) {
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s", OrganizationID, UserID)
+	s.storageLog(logger.Debug, "storage: GetDomains", ctxStr)
+
 	var domains []shared_types.Domain
 	err := s.getDB().NewSelect().Model(&domains).
 		Where("organization_id = ? AND deleted_at IS NULL", OrganizationID).
 		Scan(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetDomains: %v", err), ctxStr)
 		return nil, err
 	}
+	s.storageLog(logger.Debug, "storage: GetDomains ok", fmt.Sprintf("%s count=%d", ctxStr, len(domains)))
 	return domains, nil
 }

--- a/api/internal/features/domain/validation/validator.go
+++ b/api/internal/features/domain/validation/validator.go
@@ -1,43 +1,67 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/nixopus/nixopus/api/internal/features/domain/storage"
 	"github.com/nixopus/nixopus/api/internal/features/domain/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 type Validator struct {
 	storage storage.DomainStorageInterface
+	Logger  *logger.Logger // optional; nil disables validation logs
 }
 
 func NewValidator(storage storage.DomainStorageInterface) *Validator {
+	return NewValidatorWithLogger(storage, nil)
+}
+
+// NewValidatorWithLogger is like NewValidator but attaches a logger for Debug detail on rule failures.
+func NewValidatorWithLogger(storage storage.DomainStorageInterface, log *logger.Logger) *Validator {
 	return &Validator{
 		storage: storage,
+		Logger:  log,
 	}
 }
 
+func (v *Validator) log(sev logger.Severity, msg, data string) {
+	if v == nil || v.Logger == nil {
+		return
+	}
+	v.Logger.Log(sev, msg, data)
+}
+
 func (v *Validator) ValidateName(name string) error {
+	v.log(logger.Debug, "validation: ValidateName", fmt.Sprintf("name=%q", name))
+
 	if name == "" {
+		v.log(logger.Debug, "validation: ValidateName rejected", "reason=empty")
 		return types.ErrMissingDomainName
 	}
 
 	if len(name) < 3 {
+		v.log(logger.Debug, "validation: ValidateName rejected", fmt.Sprintf("reason=too_short name=%q len=%d", name, len(name)))
 		return types.ErrDomainNameTooShort
 	}
 
 	if len(name) > 255 {
+		v.log(logger.Debug, "validation: ValidateName rejected", fmt.Sprintf("reason=too_long name=%q len=%d", name, len(name)))
 		return types.ErrDomainNameTooLong
 	}
 
 	if !strings.Contains(name, ".") {
+		v.log(logger.Debug, "validation: ValidateName rejected", fmt.Sprintf("reason=no_dot name=%q", name))
 		return types.ErrDomainNameInvalid
 	}
 
 	tld := strings.Split(name, ".")[1]
 	if len(tld) < 2 || len(tld) > 63 {
+		v.log(logger.Debug, "validation: ValidateName rejected", fmt.Sprintf("reason=invalid_label name=%q label_len=%d", name, len(tld)))
 		return types.ErrDomainNameInvalid
 	}
 
+	v.log(logger.Debug, "validation: ValidateName ok", fmt.Sprintf("name=%q", name))
 	return nil
 }

--- a/api/internal/features/extension/controller/get_extensions.go
+++ b/api/internal/features/extension/controller/get_extensions.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/features/extension/types"
@@ -53,9 +55,24 @@ func (c *ExtensionsController) GetExtensions(ctx fuego.ContextNoBody) (*types.Li
 		}
 	}
 
+	var ctxParts []string
+	ctxParts = append(ctxParts, fmt.Sprintf("page=%d", params.Page), fmt.Sprintf("page_size=%d", params.PageSize))
+	ctxParts = append(ctxParts, fmt.Sprintf("sort_by=%s", params.SortBy), fmt.Sprintf("sort_dir=%s", params.SortDir))
+	if params.Category != nil {
+		ctxParts = append(ctxParts, fmt.Sprintf("category=%s", *params.Category))
+	}
+	if params.Type != nil {
+		ctxParts = append(ctxParts, fmt.Sprintf("type=%s", *params.Type))
+	}
+	if params.Search != "" {
+		ctxParts = append(ctxParts, fmt.Sprintf("search=%q", params.Search))
+	}
+	ctxStr := strings.Join(ctxParts, " ")
+	c.logger.Log(logger.Info, "extension: GetExtensions", ctxStr)
+
 	response, err := c.service.ListExtensions(params)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("extension: GetExtensions: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -63,6 +80,7 @@ func (c *ExtensionsController) GetExtensions(ctx fuego.ContextNoBody) (*types.Li
 		}
 	}
 
+	c.logger.Log(logger.Info, "extension: GetExtensions ok", fmt.Sprintf("%s total=%d total_pages=%d", ctxStr, response.Total, response.TotalPages))
 	return &types.ListExtensionsResponse{
 		Status:  "success",
 		Message: "Extensions retrieved successfully",
@@ -71,11 +89,13 @@ func (c *ExtensionsController) GetExtensions(ctx fuego.ContextNoBody) (*types.Li
 }
 
 func (c *ExtensionsController) GetCategories(ctx fuego.ContextNoBody) (*types.CategoriesResponse, error) {
+	c.logger.Log(logger.Info, "extension: GetCategories", "")
 	cats, err := c.service.ListCategories()
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("extension: GetCategories: %v", err), "")
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
+	c.logger.Log(logger.Info, "extension: GetCategories ok", fmt.Sprintf("count=%d", len(cats)))
 	return &types.CategoriesResponse{
 		Status:  "success",
 		Message: "Categories retrieved successfully",
@@ -86,10 +106,14 @@ func (c *ExtensionsController) GetCategories(ctx fuego.ContextNoBody) (*types.Ca
 func (c *ExtensionsController) GetExtension(ctx fuego.ContextNoBody) (*types.ExtensionResponse, error) {
 	id := ctx.PathParam("id")
 	if id == "" {
+		c.logger.Log(logger.Debug, "extension: GetExtension missing id", "")
 		return nil, fuego.BadRequestError{
 			Detail: "extension ID is required",
 		}
 	}
+
+	ctxStr := fmt.Sprintf("id=%s", id)
+	c.logger.Log(logger.Info, "extension: GetExtension", ctxStr)
 
 	extension, err := c.service.GetExtension(id)
 	if err != nil {
@@ -99,7 +123,7 @@ func (c *ExtensionsController) GetExtension(ctx fuego.ContextNoBody) (*types.Ext
 				Err:    err,
 			}
 		}
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("extension: GetExtension: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -107,6 +131,7 @@ func (c *ExtensionsController) GetExtension(ctx fuego.ContextNoBody) (*types.Ext
 		}
 	}
 
+	c.logger.Log(logger.Info, "extension: GetExtension ok", fmt.Sprintf("%s extension_id=%s", ctxStr, extension.ExtensionID))
 	return &types.ExtensionResponse{
 		Status:  "success",
 		Message: "Extension retrieved successfully",
@@ -117,10 +142,14 @@ func (c *ExtensionsController) GetExtension(ctx fuego.ContextNoBody) (*types.Ext
 func (c *ExtensionsController) GetExtensionByExtensionID(ctx fuego.ContextNoBody) (*types.ExtensionResponse, error) {
 	extensionID := ctx.PathParam("extension_id")
 	if extensionID == "" {
+		c.logger.Log(logger.Debug, "extension: GetExtensionByExtensionID missing extension_id", "")
 		return nil, fuego.BadRequestError{
 			Detail: "extension ID is required",
 		}
 	}
+
+	ctxStr := fmt.Sprintf("extension_id=%s", extensionID)
+	c.logger.Log(logger.Info, "extension: GetExtensionByExtensionID", ctxStr)
 
 	extension, err := c.service.GetExtensionByID(extensionID)
 	if err != nil {
@@ -130,7 +159,7 @@ func (c *ExtensionsController) GetExtensionByExtensionID(ctx fuego.ContextNoBody
 				Err:    err,
 			}
 		}
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("extension: GetExtensionByExtensionID: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -138,6 +167,7 @@ func (c *ExtensionsController) GetExtensionByExtensionID(ctx fuego.ContextNoBody
 		}
 	}
 
+	c.logger.Log(logger.Info, "extension: GetExtensionByExtensionID ok", ctxStr)
 	return &types.ExtensionResponse{
 		Status:  "success",
 		Message: "Extension retrieved successfully",

--- a/api/internal/features/extension/controller/init.go
+++ b/api/internal/features/extension/controller/init.go
@@ -23,7 +23,7 @@ func NewExtensionsController(
 	l logger.Logger,
 	appCache *cache.Cache,
 ) *ExtensionsController {
-	storage := storage.ExtensionStorage{DB: store.DB, Ctx: ctx}
+	storage := storage.ExtensionStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	var svc *service.ExtensionService
 	if appCache == nil {
 		svc = service.NewExtensionService(ctx, l, &storage, nil)

--- a/api/internal/features/extension/service/service.go
+++ b/api/internal/features/extension/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nixopus/nixopus/api/internal/cache"
 	"github.com/nixopus/nixopus/api/internal/features/extension/storage"
@@ -45,7 +46,7 @@ func (s *ExtensionService) GetExtension(id string) (*types.Extension, error) {
 	if s.cache != nil {
 		cached, err := s.cache.GetExtension(s.ctx, id)
 		if err != nil {
-			s.logger.Log(logger.Error, "extension cache read failed, falling through to db", err.Error())
+			s.logger.Log(logger.Debug, fmt.Sprintf("extension service: GetExtension cache read failed, falling through to db: %v", err), id)
 		}
 		if cached != nil {
 			return cached, nil
@@ -54,13 +55,13 @@ func (s *ExtensionService) GetExtension(id string) (*types.Extension, error) {
 
 	extension, err := s.storage.GetExtension(id)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("extension service: GetExtension: %v", err), id)
 		return nil, err
 	}
 
 	if s.cache != nil {
 		if cacheErr := s.cache.SetExtension(s.ctx, extension); cacheErr != nil {
-			s.logger.Log(logger.Error, "failed to cache extension", cacheErr.Error())
+			s.logger.Log(logger.Warning, fmt.Sprintf("extension service: GetExtension failed to cache extension: %v", cacheErr), id)
 		}
 	}
 
@@ -71,7 +72,7 @@ func (s *ExtensionService) GetExtensionByID(extensionID string) (*types.Extensio
 	if s.cache != nil {
 		cached, err := s.cache.GetExtensionByExtID(s.ctx, extensionID)
 		if err != nil {
-			s.logger.Log(logger.Error, "extension cache read failed, falling through to db", err.Error())
+			s.logger.Log(logger.Debug, fmt.Sprintf("extension service: GetExtensionByID cache read failed, falling through to db: %v", err), extensionID)
 		}
 		if cached != nil {
 			return cached, nil
@@ -80,13 +81,13 @@ func (s *ExtensionService) GetExtensionByID(extensionID string) (*types.Extensio
 
 	extension, err := s.storage.GetExtensionByID(extensionID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("extension service: GetExtensionByID: %v", err), extensionID)
 		return nil, err
 	}
 
 	if s.cache != nil {
 		if cacheErr := s.cache.SetExtension(s.ctx, extension); cacheErr != nil {
-			s.logger.Log(logger.Error, "failed to cache extension", cacheErr.Error())
+			s.logger.Log(logger.Warning, fmt.Sprintf("extension service: GetExtensionByID failed to cache extension: %v", cacheErr), extensionID)
 		}
 	}
 
@@ -96,7 +97,7 @@ func (s *ExtensionService) GetExtensionByID(extensionID string) (*types.Extensio
 func (s *ExtensionService) ListExtensions(params types.ExtensionListParams) (*types.ExtensionListResponse, error) {
 	response, err := s.storage.ListExtensions(params)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("extension service: ListExtensions: %v", err), "")
 		return nil, err
 	}
 	return response, nil
@@ -106,7 +107,7 @@ func (s *ExtensionService) ListCategories() ([]types.ExtensionCategory, error) {
 	if s.cache != nil {
 		cached, err := s.cache.GetExtensionCategories(s.ctx)
 		if err != nil {
-			s.logger.Log(logger.Error, "categories cache read failed, falling through to db", err.Error())
+			s.logger.Log(logger.Debug, fmt.Sprintf("extension service: ListCategories cache read failed, falling through to db: %v", err), "")
 		}
 		if cached != nil {
 			return cached, nil
@@ -115,13 +116,13 @@ func (s *ExtensionService) ListCategories() ([]types.ExtensionCategory, error) {
 
 	cats, err := s.storage.ListCategories()
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("extension service: ListCategories: %v", err), "")
 		return nil, err
 	}
 
 	if s.cache != nil {
 		if cacheErr := s.cache.SetExtensionCategories(s.ctx, cats); cacheErr != nil {
-			s.logger.Log(logger.Error, "failed to cache categories", cacheErr.Error())
+			s.logger.Log(logger.Warning, fmt.Sprintf("extension service: ListCategories failed to cache categories: %v", cacheErr), "")
 		}
 	}
 

--- a/api/internal/features/extension/service/template_loader.go
+++ b/api/internal/features/extension/service/template_loader.go
@@ -3,10 +3,10 @@ package service
 import (
 	"context"
 	"fmt"
-	"log"
 	"path/filepath"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_storage "github.com/nixopus/nixopus/api/internal/storage"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
@@ -15,17 +15,29 @@ import (
 // TemplateLoader reads extension metadata.yaml trees from disk and syncs them into Postgres.
 type TemplateLoader struct {
 	store extensionTemplateStore
+	log   *logger.Logger // optional; nil disables loader logs
 }
 
 var _ shared_storage.ExtensionTemplateLoader = (*TemplateLoader)(nil)
 
 // NewTemplateLoader constructs a loader backed by the application database.
-func NewTemplateLoader(db *bun.DB) *TemplateLoader {
-	return newTemplateLoader(newBunExtensionTemplateStore(db))
+func NewTemplateLoader(db *bun.DB, log *logger.Logger) *TemplateLoader {
+	return newTemplateLoader(newBunExtensionTemplateStore(db), log)
 }
 
-func newTemplateLoader(store extensionTemplateStore) *TemplateLoader {
-	return &TemplateLoader{store: store}
+func newTemplateLoader(store extensionTemplateStore, logOptional ...*logger.Logger) *TemplateLoader {
+	var log *logger.Logger
+	if len(logOptional) > 0 {
+		log = logOptional[0]
+	}
+	return &TemplateLoader{store: store, log: log}
+}
+
+func (l *TemplateLoader) tplLog(sev logger.Severity, msg, data string) {
+	if l == nil || l.log == nil {
+		return
+	}
+	l.log.Log(sev, msg, data)
 }
 
 func (l *TemplateLoader) LoadExtensionsFromDirectory(ctx context.Context, dirPath string) error {
@@ -36,7 +48,7 @@ func (l *TemplateLoader) LoadExtensionsFromDirectory(ctx context.Context, dirPat
 		return fmt.Errorf("failed to load extensions from directory: %w", err)
 	}
 
-	log.Printf("Found %d extension files in %s", len(extensions), dirPath)
+	l.tplLog(logger.Info, fmt.Sprintf("extension template loader: found %d extension files", len(extensions)), dirPath)
 
 	if len(extensions) == 0 {
 		return nil
@@ -95,7 +107,7 @@ func (l *TemplateLoader) LoadExtensionsFromDirectory(ctx context.Context, dirPat
 		}
 	}
 
-	log.Printf("Processing: %d new, %d updated, %d unchanged", len(toInsert), len(toUpdate), skippedCount)
+	l.tplLog(logger.Info, fmt.Sprintf("extension template loader: processing new=%d updated=%d unchanged=%d", len(toInsert), len(toUpdate), skippedCount), dirPath)
 
 	if len(toInsert) > 0 {
 		if err := l.batchInsertExtensions(ctx, toInsert, insertVariables); err != nil {
@@ -110,7 +122,7 @@ func (l *TemplateLoader) LoadExtensionsFromDirectory(ctx context.Context, dirPat
 	}
 
 	if err := l.removeDeletedExtensions(ctx, foundExtensionIDs); err != nil {
-		log.Printf("Warning: Failed to remove deleted extensions: %v", err)
+		l.tplLog(logger.Warning, fmt.Sprintf("extension template loader: remove deleted extensions: %v", err), dirPath)
 	}
 
 	return nil
@@ -218,7 +230,7 @@ func (l *TemplateLoader) removeDeletedExtensions(ctx context.Context, foundExten
 		return nil
 	}
 
-	log.Printf("Removing %d extensions that are no longer in templates directory", len(extensionsToDelete))
+	l.tplLog(logger.Info, fmt.Sprintf("extension template loader: soft-deleting %d extensions absent from templates dir", len(extensionsToDelete)), "")
 
 	if err := l.store.softDeleteExtensionsByExtensionIDs(ctx, extensionsToDelete); err != nil {
 		return fmt.Errorf("failed to delete removed extensions: %w", err)
@@ -236,6 +248,7 @@ func (l *TemplateLoader) LoadExtensionsFromTemplates(ctx context.Context) error 
 func (l *TemplateLoader) GetExtensionByID(ctx context.Context, extensionID string) (*types.Extension, error) {
 	ext, err := l.store.getExtensionWithVariables(ctx, extensionID)
 	if err != nil {
+		l.tplLog(logger.Error, fmt.Sprintf("extension template loader: GetExtensionByID: %v", err), extensionID)
 		return nil, fmt.Errorf("failed to get extension: %w", err)
 	}
 	return ext, nil

--- a/api/internal/features/extension/service/template_loader_unit_test.go
+++ b/api/internal/features/extension/service/template_loader_unit_test.go
@@ -118,7 +118,7 @@ func TestNewTemplateLoader(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sqldb.Close() })
 	db := bun.NewDB(sqldb, sqlitedialect.New())
-	l := NewTemplateLoader(db)
+	l := NewTemplateLoader(db, nil)
 	require.NotNil(t, l)
 }
 

--- a/api/internal/features/extension/storage/storage.go
+++ b/api/internal/features/extension/storage/storage.go
@@ -4,14 +4,24 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type ExtensionStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
+}
+
+func (s *ExtensionStorage) storageLog(sev logger.Severity, msg, data string) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Log(sev, msg, data)
 }
 
 type ExtensionStorageInterface interface {
@@ -26,8 +36,11 @@ type ExtensionStorageInterface interface {
 }
 
 func (s *ExtensionStorage) CreateExtension(extension *types.Extension) error {
+	ctxStr := fmt.Sprintf("extension_id=%s", extension.ExtensionID)
+	s.storageLog(logger.Debug, "storage: CreateExtension", ctxStr)
 	_, err := s.DB.NewInsert().Model(extension).Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateExtension: %v", err), ctxStr)
 		return err
 	}
 	return nil
@@ -37,14 +50,18 @@ func (s *ExtensionStorage) CreateExtensionVariables(vars []types.ExtensionVariab
 	if len(vars) == 0 {
 		return nil
 	}
+	s.storageLog(logger.Debug, "storage: CreateExtensionVariables", fmt.Sprintf("count=%d", len(vars)))
 	_, err := s.DB.NewInsert().Model(&vars).Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateExtensionVariables: %v", err), "")
 		return err
 	}
 	return nil
 }
 
 func (s *ExtensionStorage) GetExtension(id string) (*types.Extension, error) {
+	ctxStr := fmt.Sprintf("id=%s", id)
+	s.storageLog(logger.Debug, "storage: GetExtension", ctxStr)
 	var extension types.Extension
 	err := s.DB.NewSelect().
 		Model(&extension).
@@ -53,14 +70,19 @@ func (s *ExtensionStorage) GetExtension(id string) (*types.Extension, error) {
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetExtension not found", ctxStr)
 			return nil, errors.New("extension not found")
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetExtension: %v", err), ctxStr)
 		return nil, err
 	}
+	s.storageLog(logger.Debug, "storage: GetExtension ok", ctxStr)
 	return &extension, nil
 }
 
 func (s *ExtensionStorage) GetExtensionByID(extensionID string) (*types.Extension, error) {
+	ctxStr := fmt.Sprintf("extension_id=%s", extensionID)
+	s.storageLog(logger.Debug, "storage: GetExtensionByID", ctxStr)
 	var extension types.Extension
 	err := s.DB.NewSelect().
 		Model(&extension).
@@ -69,31 +91,40 @@ func (s *ExtensionStorage) GetExtensionByID(extensionID string) (*types.Extensio
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetExtensionByID not found", ctxStr)
 			return nil, errors.New("extension not found")
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetExtensionByID: %v", err), ctxStr)
 		return nil, err
 	}
+	s.storageLog(logger.Debug, "storage: GetExtensionByID ok", ctxStr)
 	return &extension, nil
 }
 
 func (s *ExtensionStorage) UpdateExtension(extension *types.Extension) error {
+	ctxStr := fmt.Sprintf("id=%s extension_id=%s", extension.ID, extension.ExtensionID)
+	s.storageLog(logger.Debug, "storage: UpdateExtension", ctxStr)
 	_, err := s.DB.NewUpdate().
 		Model(extension).
 		Where("id = ?", extension.ID).
 		Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateExtension: %v", err), ctxStr)
 		return err
 	}
 	return nil
 }
 
 func (s *ExtensionStorage) DeleteExtension(id string) error {
+	ctxStr := fmt.Sprintf("id=%s", id)
+	s.storageLog(logger.Debug, "storage: DeleteExtension", ctxStr)
 	_, err := s.DB.NewUpdate().
 		Model((*types.Extension)(nil)).
 		Set("deleted_at = NOW()").
 		Where("id = ?", id).
 		Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteExtension: %v", err), ctxStr)
 		return err
 	}
 	return nil
@@ -114,6 +145,18 @@ func (s *ExtensionStorage) ListExtensions(params types.ExtensionListParams) (*ty
 	if params.SortDir == "" {
 		params.SortDir = types.SortDirectionAsc
 	}
+
+	ctxStr := fmt.Sprintf("page=%d page_size=%d sort_by=%s sort_dir=%s", params.Page, params.PageSize, params.SortBy, params.SortDir)
+	if params.Category != nil {
+		ctxStr += fmt.Sprintf(" category=%s", *params.Category)
+	}
+	if params.Type != nil {
+		ctxStr += fmt.Sprintf(" type=%s", *params.Type)
+	}
+	if params.Search != "" {
+		ctxStr += fmt.Sprintf(" search=%q", params.Search)
+	}
+	s.storageLog(logger.Debug, "storage: ListExtensions", ctxStr)
 
 	query := s.DB.NewSelect().
 		Model(&extensions).
@@ -170,6 +213,7 @@ func (s *ExtensionStorage) ListExtensions(params types.ExtensionListParams) (*ty
 
 	total, err := countQuery.Count(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: ListExtensions count: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -178,6 +222,7 @@ func (s *ExtensionStorage) ListExtensions(params types.ExtensionListParams) (*ty
 
 	err = query.Scan(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: ListExtensions scan: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -187,6 +232,7 @@ func (s *ExtensionStorage) ListExtensions(params types.ExtensionListParams) (*ty
 		extensions = make([]types.Extension, 0)
 	}
 
+	s.storageLog(logger.Debug, "storage: ListExtensions ok", fmt.Sprintf("%s total=%d rows=%d", ctxStr, total, len(extensions)))
 	return &types.ExtensionListResponse{
 		Extensions: extensions,
 		Total:      total,
@@ -197,6 +243,7 @@ func (s *ExtensionStorage) ListExtensions(params types.ExtensionListParams) (*ty
 }
 
 func (s *ExtensionStorage) ListCategories() ([]types.ExtensionCategory, error) {
+	s.storageLog(logger.Debug, "storage: ListCategories", "")
 	var categories []types.ExtensionCategory
 	err := s.DB.NewSelect().
 		TableExpr("extensions").
@@ -204,7 +251,9 @@ func (s *ExtensionStorage) ListCategories() ([]types.ExtensionCategory, error) {
 		Where("deleted_at IS NULL").
 		Scan(s.Ctx, &categories)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: ListCategories: %v", err), "")
 		return nil, err
 	}
+	s.storageLog(logger.Debug, "storage: ListCategories ok", fmt.Sprintf("count=%d", len(categories)))
 	return categories, nil
 }

--- a/api/internal/features/feature-flags/controller/init.go
+++ b/api/internal/features/feature-flags/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-fuego/fuego"
 	"github.com/nixopus/nixopus/api/internal/cache"
@@ -30,12 +31,16 @@ func NewFeatureFlagController(service *service.FeatureFlagService, logger logger
 
 func (c *FeatureFlagController) GetFeatureFlags(f fuego.ContextNoBody) (*types.ListFeatureFlagsResponse, error) {
 	organizationID := utils.GetOrganizationID(f.Request())
+	ctxStr := fmt.Sprintf("org_id=%s", organizationID)
+	c.logger.Log(logger.Info, "feature flags: GetFeatureFlags", ctxStr)
+
 	flags, err := c.service.GetFeatureFlags(organizationID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("feature flags: GetFeatureFlags: %v", err), ctxStr)
 		return nil, err
 	}
 
+	c.logger.Log(logger.Info, "feature flags: GetFeatureFlags ok", fmt.Sprintf("%s count=%d", ctxStr, len(flags)))
 	return &types.ListFeatureFlagsResponse{
 		Status:  "success",
 		Message: "Feature flags retrieved successfully",
@@ -45,20 +50,26 @@ func (c *FeatureFlagController) GetFeatureFlags(f fuego.ContextNoBody) (*types.L
 
 func (c *FeatureFlagController) UpdateFeatureFlag(f fuego.ContextWithBody[shared_types.UpdateFeatureFlagRequest]) (*types.MessageResponse, error) {
 	organizationID := utils.GetOrganizationID(f.Request())
+	ctxStr := fmt.Sprintf("org_id=%s", organizationID)
+	c.logger.Log(logger.Info, "feature flags: UpdateFeatureFlag", ctxStr)
+
 	req, err := f.Body()
 
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("feature flags: UpdateFeatureFlag body: %v", err), ctxStr)
 		return nil, err
 	}
 
+	ctxStr = fmt.Sprintf("org_id=%s feature_name=%s is_enabled=%t", organizationID, req.FeatureName, req.IsEnabled)
 	if err = c.service.UpdateFeatureFlag(organizationID, req); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("feature flags: UpdateFeatureFlag: %v", err), ctxStr)
 		return nil, err
 	}
 
 	// Invalidate the feature flag cache
 	c.cache.InvalidateFeatureFlag(c.ctx, organizationID.String(), req.FeatureName)
 
+	c.logger.Log(logger.Info, "feature flags: UpdateFeatureFlag ok", ctxStr)
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Feature flag updated successfully",
@@ -68,13 +79,16 @@ func (c *FeatureFlagController) UpdateFeatureFlag(f fuego.ContextWithBody[shared
 func (c *FeatureFlagController) IsFeatureEnabled(f fuego.ContextNoBody) (*types.IsFeatureEnabledResponse, error) {
 	organizationID := utils.GetOrganizationID(f.Request())
 	featureName := f.Request().URL.Query().Get("feature_name")
+	ctxStr := fmt.Sprintf("org_id=%s feature_name=%s", organizationID, featureName)
+	c.logger.Log(logger.Info, "feature flags: IsFeatureEnabled", ctxStr)
 
 	isEnabled, err := c.service.IsFeatureEnabled(organizationID, featureName)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("feature flags: IsFeatureEnabled: %v", err), ctxStr)
 		return nil, err
 	}
 
+	c.logger.Log(logger.Info, "feature flags: IsFeatureEnabled ok", fmt.Sprintf("%s enabled=%t", ctxStr, isEnabled))
 	return &types.IsFeatureEnabledResponse{
 		Status:  "success",
 		Message: "Feature flag status retrieved successfully",

--- a/api/internal/features/feature-flags/service/init.go
+++ b/api/internal/features/feature-flags/service/init.go
@@ -25,18 +25,20 @@ func NewFeatureFlagService(storage storage.FeatureFlagRepository, logger logger.
 }
 
 func (s *FeatureFlagService) GetFeatureFlags(organizationID uuid.UUID) ([]types.FeatureFlag, error) {
-	s.logger.Log(logger.Info, "getting feature flags", "")
+	orgStr := organizationID.String()
+	s.logger.Log(logger.Info, "feature flags service: GetFeatureFlags", fmt.Sprintf("org_id=%s", orgStr))
 	flags, err := s.storage.GetFeatureFlags(organizationID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("feature flags service: GetFeatureFlags: %v", err), fmt.Sprintf("org_id=%s", orgStr))
 		return nil, fmt.Errorf("failed to get feature flags: %w", err)
 	}
 
 	if len(flags) == 0 {
-		s.logger.Log(logger.Info, "no feature flags found, creating defaults", "")
+		s.logger.Log(logger.Info, "feature flags service: GetFeatureFlags seeding defaults", fmt.Sprintf("org_id=%s", orgStr))
 
 		tx, err := s.storage.BeginTx()
 		if err != nil {
-			s.logger.Log(logger.Error, "failed to start transaction", err.Error())
+			s.logger.Log(logger.Error, fmt.Sprintf("feature flags service: GetFeatureFlags BeginTx: %v", err), fmt.Sprintf("org_id=%s", orgStr))
 			return nil, fmt.Errorf("failed to start transaction: %w", err)
 		}
 		defer tx.Rollback()
@@ -48,7 +50,7 @@ func (s *FeatureFlagService) GetFeatureFlags(organizationID uuid.UUID) ([]types.
 		for _, feature := range defaultFeatures {
 			err := txStorage.UpdateFeatureFlag(organizationID, string(feature), true)
 			if err != nil {
-				s.logger.Log(logger.Error, fmt.Sprintf("failed to create default feature flag %s", feature), err.Error())
+				s.logger.Log(logger.Error, fmt.Sprintf("feature flags service: GetFeatureFlags default flag %s: %v", feature, err), fmt.Sprintf("org_id=%s", orgStr))
 				return nil, fmt.Errorf("failed to create default feature flag %s: %w", feature, err)
 			}
 			defaultFlags = append(defaultFlags, types.FeatureFlag{
@@ -59,21 +61,36 @@ func (s *FeatureFlagService) GetFeatureFlags(organizationID uuid.UUID) ([]types.
 		}
 
 		if err := tx.Commit(); err != nil {
-			s.logger.Log(logger.Error, "failed to commit transaction", err.Error())
+			s.logger.Log(logger.Error, fmt.Sprintf("feature flags service: GetFeatureFlags Commit: %v", err), fmt.Sprintf("org_id=%s", orgStr))
 			return nil, fmt.Errorf("failed to commit transaction: %w", err)
 		}
 
+		s.logger.Log(logger.Info, "feature flags service: GetFeatureFlags defaults committed", fmt.Sprintf("org_id=%s count=%d", orgStr, len(defaultFlags)))
 		return defaultFlags, nil
 	}
 
+	s.logger.Log(logger.Info, "feature flags service: GetFeatureFlags ok", fmt.Sprintf("org_id=%s count=%d", orgStr, len(flags)))
 	return flags, nil
 }
 
 func (s *FeatureFlagService) UpdateFeatureFlag(organizationID uuid.UUID, req types.UpdateFeatureFlagRequest) error {
-	s.logger.Log(logger.Info, "updating feature flag", "")
-	return s.storage.UpdateFeatureFlag(organizationID, req.FeatureName, req.IsEnabled)
+	ctxStr := fmt.Sprintf("org_id=%s feature_name=%s is_enabled=%t", organizationID, req.FeatureName, req.IsEnabled)
+	s.logger.Log(logger.Info, "feature flags service: UpdateFeatureFlag", ctxStr)
+	if err := s.storage.UpdateFeatureFlag(organizationID, req.FeatureName, req.IsEnabled); err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("feature flags service: UpdateFeatureFlag: %v", err), ctxStr)
+		return err
+	}
+	s.logger.Log(logger.Info, "feature flags service: UpdateFeatureFlag ok", ctxStr)
+	return nil
 }
 
 func (s *FeatureFlagService) IsFeatureEnabled(organizationID uuid.UUID, featureName string) (bool, error) {
-	return s.storage.IsFeatureEnabled(organizationID, featureName)
+	ctxStr := fmt.Sprintf("org_id=%s feature_name=%s", organizationID, featureName)
+	enabled, err := s.storage.IsFeatureEnabled(organizationID, featureName)
+	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("feature flags service: IsFeatureEnabled: %v", err), ctxStr)
+		return false, err
+	}
+	s.logger.Log(logger.Debug, "feature flags service: IsFeatureEnabled ok", fmt.Sprintf("%s enabled=%t", ctxStr, enabled))
+	return enabled, nil
 }

--- a/api/internal/features/feature-flags/storage/init.go
+++ b/api/internal/features/feature-flags/storage/init.go
@@ -3,18 +3,21 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type FeatureFlagStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
-	tx  *bun.Tx
+	DB     *bun.DB
+	Ctx    context.Context
+	tx     *bun.Tx
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 type FeatureFlagRepository interface {
@@ -32,6 +35,13 @@ func NewFeatureFlagStorage(db *bun.DB, ctx context.Context) *FeatureFlagStorage 
 	}
 }
 
+func (s *FeatureFlagStorage) storageLog(sev logger.Severity, msg, data string) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Log(sev, msg, data)
+}
+
 func (s *FeatureFlagStorage) getDB() bun.IDB {
 	if s.tx != nil {
 		return s.tx
@@ -40,6 +50,8 @@ func (s *FeatureFlagStorage) getDB() bun.IDB {
 }
 
 func (s *FeatureFlagStorage) GetFeatureFlags(organizationID uuid.UUID) ([]types.FeatureFlag, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", organizationID)
+	s.storageLog(logger.Debug, "storage: GetFeatureFlags", ctxStr)
 	var flags []types.FeatureFlag
 	err := s.getDB().NewSelect().
 		Model(&flags).
@@ -48,13 +60,17 @@ func (s *FeatureFlagStorage) GetFeatureFlags(organizationID uuid.UUID) ([]types.
 		Scan(s.Ctx)
 
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetFeatureFlags: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get feature flags: %w", err)
 	}
 
+	s.storageLog(logger.Debug, "storage: GetFeatureFlags ok", fmt.Sprintf("%s count=%d", ctxStr, len(flags)))
 	return flags, nil
 }
 
 func (s *FeatureFlagStorage) UpdateFeatureFlag(organizationID uuid.UUID, featureName string, isEnabled bool) error {
+	ctxStr := fmt.Sprintf("org_id=%s feature_name=%s is_enabled=%t", organizationID, featureName, isEnabled)
+	s.storageLog(logger.Debug, "storage: UpdateFeatureFlag", ctxStr)
 	flag := &types.FeatureFlag{}
 	err := s.getDB().NewSelect().
 		Model(flag).
@@ -64,7 +80,7 @@ func (s *FeatureFlagStorage) UpdateFeatureFlag(organizationID uuid.UUID, feature
 		Scan(s.Ctx)
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			flag = &types.FeatureFlag{
 				ID:             uuid.New(),
 				OrganizationID: organizationID,
@@ -74,8 +90,12 @@ func (s *FeatureFlagStorage) UpdateFeatureFlag(organizationID uuid.UUID, feature
 				UpdatedAt:      time.Now(),
 			}
 			_, err = s.getDB().NewInsert().Model(flag).Exec(s.Ctx)
+			if err != nil {
+				s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateFeatureFlag insert: %v", err), ctxStr)
+			}
 			return err
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateFeatureFlag select: %v", err), ctxStr)
 		return fmt.Errorf("failed to get feature flag: %w", err)
 	}
 
@@ -86,10 +106,15 @@ func (s *FeatureFlagStorage) UpdateFeatureFlag(organizationID uuid.UUID, feature
 		Where("id = ?", flag.ID).
 		Exec(s.Ctx)
 
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateFeatureFlag update: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *FeatureFlagStorage) IsFeatureEnabled(organizationID uuid.UUID, featureName string) (bool, error) {
+	ctxStr := fmt.Sprintf("org_id=%s feature_name=%s", organizationID, featureName)
+	s.storageLog(logger.Debug, "storage: IsFeatureEnabled", ctxStr)
 	var isEnabled bool
 	err := s.getDB().NewSelect().
 		TableExpr("feature_flags").
@@ -100,9 +125,11 @@ func (s *FeatureFlagStorage) IsFeatureEnabled(organizationID uuid.UUID, featureN
 		Scan(s.Ctx, &isEnabled)
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: IsFeatureEnabled not found default enabled", ctxStr)
 			return true, nil // Default to enabled if not configured
 		}
+		s.storageLog(logger.Error, fmt.Sprintf("storage: IsFeatureEnabled: %v", err), ctxStr)
 		return false, fmt.Errorf("failed to check feature flag: %w", err)
 	}
 
@@ -120,8 +147,9 @@ func (s *FeatureFlagStorage) BeginTx() (bun.Tx, error) {
 
 func (s *FeatureFlagStorage) WithTx(tx bun.Tx) FeatureFlagRepository {
 	return &FeatureFlagStorage{
-		DB:  s.DB,
-		Ctx: s.Ctx,
-		tx:  &tx,
+		DB:     s.DB,
+		Ctx:    s.Ctx,
+		tx:     &tx,
+		Logger: s.Logger,
 	}
 }

--- a/api/internal/features/github-connector/controller/create_connector.go
+++ b/api/internal/features/github-connector/controller/create_connector.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -14,6 +15,7 @@ func (c *GithubConnectorController) CreateGithubConnector(f fuego.ContextWithBod
 	githubConnectorRequest, err := f.Body()
 
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("github connector: CreateGithubConnector body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -28,9 +30,12 @@ func (c *GithubConnectorController) CreateGithubConnector(f fuego.ContextWithBod
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s", user.ID)
+	c.logger.Log(logger.Info, "github connector: CreateGithubConnector", ctxStr)
+
 	err = c.service.CreateConnector(&githubConnectorRequest, user.ID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("github connector: CreateGithubConnector: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -38,6 +43,7 @@ func (c *GithubConnectorController) CreateGithubConnector(f fuego.ContextWithBod
 		}
 	}
 
+	c.logger.Log(logger.Info, "github connector: CreateGithubConnector ok", ctxStr)
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "connector created",

--- a/api/internal/features/github-connector/controller/delete_connector.go
+++ b/api/internal/features/github-connector/controller/delete_connector.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -13,6 +14,7 @@ func (c *GithubConnectorController) DeleteGithubConnector(f fuego.ContextWithBod
 	deleteRequest, err := f.Body()
 
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("github connector: DeleteGithubConnector body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -28,9 +30,12 @@ func (c *GithubConnectorController) DeleteGithubConnector(f fuego.ContextWithBod
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s connector_id=%s", user.ID, deleteRequest.ID)
+	c.logger.Log(logger.Info, "github connector: DeleteGithubConnector", ctxStr)
+
 	err = c.service.DeleteConnector(deleteRequest.ID, user.ID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("github connector: DeleteGithubConnector: %v", err), ctxStr)
 		if err == types.ErrConnectorDoesNotExist {
 			return nil, fuego.NotFoundError{Detail: err.Error(), Err: err}
 		}
@@ -44,6 +49,7 @@ func (c *GithubConnectorController) DeleteGithubConnector(f fuego.ContextWithBod
 		}
 	}
 
+	c.logger.Log(logger.Info, "github connector: DeleteGithubConnector ok", ctxStr)
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Github Connector deleted successfully",

--- a/api/internal/features/github-connector/controller/get_connectors.go
+++ b/api/internal/features/github-connector/controller/get_connectors.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -18,9 +19,12 @@ func (c *GithubConnectorController) GetGithubConnectors(f fuego.ContextNoBody) (
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s", user.ID)
+	c.logger.Log(logger.Info, "github connector: GetGithubConnectors", ctxStr)
+
 	connectors, err := c.service.GetAllConnectors(user.ID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("github connector: GetGithubConnectors: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -28,6 +32,7 @@ func (c *GithubConnectorController) GetGithubConnectors(f fuego.ContextNoBody) (
 		}
 	}
 
+	c.logger.Log(logger.Info, "github connector: GetGithubConnectors ok", fmt.Sprintf("%s count=%d", ctxStr, len(connectors)))
 	return &types.ListConnectorsResponse{
 		Status:  "success",
 		Message: "Connectors fetched successfully",

--- a/api/internal/features/github-connector/controller/get_github_repositories.go
+++ b/api/internal/features/github-connector/controller/get_github_repositories.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -42,9 +43,12 @@ func (c *GithubConnectorController) GetGithubRepositories(f fuego.ContextNoBody)
 		sortDirection = "asc" // Default to asc if invalid
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s page=%d page_size=%d connector_id=%s search=%q sort_by=%s sort_dir=%s", user.ID, page, pageSize, connectorID, search, sortBy, sortDirection)
+	c.logger.Log(logger.Info, "github connector: GetGithubRepositories", ctxStr)
+
 	repositories, totalCount, err := c.service.GetRepositoriesPaginated(user.ID.String(), page, pageSize, connectorID, search, sortBy, sortDirection)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("github connector: GetGithubRepositories: %v", err), ctxStr)
 
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "invalid GitHub installation") || strings.Contains(errMsg, "installation not found") {
@@ -64,6 +68,7 @@ func (c *GithubConnectorController) GetGithubRepositories(f fuego.ContextNoBody)
 		}
 	}
 
+	c.logger.Log(logger.Info, "github connector: GetGithubRepositories ok", fmt.Sprintf("%s total=%d count=%d", ctxStr, totalCount, len(repositories)))
 	return &types.ListRepositoriesResponse{
 		Status:  "success",
 		Message: "Repositories fetched successfully",

--- a/api/internal/features/github-connector/controller/get_repository_branches.go
+++ b/api/internal/features/github-connector/controller/get_repository_branches.go
@@ -25,6 +25,7 @@ func (c *GithubConnectorController) GetGithubRepositoryBranches(f fuego.ContextW
 
 	body, err := f.Body()
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("github connector: GetGithubRepositoryBranches body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -32,9 +33,12 @@ func (c *GithubConnectorController) GetGithubRepositoryBranches(f fuego.ContextW
 		return nil, fuego.BadRequestError{Detail: "repository_name is required", Err: fmt.Errorf("repository_name is required")}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s repository=%s", user.ID, body.RepositoryName)
+	c.logger.Log(logger.Info, "github connector: GetGithubRepositoryBranches", ctxStr)
+
 	branches, err := c.service.GetRepositoryBranches(user.ID.String(), body.RepositoryName)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("github connector: GetGithubRepositoryBranches: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -42,6 +46,7 @@ func (c *GithubConnectorController) GetGithubRepositoryBranches(f fuego.ContextW
 		}
 	}
 
+	c.logger.Log(logger.Info, "github connector: GetGithubRepositoryBranches ok", fmt.Sprintf("%s count=%d", ctxStr, len(branches)))
 	return &types.ListBranchesResponse{
 		Status:  "success",
 		Message: "Branches fetched successfully",

--- a/api/internal/features/github-connector/controller/init.go
+++ b/api/internal/features/github-connector/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/nixopus/nixopus/api/internal/features/github-connector/service"
@@ -28,10 +29,10 @@ func NewGithubConnectorController(
 	l logger.Logger,
 	notifier shared_types.Notifier,
 ) *GithubConnectorController {
-	storage := storage.GithubConnectorStorage{DB: store.DB, Ctx: ctx}
+	storage := storage.GithubConnectorStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	return &GithubConnectorController{
 		store:     store,
-		validator: validation.NewValidator(&storage),
+		validator: validation.NewValidatorWithLogger(&storage, &l),
 		service:   service.NewGithubConnectorService(store, ctx, l, &storage),
 		ctx:       ctx,
 		logger:    l,
@@ -43,12 +44,12 @@ func (c *GithubConnectorController) parseAndValidate(w http.ResponseWriter, r *h
 	user := utils.GetUser(w, r)
 
 	if user == nil {
-		c.logger.Log(logger.Error, shared_types.ErrFailedToGetUserFromContext.Error(), shared_types.ErrFailedToGetUserFromContext.Error())
+		c.logger.Log(logger.Error, "github connector: parseAndValidate no user in context", "")
 		return shared_types.ErrFailedToGetUserFromContext
 	}
 
 	if err := c.validator.ValidateRequest(req); err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("github connector: validation failed: %v", err), fmt.Sprintf("user_id=%s", user.ID))
 		return err
 	}
 

--- a/api/internal/features/github-connector/controller/update_connector.go
+++ b/api/internal/features/github-connector/controller/update_connector.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,6 +16,7 @@ func (c *GithubConnectorController) UpdateGithubConnectorRequest(f fuego.Context
 	UpdateConnectorRequest, err := f.Body()
 
 	if err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("github connector: UpdateGithubConnector body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -30,9 +32,12 @@ func (c *GithubConnectorController) UpdateGithubConnectorRequest(f fuego.Context
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s connector_id=%s", user.ID, UpdateConnectorRequest.ConnectorID)
+	c.logger.Log(logger.Info, "github connector: UpdateGithubConnector", ctxStr)
+
 	err = c.service.UpdateConnectorInstallation(UpdateConnectorRequest.InstallationID, user.ID.String(), UpdateConnectorRequest.ConnectorID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("github connector: UpdateGithubConnector: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -40,6 +45,7 @@ func (c *GithubConnectorController) UpdateGithubConnectorRequest(f fuego.Context
 		}
 	}
 
+	c.logger.Log(logger.Info, "github connector: UpdateGithubConnector ok", ctxStr)
 	return &types.MessageResponse{
 		Status:  "success",
 		Message: "Github Connector Request Updated",

--- a/api/internal/features/github-connector/service/clone_repository.go
+++ b/api/internal/features/github-connector/service/clone_repository.go
@@ -21,23 +21,24 @@ type CloneRepositoryConfig struct {
 }
 
 func (s *GithubConnectorService) CloneRepository(ctx context.Context, c CloneRepositoryConfig, commitHash *string) (string, error) {
+	ctxStr := fmt.Sprintf("user_id=%s repo_id=%d env=%s app_id=%s", c.UserID, c.RepoID, c.Environment, c.ApplicationID)
 	repo, err := s.GetRepositoryByID(c.UserID, c.RepoID)
 	if err != nil {
-		s.Logger.Log(logger.Error, fmt.Sprintf("Failed to get repository details: %s", err.Error()), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository get repo: %v", err), ctxStr)
 		return "", err
 	}
 	repoURL := repo.CloneURL
 
-	s.Logger.Log(logger.Info, fmt.Sprintf("Cloning repository %s", repoURL), c.UserID)
+	s.Logger.Log(logger.Info, fmt.Sprintf("github connector service: CloneRepository start repo_url=%s", repoURL), ctxStr)
 
 	connectors, err := s.Storage.GetAllConnectors(c.UserID)
 	if err != nil {
-		s.Logger.Log(logger.Error, err.Error(), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository list connectors: %v", err), ctxStr)
 		return "", err
 	}
 
 	if len(connectors) == 0 {
-		s.Logger.Log(logger.Error, "No connectors found for user", c.UserID)
+		s.Logger.Log(logger.Error, "github connector service: CloneRepository no connectors", ctxStr)
 		return "", fmt.Errorf("no connectors found for user %s", c.UserID)
 	}
 
@@ -46,13 +47,13 @@ func (s *GithubConnectorService) CloneRepository(ctx context.Context, c CloneRep
 
 	accessToken, err := gh.InstallationToken(jwt, installationID)
 	if err != nil {
-		s.Logger.Log(logger.Error, fmt.Sprintf("Failed to get installation token: %s", err.Error()), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository installation token: %v", err), ctxStr)
 		return "", err
 	}
 
 	authenticatedURL, err := gh.CreateAuthenticatedRepoURL(repoURL, accessToken)
 	if err != nil {
-		s.Logger.Log(logger.Error, fmt.Sprintf("Failed to create authenticated URL: %s", err.Error()), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository authenticated URL: %v", err), ctxStr)
 		return "", err
 	}
 
@@ -62,38 +63,38 @@ func (s *GithubConnectorService) CloneRepository(ctx context.Context, c CloneRep
 	} else {
 		latestCommitHash, err = gh.LatestCommitHash(s.Logger, repoURL, accessToken)
 		if err != nil {
-			s.Logger.Log(logger.Error, fmt.Sprintf("Failed to get latest commit hash: %s", err.Error()), "")
+			s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository latest commit: %v", err), ctxStr)
 			return "", err
 		}
 	}
 
 	clonePath, shouldPull, err := s.GetClonePath(ctx, c.UserID, c.Environment, c.ApplicationID)
 	if err != nil {
-		s.Logger.Log(logger.Error, fmt.Sprintf("Failed to get clone path: %s", err.Error()), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository clone path: %v", err), ctxStr)
 		return "", err
 	}
 
-	s.Logger.Log(logger.Info, fmt.Sprintf("Clone path: %s", clonePath), "")
+	s.Logger.Log(logger.Info, fmt.Sprintf("github connector service: CloneRepository clone_path=%s should_pull=%t", clonePath, shouldPull), ctxStr)
 
 	gitClient, err := s.getGitClient(ctx)
 	if err != nil {
-		s.Logger.Log(logger.Error, fmt.Sprintf("Failed to get git client: %s", err.Error()), "")
+		s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository git client: %v", err), ctxStr)
 		return "", err
 	}
 
 	if c.DeploymentType == shared_types.DeploymentTypeRollback {
-		s.Logger.Log(logger.Info, "Rolling back repository", c.UserID)
+		s.Logger.Log(logger.Info, "github connector service: CloneRepository rollback", ctxStr)
 		err = gitClient.SetHeadToCommitHash(authenticatedURL, clonePath, latestCommitHash)
 		if err != nil {
-			s.Logger.Log(logger.Error, fmt.Sprintf("Failed to rollback repository: %s", err.Error()), "")
+			s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository rollback: %v", err), ctxStr)
 			return "", err
 		}
 	} else {
 		if !shouldPull {
-			s.Logger.Log(logger.Info, "Cloning repository", c.UserID)
+			s.Logger.Log(logger.Info, "github connector service: CloneRepository clone", ctxStr)
 			err = gitClient.Clone(authenticatedURL, clonePath)
 			if err != nil {
-				s.Logger.Log(logger.Error, fmt.Sprintf("Failed to clone repository: %s", err.Error()), "")
+				s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository clone failed: %v", err), ctxStr)
 				return "", err
 			}
 		} else {
@@ -103,15 +104,15 @@ func (s *GithubConnectorService) CloneRepository(ctx context.Context, c CloneRep
 		}
 
 		if c.Branch != "" {
-			s.Logger.Log(logger.Info, fmt.Sprintf("Switching to branch %s", c.Branch), c.UserID)
+			s.Logger.Log(logger.Info, fmt.Sprintf("github connector service: CloneRepository checkout branch=%s", c.Branch), ctxStr)
 			err = gitClient.SwitchBranch(clonePath, c.Branch)
 			if err != nil {
-				s.Logger.Log(logger.Error, fmt.Sprintf("Failed to switch to branch %s: %s", c.Branch, err.Error()), "")
+				s.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CloneRepository branch %s: %v", c.Branch, err), ctxStr)
 				return "", err
 			}
 		}
 	}
 
-	s.Logger.Log(logger.Info, fmt.Sprintf("Context loaded successfully %s", repoURL), c.UserID)
+	s.Logger.Log(logger.Info, "github connector service: CloneRepository ok", ctxStr)
 	return clonePath, nil
 }

--- a/api/internal/features/github-connector/service/git/git.go
+++ b/api/internal/features/github-connector/service/git/git.go
@@ -58,7 +58,7 @@ func (g *sshGit) Clone(repoURL, destinationPath string) error {
 	if err != nil {
 		return fmt.Errorf("git clone failed: %s, output: %s", err.Error(), output)
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully cloned repository to %s", destinationPath), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: cloned to %s", destinationPath), "")
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (g *sshGit) Pull(repoURL, destinationPath string) error {
 	if err != nil {
 		return fmt.Errorf("git pull failed: %s, output: %s", err.Error(), output)
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully pulled latest changes for repository at %s", destinationPath), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: pulled at %s", destinationPath), "")
 	return nil
 }
 
@@ -92,7 +92,7 @@ func (g *sshGit) SetHeadToCommitHash(repoURL, destinationPath, commitHash string
 	if err != nil {
 		return fmt.Errorf("git checkout failed: %s, output: %s", err.Error(), output)
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully checked out commit %s at %s", commitHash, destinationPath), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: checked out commit %s at %s", commitHash, destinationPath), "")
 	return nil
 }
 
@@ -109,7 +109,7 @@ func (g *sshGit) SwitchBranch(destinationPath, branch string) error {
 	if err != nil {
 		return fmt.Errorf("git checkout branch failed: %s, output: %s", err.Error(), output)
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully switched to branch %s at %s", branch, destinationPath), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: switched to branch %s at %s", branch, destinationPath), "")
 	return nil
 }
 
@@ -146,7 +146,7 @@ func (g *sshGit) Stash(destinationPath string) (string, error) {
 	if stashID == "" {
 		return "", fmt.Errorf("no stash created")
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully stashed changes at %s with ID %s", destinationPath, stashID), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: stashed at %s id=%s", destinationPath, stashID), "")
 	return stashID, nil
 }
 
@@ -162,7 +162,7 @@ func (g *sshGit) ApplyStash(destinationPath, stashID string) error {
 	if err != nil {
 		return fmt.Errorf("git stash apply failed: %s, output: %s", err.Error(), output)
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully applied stash %s at %s", stashID, destinationPath), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: applied stash %s at %s", stashID, destinationPath), "")
 	return nil
 }
 
@@ -175,7 +175,7 @@ func (g *sshGit) ResetHard(destinationPath string) error {
 	if err != nil {
 		return fmt.Errorf("git reset --hard failed: %s, output: %s", err.Error(), output)
 	}
-	g.logger.Log(logger.Info, fmt.Sprintf("Successfully reset repository at %s", destinationPath), "")
+	g.logger.Log(logger.Info, fmt.Sprintf("github connector git: reset hard at %s", destinationPath), "")
 	return nil
 }
 

--- a/api/internal/features/github-connector/service/git/paths.go
+++ b/api/internal/features/github-connector/service/git/paths.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/utils"
 	"github.com/pkg/sftp"
 )
 
 // ResolveClonePath computes the tenant clone path via SFTP and ensures the directory exists.
-func ResolveClonePath(ctx context.Context, userID, environment, applicationID string) (string, bool, error) {
+func ResolveClonePath(ctx context.Context, l logger.Logger, userID, environment, applicationID string) (string, bool, error) {
+	ctxStr := fmt.Sprintf("user_id=%s env=%s application_id=%s", userID, environment, applicationID)
+	l.Log(logger.Debug, "github connector git: ResolveClonePath", ctxStr)
+
 	repoBaseURL := "/var/nixopus/repos"
 	clonePath := filepath.Join(repoBaseURL, userID, environment, applicationID)
 	var shouldPull bool
@@ -18,16 +22,21 @@ func ResolveClonePath(ctx context.Context, userID, environment, applicationID st
 		info, statErr := sftpClient.Stat(clonePath)
 		if statErr == nil && info.IsDir() {
 			shouldPull = true
+			l.Log(logger.Debug, "github connector git: ResolveClonePath existing repo dir", fmt.Sprintf("%s path=%s", ctxStr, clonePath))
 		}
 		if !shouldPull {
 			if mkErr := sftpClient.MkdirAll(clonePath); mkErr != nil {
+				l.Log(logger.Error, fmt.Sprintf("github connector git: ResolveClonePath MkdirAll: %v", mkErr), fmt.Sprintf("%s path=%s", ctxStr, clonePath))
 				return fmt.Errorf("failed to create directory via SFTP: %w", mkErr)
 			}
+			l.Log(logger.Debug, "github connector git: ResolveClonePath created dirs", fmt.Sprintf("%s path=%s", ctxStr, clonePath))
 		}
 		return nil
 	})
 	if err != nil {
+		l.Log(logger.Error, fmt.Sprintf("github connector git: ResolveClonePath SFTP pool: %v", err), ctxStr)
 		return "", false, err
 	}
+	l.Log(logger.Debug, "github connector git: ResolveClonePath ok", fmt.Sprintf("%s path=%s should_pull=%t", ctxStr, clonePath, shouldPull))
 	return clonePath, shouldPull, nil
 }

--- a/api/internal/features/github-connector/service/git/pull.go
+++ b/api/internal/features/github-connector/service/git/pull.go
@@ -10,19 +10,19 @@ import (
 func HandlePullWithClient(log logger.Logger, client Git, authenticatedURL, clonePath, userID string) error {
 	hasChanges, err := client.HasUncommittedChanges(clonePath)
 	if err != nil {
-		log.Log(logger.Error, fmt.Sprintf("Failed to check for uncommitted changes: %s", err.Error()), userID)
+		log.Log(logger.Error, fmt.Sprintf("github connector git: uncommitted changes check: %s", err.Error()), userID)
 		return err
 	}
 	if hasChanges {
-		log.Log(logger.Info, "Discarding local changes for clean state", userID)
+		log.Log(logger.Info, "github connector git: discarding local changes for clean pull", userID)
 		if err := client.ResetHard(clonePath); err != nil {
-			log.Log(logger.Error, fmt.Sprintf("Failed to reset repository: %s", err.Error()), userID)
+			log.Log(logger.Error, fmt.Sprintf("github connector git: reset hard: %s", err.Error()), userID)
 			return err
 		}
 	}
-	log.Log(logger.Info, "Pulling latest changes", userID)
+	log.Log(logger.Info, "github connector git: pulling latest", userID)
 	if err := client.Pull(authenticatedURL, clonePath); err != nil {
-		log.Log(logger.Error, fmt.Sprintf("Failed to pull repository: %s", err.Error()), userID)
+		log.Log(logger.Error, fmt.Sprintf("github connector git: pull: %s", err.Error()), userID)
 		return err
 	}
 	return nil

--- a/api/internal/features/github-connector/service/github/connectors.go
+++ b/api/internal/features/github-connector/service/github/connectors.go
@@ -16,9 +16,10 @@ import (
 // CreateConnector creates a new GitHub connector for the given user.
 func (a *API) CreateConnector(connector *gctypes.CreateGithubConnectorRequest, userID string) error {
 	if _, err := uuid.Parse(userID); err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CreateConnector invalid user_id: %v", err), userID)
 		return err
 	}
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
 	githubConfig := config.AppConfig.GitHub
 	appID := connector.AppID
 	slug := connector.Slug
@@ -28,7 +29,7 @@ func (a *API) CreateConnector(connector *gctypes.CreateGithubConnectorRequest, u
 	webhookSecret := connector.WebhookSecret
 	if appID == "" || pem == "" {
 		if githubConfig.AppID == "" || githubConfig.Pem == "" {
-			a.Logger.Log(logger.Error, "GitHub App credentials not configured", "")
+			a.Logger.Log(logger.Error, "github connector service: CreateConnector GitHub App credentials not configured", ctxStr)
 			return fmt.Errorf("GitHub App credentials not configured")
 		}
 		appID = githubConfig.AppID
@@ -52,23 +53,30 @@ func (a *API) CreateConnector(connector *gctypes.CreateGithubConnectorRequest, u
 		DeletedAt:      nil,
 		UserID:         uuid.MustParse(userID),
 	}
-	return a.Storage.CreateConnector(&newConn)
+	if err := a.Storage.CreateConnector(&newConn); err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: CreateConnector: %v", err), ctxStr)
+		return err
+	}
+	a.Logger.Log(logger.Info, "github connector service: CreateConnector ok", fmt.Sprintf("%s connector_id=%s", ctxStr, newConn.ID))
+	return nil
 }
 
 // UpdateConnectorInstallation updates the GitHub App installation ID for the user's connector.
 func (a *API) UpdateConnectorInstallation(installationID, userID, connectorID string) error {
+	ctxStr := fmt.Sprintf("user_id=%s connector_id=%s", userID, connectorID)
 	connectors, err := a.Storage.GetAllConnectors(userID)
 	if err != nil {
-		fmt.Println(err)
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: UpdateConnectorInstallation list: %v", err), ctxStr)
 		return err
 	}
 	if len(connectors) == 0 {
-		fmt.Println("no connector found")
+		a.Logger.Log(logger.Error, "github connector service: UpdateConnectorInstallation no connectors for user", ctxStr)
 		return fmt.Errorf("no connectors found for user")
 	}
 	var connectorToUpdate *shared_types.GithubConnector
 	if connectorID != "" {
 		if _, err := uuid.Parse(connectorID); err != nil {
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: UpdateConnectorInstallation invalid connector_id: %v", err), ctxStr)
 			return fmt.Errorf("invalid connector_id format: %v", err)
 		}
 		for i := range connectors {
@@ -78,10 +86,12 @@ func (a *API) UpdateConnectorInstallation(installationID, userID, connectorID st
 			}
 		}
 		if connectorToUpdate == nil {
+			a.Logger.Log(logger.Error, "github connector service: UpdateConnectorInstallation connector not found for user", ctxStr)
 			return fmt.Errorf("connector with id %s not found", connectorID)
 		}
 	} else {
 		if len(connectors) > 1 {
+			a.Logger.Log(logger.Error, "github connector service: UpdateConnectorInstallation connector_id required when multiple connectors", ctxStr)
 			return fmt.Errorf("connector_id is required when multiple connectors exist")
 		}
 		for i := range connectors {
@@ -94,29 +104,37 @@ func (a *API) UpdateConnectorInstallation(installationID, userID, connectorID st
 			connectorToUpdate = &connectors[0]
 		}
 	}
-	return a.Storage.UpdateConnector(connectorToUpdate.ID.String(), installationID)
+	ctxStr = fmt.Sprintf("%s target_connector_id=%s", ctxStr, connectorToUpdate.ID)
+	if err := a.Storage.UpdateConnector(connectorToUpdate.ID.String(), installationID); err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: UpdateConnectorInstallation: %v", err), ctxStr)
+		return err
+	}
+	a.Logger.Log(logger.Info, "github connector service: UpdateConnectorInstallation ok", ctxStr)
+	return nil
 }
 
 // DeleteConnector soft-deletes a connector after ownership checks.
 func (a *API) DeleteConnector(connectorID, userID string) error {
+	ctxStr := fmt.Sprintf("connector_id=%s user_id=%s", connectorID, userID)
 	connector, err := a.Storage.GetConnector(connectorID)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: DeleteConnector lookup: %v", err), ctxStr)
 		return gctypes.ErrConnectorDoesNotExist
 	}
 	if connector.UserID.String() != userID {
-		a.Logger.Log(logger.Error, "User does not own this connector", "")
+		a.Logger.Log(logger.Error, "github connector service: DeleteConnector permission denied", ctxStr)
 		return gctypes.ErrPermissionDenied
 	}
 	if connector.DeletedAt != nil {
-		a.Logger.Log(logger.Error, "Connector already deleted", "")
+		a.Logger.Log(logger.Error, "github connector service: DeleteConnector already deleted", ctxStr)
 		return gctypes.ErrConnectorDoesNotExist
 	}
 	err = a.Storage.DeleteConnector(connectorID, userID)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: DeleteConnector: %v", err), ctxStr)
 		return err
 	}
+	a.Logger.Log(logger.Info, "github connector service: DeleteConnector ok", ctxStr)
 	return nil
 }
 

--- a/api/internal/features/github-connector/service/github/jwt.go
+++ b/api/internal/features/github-connector/service/github/jwt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/nixopus/nixopus/api/internal/config"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/sirupsen/logrus"
 )
 
 // InstallationToken exchanges a GitHub App JWT for an installation access token.
@@ -62,7 +63,7 @@ func GenerateJwt(appCredentials *shared_types.GithubConnector) string {
 	} else {
 		githubConfig := config.AppConfig.GitHub
 		if githubConfig.Pem == "" || githubConfig.AppID == "" {
-			fmt.Println("Error: GitHub App credentials not configured")
+			logrus.Error("github connector service: GenerateJwt GitHub App credentials not configured")
 			return ""
 		}
 		pem = githubConfig.Pem
@@ -70,7 +71,7 @@ func GenerateJwt(appCredentials *shared_types.GithubConnector) string {
 	}
 	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(pem))
 	if err != nil {
-		fmt.Println("Error parsing private key:", err)
+		logrus.Errorf("github connector service: GenerateJwt parse private key: %v", err)
 		return ""
 	}
 	now := time.Now()
@@ -82,7 +83,7 @@ func GenerateJwt(appCredentials *shared_types.GithubConnector) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	tokenString, err := token.SignedString(privateKey)
 	if err != nil {
-		fmt.Println("Error signing token:", err)
+		logrus.Errorf("github connector service: GenerateJwt sign token: %v", err)
 		return ""
 	}
 	return tokenString

--- a/api/internal/features/github-connector/service/github/repositories.go
+++ b/api/internal/features/github-connector/service/github/repositories.go
@@ -15,12 +15,13 @@ import (
 // GetRepositoriesPaginated lists installation repos with optional search/sort.
 func (a *API) GetRepositoriesPaginated(userID string, page, pageSize int, connectorID, search, sortBy, sortDirection string) ([]shared_types.GithubRepository, int, error) {
 	connectors, err := a.Storage.GetAllConnectors(userID)
+	ctxBase := fmt.Sprintf("user_id=%s", userID)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoriesPaginated list connectors: %v", err), ctxBase)
 		return nil, 0, err
 	}
 	if len(connectors) == 0 {
-		a.Logger.Log(logger.Error, "No connectors found for user", userID)
+		a.Logger.Log(logger.Debug, "github connector service: GetRepositoriesPaginated no connectors", ctxBase)
 		return []shared_types.GithubRepository{}, 0, nil
 	}
 	var connectorToUse *shared_types.GithubConnector
@@ -32,7 +33,7 @@ func (a *API) GetRepositoriesPaginated(userID string, page, pageSize int, connec
 			}
 		}
 		if connectorToUse == nil {
-			a.Logger.Log(logger.Error, fmt.Sprintf("Connector with id %s not found for user", connectorID), userID)
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoriesPaginated connector_id=%s not found", connectorID), ctxBase)
 			return nil, 0, fmt.Errorf("connector not found")
 		}
 	} else {
@@ -43,23 +44,23 @@ func (a *API) GetRepositoriesPaginated(userID string, page, pageSize int, connec
 			}
 		}
 		if connectorToUse == nil {
-			a.Logger.Log(logger.Error, "No connector with valid installation_id found for user", userID)
+			a.Logger.Log(logger.Error, "github connector service: GetRepositoriesPaginated no connector with installation_id", ctxBase)
 			return nil, 0, fmt.Errorf("no connector with valid installation found")
 		}
 	}
 	if connectorToUse.InstallationID == "" || connectorToUse.InstallationID == " " {
-		a.Logger.Log(logger.Error, fmt.Sprintf("Connector %s has empty installation_id", connectorToUse.ID.String()), userID)
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoriesPaginated empty installation_id connector_id=%s", connectorToUse.ID.String()), ctxBase)
 		return nil, 0, fmt.Errorf("connector has no installation_id")
 	}
 	installationID := connectorToUse.InstallationID
 	jwt := GenerateJwt(connectorToUse)
 	if jwt == "" {
-		a.Logger.Log(logger.Error, "Failed to generate app JWT", "")
+		a.Logger.Log(logger.Error, "github connector service: GetRepositoriesPaginated JWT generation failed", ctxBase)
 		return nil, 0, fmt.Errorf("failed to generate app JWT: GitHub App credentials are not configured")
 	}
 	accessToken, err := InstallationToken(jwt, installationID)
 	if err != nil {
-		a.Logger.Log(logger.Error, fmt.Sprintf("Failed to get installation token: %s", err.Error()), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoriesPaginated installation token: %v", err), ctxBase)
 		if strings.Contains(err.Error(), "installation not found") {
 			return nil, 0, fmt.Errorf("invalid GitHub installation: %w. Please reconnect your GitHub account", err)
 		}
@@ -85,7 +86,7 @@ func (a *API) fetchPaginatedRepositories(accessToken string, page, pageSize int)
 	u := fmt.Sprintf("%s/installation/repositories?per_page=%d&page=%d", APIBaseURL, pageSize, page)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 		return nil, 0, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
@@ -93,13 +94,13 @@ func (a *API) fetchPaginatedRepositories(accessToken string, page, pageSize int)
 	req.Header.Set("User-Agent", "nixopus")
 	resp, err := client.Do(req)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 		return nil, 0, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		a.Logger.Log(logger.Error, fmt.Sprintf("GitHub API error: %s - %s", resp.Status, string(bodyBytes)), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GitHub API error: %s - %s", resp.Status, string(bodyBytes)), "")
 		return nil, 0, fmt.Errorf("GitHub API error: %s", resp.Status)
 	}
 	var response struct {
@@ -107,7 +108,7 @@ func (a *API) fetchPaginatedRepositories(accessToken string, page, pageSize int)
 		Repositories []shared_types.GithubRepository `json:"repositories"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 		return nil, 0, err
 	}
 	return response.Repositories, response.TotalCount, nil
@@ -122,7 +123,7 @@ func (a *API) fetchAllAndFilter(accessToken string, page, pageSize int, search, 
 		u := fmt.Sprintf("%s/installation/repositories?per_page=%d&page=%d", APIBaseURL, perPage, currentPage)
 		req, err := http.NewRequest("GET", u, nil)
 		if err != nil {
-			a.Logger.Log(logger.Error, err.Error(), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 			return nil, 0, err
 		}
 		req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
@@ -130,13 +131,13 @@ func (a *API) fetchAllAndFilter(accessToken string, page, pageSize int, search, 
 		req.Header.Set("User-Agent", "nixopus")
 		resp, err := client.Do(req)
 		if err != nil {
-			a.Logger.Log(logger.Error, err.Error(), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 			return nil, 0, err
 		}
 		if resp.StatusCode != http.StatusOK {
 			bodyBytes, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			a.Logger.Log(logger.Error, fmt.Sprintf("GitHub API error: %s - %s", resp.Status, string(bodyBytes)), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GitHub API error: %s - %s", resp.Status, string(bodyBytes)), "")
 			return nil, 0, fmt.Errorf("GitHub API error: %s", resp.Status)
 		}
 		var response struct {
@@ -145,7 +146,7 @@ func (a *API) fetchAllAndFilter(accessToken string, page, pageSize int, search, 
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 			resp.Body.Close()
-			a.Logger.Log(logger.Error, err.Error(), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 			return nil, 0, err
 		}
 		resp.Body.Close()
@@ -218,7 +219,7 @@ func (a *API) fetchAllSortAndPaginate(accessToken string, page, pageSize int, so
 		u := fmt.Sprintf("%s/installation/repositories?per_page=%d&page=%d", APIBaseURL, perPage, currentPage)
 		req, err := http.NewRequest("GET", u, nil)
 		if err != nil {
-			a.Logger.Log(logger.Error, err.Error(), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 			return nil, 0, err
 		}
 		req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
@@ -226,13 +227,13 @@ func (a *API) fetchAllSortAndPaginate(accessToken string, page, pageSize int, so
 		req.Header.Set("User-Agent", "nixopus")
 		resp, err := client.Do(req)
 		if err != nil {
-			a.Logger.Log(logger.Error, err.Error(), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 			return nil, 0, err
 		}
 		if resp.StatusCode != http.StatusOK {
 			bodyBytes, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			a.Logger.Log(logger.Error, fmt.Sprintf("GitHub API error: %s - %s", resp.Status, string(bodyBytes)), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GitHub API error: %s - %s", resp.Status, string(bodyBytes)), "")
 			return nil, 0, fmt.Errorf("GitHub API error: %s", resp.Status)
 		}
 		var response struct {
@@ -241,7 +242,7 @@ func (a *API) fetchAllSortAndPaginate(accessToken string, page, pageSize int, so
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 			resp.Body.Close()
-			a.Logger.Log(logger.Error, err.Error(), "")
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: installation repos: %v", err), "")
 			return nil, 0, err
 		}
 		resp.Body.Close()

--- a/api/internal/features/github-connector/service/github/repository.go
+++ b/api/internal/features/github-connector/service/github/repository.go
@@ -17,26 +17,29 @@ import (
 
 // GetRepositoryByID fetches repository metadata from GitHub by numeric repo ID.
 func (a *API) GetRepositoryByID(userID string, repoID uint64) (*shared_types.GithubRepository, error) {
+	ctxStr := fmt.Sprintf("user_id=%s repo_id=%d", userID, repoID)
 	connectors, err := a.Storage.GetAllConnectors(userID)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryByID list connectors: %v", err), ctxStr)
 		return nil, err
 	}
 	if len(connectors) == 0 {
-		a.Logger.Log(logger.Error, "No connectors found for user", userID)
+		a.Logger.Log(logger.Error, "github connector service: GetRepositoryByID no connectors", ctxStr)
 		return nil, fmt.Errorf("no connectors found for user")
 	}
 	jwt := GenerateJwt(&connectors[0])
 	if jwt == "" {
+		a.Logger.Log(logger.Error, "github connector service: GetRepositoryByID JWT generation failed", ctxStr)
 		return nil, fmt.Errorf("failed to generate app JWT")
 	}
 	accessToken, err := InstallationToken(jwt, connectors[0].InstallationID)
 	if err != nil {
-		a.Logger.Log(logger.Error, fmt.Sprintf("Failed to get installation token: %s", err.Error()), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryByID installation token: %v", err), ctxStr)
 		return nil, err
 	}
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/repositories/%d", APIBaseURL, repoID), nil)
 	if err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryByID new request: %v", err), ctxStr)
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
@@ -44,15 +47,18 @@ func (a *API) GetRepositoryByID(userID string, repoID uint64) (*shared_types.Git
 	req.Header.Set("User-Agent", "nixopus")
 	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryByID request: %v", err), ctxStr)
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryByID GitHub API: %s - %s", resp.Status, string(bodyBytes)), ctxStr)
 		return nil, fmt.Errorf("GitHub API error: %s - %s", resp.Status, string(bodyBytes))
 	}
 	var repo shared_types.GithubRepository
 	if err := json.NewDecoder(resp.Body).Decode(&repo); err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryByID decode: %v", err), ctxStr)
 		return nil, err
 	}
 	return &repo, nil
@@ -60,27 +66,31 @@ func (a *API) GetRepositoryByID(userID string, repoID uint64) (*shared_types.Git
 
 // GetRepositoryBranches lists branches for a repo (owner/repo name or numeric ID).
 func (a *API) GetRepositoryBranches(userID, repositoryName string) ([]shared_types.GithubRepositoryBranch, error) {
+	ctxStr := fmt.Sprintf("user_id=%s repository=%s", userID, repositoryName)
 	connectors, err := a.Storage.GetAllConnectors(userID)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches list connectors: %v", err), ctxStr)
 		return nil, err
 	}
 	if len(connectors) == 0 {
+		a.Logger.Log(logger.Debug, "github connector service: GetRepositoryBranches no connectors", ctxStr)
 		return []shared_types.GithubRepositoryBranch{}, nil
 	}
 	jwt := GenerateJwt(&connectors[0])
 	if jwt == "" {
+		a.Logger.Log(logger.Error, "github connector service: GetRepositoryBranches JWT generation failed", ctxStr)
 		return nil, fmt.Errorf("failed to generate app JWT")
 	}
 	accessToken, err := InstallationToken(jwt, connectors[0].InstallationID)
 	if err != nil {
-		a.Logger.Log(logger.Error, fmt.Sprintf("Failed to get installation token: %s", err.Error()), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches installation token: %v", err), ctxStr)
 		return nil, err
 	}
 	var repoFullName string
 	if repoID, err := strconv.ParseUint(repositoryName, 10, 64); err == nil {
 		repo, err := a.GetRepositoryByID(userID, repoID)
 		if err != nil {
+			a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches resolve repo id: %v", err), ctxStr)
 			return nil, fmt.Errorf("failed to get repository details: %s", err.Error())
 		}
 		repoFullName = repo.FullName
@@ -89,6 +99,7 @@ func (a *API) GetRepositoryBranches(userID, repositoryName string) ([]shared_typ
 	}
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/repos/%s/branches", APIBaseURL, repoFullName), nil)
 	if err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches new request: %v", err), ctxStr)
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
@@ -96,15 +107,18 @@ func (a *API) GetRepositoryBranches(userID, repositoryName string) ([]shared_typ
 	req.Header.Set("User-Agent", "nixopus")
 	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches request: %v", err), ctxStr)
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches GitHub API: %s - %s", resp.Status, string(bodyBytes)), ctxStr)
 		return nil, fmt.Errorf("GitHub API error: %s - %s", resp.Status, string(bodyBytes))
 	}
 	var branches []shared_types.GithubRepositoryBranch
 	if err := json.NewDecoder(resp.Body).Decode(&branches); err != nil {
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryBranches decode: %v", err), ctxStr)
 		return nil, err
 	}
 	return branches, nil
@@ -119,10 +133,11 @@ type contentResponse struct {
 func (a *API) GetRepositoryFileContent(userID, repository, branch, filePath string) ([]byte, error) {
 	connectors, err := a.Storage.GetAllConnectors(userID)
 	if err != nil {
-		a.Logger.Log(logger.Error, err.Error(), "")
+		a.Logger.Log(logger.Error, fmt.Sprintf("github connector service: GetRepositoryFileContent list connectors: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return nil, err
 	}
 	if len(connectors) == 0 {
+		a.Logger.Log(logger.Error, "github connector service: GetRepositoryFileContent no connectors", fmt.Sprintf("user_id=%s", userID))
 		return nil, fmt.Errorf("no GitHub connectors found for user")
 	}
 	jwt := GenerateJwt(&connectors[0])
@@ -206,6 +221,6 @@ func LatestCommitHash(log logger.Logger, repoURL string, accessToken string) (st
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return "", fmt.Errorf("failed to decode response: %s", err.Error())
 	}
-	log.Log(logger.Info, fmt.Sprintf("Latest commit hash: %s", response.SHA), "")
+	log.Log(logger.Info, fmt.Sprintf("github connector service: LatestCommitHash %s", response.SHA), "")
 	return response.SHA, nil
 }

--- a/api/internal/features/github-connector/service/init.go
+++ b/api/internal/features/github-connector/service/init.go
@@ -60,5 +60,5 @@ func (s *GithubConnectorService) GetClonePath(ctx context.Context, userID, envir
 	if s.clonePathProvider != nil {
 		return s.clonePathProvider(ctx, userID, environment, applicationID)
 	}
-	return git.ResolveClonePath(ctx, userID, environment, applicationID)
+	return git.ResolveClonePath(ctx, s.Logger, userID, environment, applicationID)
 }

--- a/api/internal/features/github-connector/storage/init.go
+++ b/api/internal/features/github-connector/storage/init.go
@@ -2,13 +2,17 @@ package storage
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type GithubConnectorStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 type GithubConnectorRepository interface {
@@ -18,6 +22,13 @@ type GithubConnectorRepository interface {
 	GetConnector(ConnectorID string) (*shared_types.GithubConnector, error)
 	GetAllConnectors(UserID string) ([]shared_types.GithubConnector, error)
 	GetConnectorByAppID(AppID string) (*shared_types.GithubConnector, error)
+}
+
+func (s *GithubConnectorStorage) storageLog(sev logger.Severity, msg, data string) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Log(sev, msg, data)
 }
 
 // CreateConnector creates a new GitHub connector for the given user.
@@ -31,18 +42,23 @@ type GithubConnectorRepository interface {
 //
 // If the connector cannot be created, an error is returned.
 func (s *GithubConnectorStorage) CreateConnector(connector *shared_types.GithubConnector) error {
+	ctxStr := fmt.Sprintf("user_id=%s connector_id=%s app_id=%s", connector.UserID, connector.ID, connector.AppID)
+	s.storageLog(logger.Debug, "storage: CreateConnector", ctxStr)
 	tx, err := s.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateConnector BeginTx: %v", err), ctxStr)
 		return err
 	}
 	defer tx.Rollback()
 
 	_, err = tx.NewInsert().Model(connector).Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateConnector insert: %v", err), ctxStr)
 		return err
 	}
 
 	if err := tx.Commit(); err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateConnector Commit: %v", err), ctxStr)
 		return err
 	}
 
@@ -56,8 +72,11 @@ func (s *GithubConnectorStorage) CreateConnector(connector *shared_types.GithubC
 //
 // If the connector cannot be updated, an error is returned.
 func (s *GithubConnectorStorage) UpdateConnector(ConnectorID, InstallationID string) error {
+	ctxStr := fmt.Sprintf("connector_id=%s", ConnectorID)
+	s.storageLog(logger.Debug, "storage: UpdateConnector", ctxStr)
 	tx, err := s.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateConnector BeginTx: %v", err), ctxStr)
 		return err
 	}
 	defer tx.Rollback()
@@ -67,10 +86,12 @@ func (s *GithubConnectorStorage) UpdateConnector(ConnectorID, InstallationID str
 		SetColumn("installation_id", InstallationID).
 		Where("id = ?", ConnectorID).Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateConnector: %v", err), ctxStr)
 		return err
 	}
 
 	if err := tx.Commit(); err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateConnector Commit: %v", err), ctxStr)
 		return err
 	}
 
@@ -92,8 +113,15 @@ func (s *GithubConnectorStorage) UpdateConnector(ConnectorID, InstallationID str
 //	*shared_types.GithubConnector - a pointer to the GitHub connector object if found.
 //	error - an error if the connector cannot be retrieved or does not exist.
 func (s *GithubConnectorStorage) GetConnector(ConnectorID string) (*shared_types.GithubConnector, error) {
+	ctxStr := fmt.Sprintf("connector_id=%s", ConnectorID)
+	s.storageLog(logger.Debug, "storage: GetConnector", ctxStr)
 	var connector shared_types.GithubConnector
 	err := s.DB.NewSelect().Model(&connector).Where("id = ? AND deleted_at IS NULL", ConnectorID).Scan(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetConnector: %v", err), ctxStr)
+	} else {
+		s.storageLog(logger.Debug, "storage: GetConnector ok", ctxStr)
+	}
 	return &connector, err
 }
 
@@ -112,8 +140,15 @@ func (s *GithubConnectorStorage) GetConnector(ConnectorID string) (*shared_types
 //	[]shared_types.GithubConnector - a slice of GitHub connector objects if found.
 //	error - an error if the connectors cannot be retrieved or do not exist.
 func (s *GithubConnectorStorage) GetAllConnectors(UserID string) ([]shared_types.GithubConnector, error) {
+	ctxStr := fmt.Sprintf("user_id=%s", UserID)
+	s.storageLog(logger.Debug, "storage: GetAllConnectors", ctxStr)
 	var connectors []shared_types.GithubConnector
 	err := s.DB.NewSelect().Model(&connectors).Where("user_id = ? AND deleted_at IS NULL", UserID).Scan(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetAllConnectors: %v", err), ctxStr)
+	} else {
+		s.storageLog(logger.Debug, "storage: GetAllConnectors ok", fmt.Sprintf("%s count=%d", ctxStr, len(connectors)))
+	}
 	return connectors, err
 }
 
@@ -132,8 +167,11 @@ func (s *GithubConnectorStorage) GetAllConnectors(UserID string) ([]shared_types
 //
 //	error - an error if the connector cannot be deleted or does not exist.
 func (s *GithubConnectorStorage) DeleteConnector(ConnectorID string, UserID string) error {
+	ctxStr := fmt.Sprintf("connector_id=%s user_id=%s", ConnectorID, UserID)
+	s.storageLog(logger.Debug, "storage: DeleteConnector", ctxStr)
 	tx, err := s.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteConnector BeginTx: %v", err), ctxStr)
 		return err
 	}
 	defer tx.Rollback()
@@ -145,10 +183,12 @@ func (s *GithubConnectorStorage) DeleteConnector(ConnectorID string, UserID stri
 		Where("id = ? AND user_id = ? AND deleted_at IS NULL", ConnectorID, UserID).
 		Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteConnector: %v", err), ctxStr)
 		return err
 	}
 
 	if err := tx.Commit(); err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteConnector Commit: %v", err), ctxStr)
 		return err
 	}
 
@@ -170,7 +210,14 @@ func (s *GithubConnectorStorage) DeleteConnector(ConnectorID string, UserID stri
 //	*shared_types.GithubConnector - a pointer to the GitHub connector object if found.
 //	error - an error if the connector cannot be retrieved or does not exist.
 func (s *GithubConnectorStorage) GetConnectorByAppID(AppID string) (*shared_types.GithubConnector, error) {
+	ctxStr := fmt.Sprintf("app_id=%s", AppID)
+	s.storageLog(logger.Debug, "storage: GetConnectorByAppID", ctxStr)
 	var connector shared_types.GithubConnector
 	err := s.DB.NewSelect().Model(&connector).Where("app_id = ?", AppID).Scan(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetConnectorByAppID: %v", err), ctxStr)
+	} else {
+		s.storageLog(logger.Debug, "storage: GetConnectorByAppID ok", ctxStr)
+	}
 	return &connector, err
 }

--- a/api/internal/features/github-connector/validation/validator.go
+++ b/api/internal/features/github-connector/validation/validator.go
@@ -1,9 +1,11 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/nixopus/nixopus/api/internal/features/github-connector/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
@@ -16,13 +18,27 @@ type GithubConnectorRepository interface {
 // Validator handles validation logic for github connector
 type Validator struct {
 	storage GithubConnectorRepository
+	Logger  *logger.Logger // optional; nil disables validation logs
 }
 
 // NewValidator creates a new validator instance
 func NewValidator(storage GithubConnectorRepository) *Validator {
+	return NewValidatorWithLogger(storage, nil)
+}
+
+// NewValidatorWithLogger is like NewValidator but attaches a logger for Debug detail on rule failures.
+func NewValidatorWithLogger(storage GithubConnectorRepository, log *logger.Logger) *Validator {
 	return &Validator{
 		storage: storage,
+		Logger:  log,
 	}
+}
+
+func (v *Validator) valog(sev logger.Severity, msg, data string) {
+	if v == nil || v.Logger == nil {
+		return
+	}
+	v.Logger.Log(sev, msg, data)
 }
 
 // ValidateRequest validates a request object against a set of predefined rules.
@@ -44,6 +60,7 @@ func (v *Validator) ValidateRequest(req any) error {
 	case *types.DeleteGithubConnectorRequest:
 		return v.validateDeleteGithubConnectorRequest(*r)
 	default:
+		v.valog(logger.Debug, "github connector validation: invalid request type", fmt.Sprintf("%T", req))
 		return types.ErrInvalidRequestType
 	}
 }
@@ -73,18 +90,23 @@ func (v *Validator) validateCreateGithubConnectorRequest(req types.CreateGithubC
 	// If any credential is provided, all must be provided (backward compatibility)
 	if hasCredentials {
 		if isEmpty(req.Slug) {
+			v.valog(logger.Debug, "github connector validation: create rejected", "reason=missing_slug")
 			return types.ErrMissingSlug
 		}
 		if isEmpty(req.Pem) {
+			v.valog(logger.Debug, "github connector validation: create rejected", "reason=missing_pem")
 			return types.ErrMissingPem
 		}
 		if isEmpty(req.ClientID) {
+			v.valog(logger.Debug, "github connector validation: create rejected", "reason=missing_client_id")
 			return types.ErrMissingClientID
 		}
 		if isEmpty(req.ClientSecret) {
+			v.valog(logger.Debug, "github connector validation: create rejected", "reason=missing_client_secret")
 			return types.ErrMissingClientSecret
 		}
 		if isEmpty(req.WebhookSecret) {
+			v.valog(logger.Debug, "github connector validation: create rejected", "reason=missing_webhook_secret")
 			return types.ErrMissingWebhookSecret
 		}
 	}
@@ -94,6 +116,7 @@ func (v *Validator) validateCreateGithubConnectorRequest(req types.CreateGithubC
 
 func (v *Validator) validateUpdateGithubConnectorRequest(req types.UpdateGithubConnectorRequest) error {
 	if req.InstallationID == "" {
+		v.valog(logger.Debug, "github connector validation: update rejected", "reason=missing_installation_id")
 		return types.ErrMissingInstallationID
 	}
 
@@ -102,6 +125,7 @@ func (v *Validator) validateUpdateGithubConnectorRequest(req types.UpdateGithubC
 
 func (v *Validator) validateDeleteGithubConnectorRequest(req types.DeleteGithubConnectorRequest) error {
 	if req.ID == "" {
+		v.valog(logger.Debug, "github connector validation: delete rejected", "reason=missing_id")
 		return types.ErrMissingID
 	}
 

--- a/api/internal/features/healthcheck/controller/create_healthcheck.go
+++ b/api/internal/features/healthcheck/controller/create_healthcheck.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
@@ -13,22 +15,27 @@ func (c *HealthCheckController) CreateHealthCheck(f fuego.ContextWithBody[types.
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: CreateHealthCheck: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
-		return nil, fuego.BadRequestError{Detail: types.ErrInvalidApplicationID.Error(), Err: types.ErrInvalidApplicationID}
+		c.logger.Log(logger.Debug, "healthcheck: CreateHealthCheck: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Debug, fmt.Sprintf("healthcheck: CreateHealthCheck body: %v", err), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s", orgID, user.ID, body.ApplicationID)
+	c.logger.Log(logger.Info, "healthcheck: CreateHealthCheck", ctxStr)
+
 	if err := c.validator.ValidateRequest(&body); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: CreateHealthCheck validation: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckResponse{
 			Status: "error",
@@ -38,7 +45,7 @@ func (c *HealthCheckController) CreateHealthCheck(f fuego.ContextWithBody[types.
 
 	healthCheck, err := c.service.CreateHealthCheck(user.ID, orgID, &body)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: CreateHealthCheck: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckResponse{
 			Status: "error",
@@ -46,6 +53,7 @@ func (c *HealthCheckController) CreateHealthCheck(f fuego.ContextWithBody[types.
 		}, fuego.HTTPError{Detail: mappedErr.Error(), Status: statusCode}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: CreateHealthCheck ok", fmt.Sprintf("%s health_check_id=%s", ctxStr, healthCheck.ID))
 	return &types.HealthCheckResponse{
 		Status:  "success",
 		Message: "Health check created successfully",

--- a/api/internal/features/healthcheck/controller/delete_healthcheck.go
+++ b/api/internal/features/healthcheck/controller/delete_healthcheck.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
@@ -13,22 +15,28 @@ func (c *HealthCheckController) DeleteHealthCheck(f fuego.ContextNoBody) (*types
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: DeleteHealthCheck: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
+		c.logger.Log(logger.Debug, "healthcheck: DeleteHealthCheck: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	q := r.URL.Query()
 	applicationID := q.Get("application_id")
 	if applicationID == "" {
+		c.logger.Log(logger.Debug, "healthcheck: DeleteHealthCheck: application_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: types.ErrInvalidApplicationID.Error(), Err: types.ErrInvalidApplicationID}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s", orgID, user.ID, applicationID)
+	c.logger.Log(logger.Info, "healthcheck: DeleteHealthCheck", ctxStr)
+
 	if err := c.service.DeleteHealthCheck(applicationID, orgID); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: DeleteHealthCheck: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckMessageResponse{
 			Status: "error",
@@ -36,6 +44,7 @@ func (c *HealthCheckController) DeleteHealthCheck(f fuego.ContextNoBody) (*types
 		}, fuego.HTTPError{Detail: mappedErr.Error(), Status: statusCode}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: DeleteHealthCheck ok", ctxStr)
 	return &types.HealthCheckMessageResponse{
 		Status:  "success",
 		Message: "Health check deleted successfully",

--- a/api/internal/features/healthcheck/controller/get_healthcheck.go
+++ b/api/internal/features/healthcheck/controller/get_healthcheck.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,26 +16,33 @@ func (c *HealthCheckController) GetHealthCheck(f fuego.ContextNoBody) (*types.He
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheck: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheck: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	q := r.URL.Query()
 	applicationID := q.Get("application_id")
 	if applicationID == "" {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheck: application_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: types.ErrInvalidApplicationID.Error(), Err: types.ErrInvalidApplicationID}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s", orgID, user.ID, applicationID)
+	c.logger.Log(logger.Info, "healthcheck: GetHealthCheck", ctxStr)
+
 	healthCheck, err := c.service.GetHealthCheck(applicationID, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: GetHealthCheck: %v", err), ctxStr)
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: GetHealthCheck ok", fmt.Sprintf("%s has_data=%t", ctxStr, healthCheck != nil))
 	// Return success with null data if health check doesn't exist
 	return &types.HealthCheckResponse{
 		Status:  "success",

--- a/api/internal/features/healthcheck/controller/get_results.go
+++ b/api/internal/features/healthcheck/controller/get_results.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -16,17 +17,20 @@ func (c *HealthCheckController) GetHealthCheckResults(f fuego.ContextNoBody) (*t
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheckResults: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheckResults: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	q := r.URL.Query()
 	applicationID := q.Get("application_id")
 	if applicationID == "" {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheckResults: application_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: types.ErrInvalidApplicationID.Error(), Err: types.ErrInvalidApplicationID}
 	}
 
@@ -40,9 +44,12 @@ func (c *HealthCheckController) GetHealthCheckResults(f fuego.ContextNoBody) (*t
 	startTime := q.Get("start_time")
 	endTime := q.Get("end_time")
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s limit=%d", orgID, user.ID, applicationID, limit)
+	c.logger.Log(logger.Info, "healthcheck: GetHealthCheckResults", ctxStr)
+
 	results, err := c.service.GetHealthCheckResults(applicationID, orgID, limit, startTime, endTime)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: GetHealthCheckResults: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		if statusCode == http.StatusNotFound {
 			// Plain HTTPError with Status set — reliable with Fuego's castHTTPError / StatusCode().
@@ -56,6 +63,7 @@ func (c *HealthCheckController) GetHealthCheckResults(f fuego.ContextNoBody) (*t
 		return nil, fuego.HTTPError{Detail: mappedErr.Error(), Status: statusCode}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: GetHealthCheckResults ok", fmt.Sprintf("%s count=%d", ctxStr, len(results)))
 	return &types.HealthCheckResultsResponse{
 		Status:  "success",
 		Message: "Health check results fetched successfully",

--- a/api/internal/features/healthcheck/controller/get_stats.go
+++ b/api/internal/features/healthcheck/controller/get_stats.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -16,17 +17,20 @@ func (c *HealthCheckController) GetHealthCheckStats(f fuego.ContextNoBody) (*typ
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheckStats: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheckStats: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	q := r.URL.Query()
 	applicationID := q.Get("application_id")
 	if applicationID == "" {
+		c.logger.Log(logger.Debug, "healthcheck: GetHealthCheckStats: application_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: types.ErrInvalidApplicationID.Error(), Err: types.ErrInvalidApplicationID}
 	}
 
@@ -35,9 +39,12 @@ func (c *HealthCheckController) GetHealthCheckStats(f fuego.ContextNoBody) (*typ
 		period = "24h"
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s period=%s", orgID, user.ID, applicationID, period)
+	c.logger.Log(logger.Info, "healthcheck: GetHealthCheckStats", ctxStr)
+
 	stats, err := c.service.GetHealthCheckStats(applicationID, orgID, period)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: GetHealthCheckStats: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		if statusCode == http.StatusNotFound {
 			return nil, fuego.HTTPError{
@@ -50,6 +57,7 @@ func (c *HealthCheckController) GetHealthCheckStats(f fuego.ContextNoBody) (*typ
 		return nil, fuego.HTTPError{Detail: mappedErr.Error(), Status: statusCode}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: GetHealthCheckStats ok", ctxStr)
 	data := mapStatsResponse(stats)
 
 	return &types.HealthCheckStatsResponse{

--- a/api/internal/features/healthcheck/controller/init.go
+++ b/api/internal/features/healthcheck/controller/init.go
@@ -23,11 +23,11 @@ func NewHealthCheckController(
 	ctx context.Context,
 	l logger.Logger,
 ) *HealthCheckController {
-	healthCheckStorage := storage.HealthCheckStorage{DB: store.DB, Ctx: ctx}
+	healthCheckStorage := storage.HealthCheckStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	healthCheckService := service.NewHealthCheckService(store, ctx, l, &healthCheckStorage)
 	return &HealthCheckController{
 		store:     store,
-		validator: validation.NewValidator(&healthCheckStorage),
+		validator: validation.NewValidatorWithLogger(&healthCheckStorage, &l),
 		service:   healthCheckService,
 		ctx:       ctx,
 		logger:    l,

--- a/api/internal/features/healthcheck/controller/toggle_healthcheck.go
+++ b/api/internal/features/healthcheck/controller/toggle_healthcheck.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
@@ -13,22 +15,27 @@ func (c *HealthCheckController) ToggleHealthCheck(f fuego.ContextWithBody[types.
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: ToggleHealthCheck: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
+		c.logger.Log(logger.Debug, "healthcheck: ToggleHealthCheck: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Debug, fmt.Sprintf("healthcheck: ToggleHealthCheck body: %v", err), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s enabled=%t", orgID, user.ID, body.ApplicationID, body.Enabled)
+	c.logger.Log(logger.Info, "healthcheck: ToggleHealthCheck", ctxStr)
+
 	if err := c.validator.ValidateRequest(&body); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: ToggleHealthCheck validation: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckResponse{
 			Status: "error",
@@ -38,7 +45,7 @@ func (c *HealthCheckController) ToggleHealthCheck(f fuego.ContextWithBody[types.
 
 	healthCheck, err := c.service.ToggleHealthCheck(orgID, &body)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: ToggleHealthCheck: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckResponse{
 			Status: "error",
@@ -46,6 +53,7 @@ func (c *HealthCheckController) ToggleHealthCheck(f fuego.ContextWithBody[types.
 		}, fuego.HTTPError{Detail: mappedErr.Error(), Status: statusCode}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: ToggleHealthCheck ok", fmt.Sprintf("%s health_check_id=%s", ctxStr, healthCheck.ID))
 	return &types.HealthCheckResponse{
 		Status:  "success",
 		Message: "Health check toggled successfully",

--- a/api/internal/features/healthcheck/controller/update_healthcheck.go
+++ b/api/internal/features/healthcheck/controller/update_healthcheck.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
@@ -13,22 +15,27 @@ func (c *HealthCheckController) UpdateHealthCheck(f fuego.ContextWithBody[types.
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "healthcheck: UpdateHealthCheck: authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == (uuid.UUID{}) {
+		c.logger.Log(logger.Debug, "healthcheck: UpdateHealthCheck: organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Debug, fmt.Sprintf("healthcheck: UpdateHealthCheck body: %v", err), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s application_id=%s", orgID, user.ID, body.ApplicationID)
+	c.logger.Log(logger.Info, "healthcheck: UpdateHealthCheck", ctxStr)
+
 	if err := c.validator.ValidateRequest(&body); err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: UpdateHealthCheck validation: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckResponse{
 			Status: "error",
@@ -38,7 +45,7 @@ func (c *HealthCheckController) UpdateHealthCheck(f fuego.ContextWithBody[types.
 
 	healthCheck, err := c.service.UpdateHealthCheck(orgID, &body)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("healthcheck: UpdateHealthCheck: %v", err), ctxStr)
 		statusCode, mappedErr := mapHealthCheckError(err)
 		return &types.HealthCheckResponse{
 			Status: "error",
@@ -46,6 +53,7 @@ func (c *HealthCheckController) UpdateHealthCheck(f fuego.ContextWithBody[types.
 		}, fuego.HTTPError{Detail: mappedErr.Error(), Status: statusCode}
 	}
 
+	c.logger.Log(logger.Info, "healthcheck: UpdateHealthCheck ok", fmt.Sprintf("%s health_check_id=%s", ctxStr, healthCheck.ID))
 	return &types.HealthCheckResponse{
 		Status:  "success",
 		Message: "Health check updated successfully",

--- a/api/internal/features/healthcheck/service/create_healthcheck.go
+++ b/api/internal/features/healthcheck/service/create_healthcheck.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,7 +11,7 @@ import (
 )
 
 func (s *HealthCheckService) CreateHealthCheck(userID uuid.UUID, organizationID uuid.UUID, req *types.CreateHealthCheckRequest) (*shared_types.HealthCheck, error) {
-	s.logger.Log(logger.Info, "creating health check", "application_id: "+req.ApplicationID)
+	s.logger.Log(logger.Info, "healthcheck service: CreateHealthCheck", fmt.Sprintf("application_id=%s org_id=%s", req.ApplicationID, organizationID))
 
 	applicationID, err := uuid.Parse(req.ApplicationID)
 	if err != nil {
@@ -85,7 +86,7 @@ func (s *HealthCheckService) CreateHealthCheck(userID uuid.UUID, organizationID 
 	}
 
 	if err := s.storage.CreateHealthCheck(healthCheck); err != nil {
-		s.logger.Log(logger.Error, "failed to create health check", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: CreateHealthCheck: %v", err), fmt.Sprintf("application_id=%s org_id=%s", req.ApplicationID, organizationID))
 		return nil, err
 	}
 

--- a/api/internal/features/healthcheck/service/delete_healthcheck.go
+++ b/api/internal/features/healthcheck/service/delete_healthcheck.go
@@ -1,13 +1,15 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (s *HealthCheckService) DeleteHealthCheck(applicationIDStr string, organizationID uuid.UUID) error {
-	s.logger.Log(logger.Info, "deleting health check", "application_id: "+applicationIDStr)
+	s.logger.Log(logger.Info, "healthcheck service: DeleteHealthCheck", fmt.Sprintf("application_id=%s org_id=%s", applicationIDStr, organizationID))
 
 	applicationID, err := uuid.Parse(applicationIDStr)
 	if err != nil {
@@ -15,7 +17,7 @@ func (s *HealthCheckService) DeleteHealthCheck(applicationIDStr string, organiza
 	}
 
 	if err := s.storage.DeleteHealthCheck(applicationID, organizationID); err != nil {
-		s.logger.Log(logger.Error, "failed to delete health check", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: DeleteHealthCheck: %v", err), fmt.Sprintf("application_id=%s org_id=%s", applicationIDStr, organizationID))
 		return err
 	}
 

--- a/api/internal/features/healthcheck/service/execute_check.go
+++ b/api/internal/features/healthcheck/service/execute_check.go
@@ -67,8 +67,9 @@ func (s *HealthCheckService) ExecuteHealthCheck(healthCheck *shared_types.Health
 
 	appProvider := s.getAppProvider()
 	application, err := appProvider.GetApplicationById(healthCheck.ApplicationID.String(), healthCheck.OrganizationID)
+	execCtx := fmt.Sprintf("health_check_id=%s application_id=%s org_id=%s", healthCheck.ID, healthCheck.ApplicationID, healthCheck.OrganizationID)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get application for health check", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: ExecuteHealthCheck get application: %v", err), execCtx)
 		return nil, fmt.Errorf("failed to get application: %w", err)
 	}
 
@@ -87,7 +88,7 @@ func (s *HealthCheckService) ExecuteHealthCheck(healthCheck *shared_types.Health
 	}
 
 	if reqErr != nil {
-		s.logger.Log(logger.Error, "failed to create HTTP request", reqErr.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: ExecuteHealthCheck new request: %v", reqErr), execCtx)
 		result := &shared_types.HealthCheckResult{
 			ID:            uuid.New(),
 			HealthCheckID: healthCheck.ID,
@@ -161,8 +162,9 @@ func (s *HealthCheckService) ExecuteHealthCheck(healthCheck *shared_types.Health
 
 // ProcessHealthCheckResult processes a health check result and updates the health check status
 func (s *HealthCheckService) ProcessHealthCheckResult(healthCheck *shared_types.HealthCheck, result *shared_types.HealthCheckResult) error {
+	procCtx := fmt.Sprintf("health_check_id=%s result_id=%s status=%s", healthCheck.ID, result.ID, result.Status)
 	if err := s.storage.AddHealthCheckResult(result); err != nil {
-		s.logger.Log(logger.Error, "failed to save health check result", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: ProcessHealthCheckResult save result: %v", err), procCtx)
 		return err
 	}
 
@@ -180,7 +182,7 @@ func (s *HealthCheckService) ProcessHealthCheckResult(healthCheck *shared_types.
 	}
 
 	if err := s.storage.UpdateHealthCheckStatus(healthCheck.ID, consecutiveFails, result.CheckedAt); err != nil {
-		s.logger.Log(logger.Error, "failed to update health check status", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: ProcessHealthCheckResult update status: %v", err), fmt.Sprintf("health_check_id=%s consecutive_fails=%d", healthCheck.ID, consecutiveFails))
 		return err
 	}
 

--- a/api/internal/features/healthcheck/service/get_due_checks.go
+++ b/api/internal/features/healthcheck/service/get_due_checks.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
@@ -8,7 +10,7 @@ import (
 func (s *HealthCheckService) GetDueHealthChecks() ([]*shared_types.HealthCheck, error) {
 	checks, err := s.storage.GetDueHealthChecks()
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get due health checks", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: GetDueHealthChecks: %v", err), "")
 		return nil, err
 	}
 	return checks, nil

--- a/api/internal/features/healthcheck/service/get_healthcheck.go
+++ b/api/internal/features/healthcheck/service/get_healthcheck.go
@@ -3,6 +3,7 @@ package service
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
@@ -22,7 +23,7 @@ func (s *HealthCheckService) GetHealthCheck(applicationIDStr string, organizatio
 			// Return nil, nil when health check is not found (not an error)
 			return nil, nil
 		}
-		s.logger.Log(logger.Error, "failed to get health check", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: GetHealthCheck: %v", err), fmt.Sprintf("application_id=%s org_id=%s", applicationIDStr, organizationID))
 		return nil, types.ErrHealthCheckNotFound
 	}
 

--- a/api/internal/features/healthcheck/service/get_results.go
+++ b/api/internal/features/healthcheck/service/get_results.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,7 +41,7 @@ func (s *HealthCheckService) GetHealthCheckResults(applicationIDStr string, orga
 
 	results, err := s.storage.GetHealthCheckResults(healthCheck.ID, limit, startTime, endTime)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get health check results", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: GetHealthCheckResults: %v", err), fmt.Sprintf("application_id=%s org_id=%s health_check_id=%s", applicationIDStr, organizationID, healthCheck.ID))
 		return nil, err
 	}
 

--- a/api/internal/features/healthcheck/service/get_stats.go
+++ b/api/internal/features/healthcheck/service/get_stats.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -52,7 +53,7 @@ func (s *HealthCheckService) GetHealthCheckStats(applicationIDStr string, organi
 
 	stats, err := s.storage.GetHealthCheckStats(healthCheck.ID, startTime, endTime)
 	if err != nil {
-		s.logger.Log(logger.Error, "failed to get health check stats", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: GetHealthCheckStats: %v", err), fmt.Sprintf("application_id=%s org_id=%s health_check_id=%s", applicationIDStr, organizationID, healthCheck.ID))
 		return nil, err
 	}
 

--- a/api/internal/features/healthcheck/service/toggle_healthcheck.go
+++ b/api/internal/features/healthcheck/service/toggle_healthcheck.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *HealthCheckService) ToggleHealthCheck(organizationID uuid.UUID, req *types.ToggleHealthCheckRequest) (*shared_types.HealthCheck, error) {
-	s.logger.Log(logger.Info, "toggling health check", fmt.Sprintf("application_id: %s, enabled: %t", req.ApplicationID, req.Enabled))
+	s.logger.Log(logger.Info, "healthcheck service: ToggleHealthCheck", fmt.Sprintf("application_id=%s org_id=%s enabled=%t", req.ApplicationID, organizationID, req.Enabled))
 
 	applicationID, err := uuid.Parse(req.ApplicationID)
 	if err != nil {
@@ -18,7 +18,7 @@ func (s *HealthCheckService) ToggleHealthCheck(organizationID uuid.UUID, req *ty
 	}
 
 	if err := s.storage.ToggleHealthCheck(applicationID, organizationID, req.Enabled); err != nil {
-		s.logger.Log(logger.Error, "failed to toggle health check", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: ToggleHealthCheck: %v", err), fmt.Sprintf("application_id=%s org_id=%s", req.ApplicationID, organizationID))
 		return nil, err
 	}
 

--- a/api/internal/features/healthcheck/service/update_healthcheck.go
+++ b/api/internal/features/healthcheck/service/update_healthcheck.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,7 +11,7 @@ import (
 )
 
 func (s *HealthCheckService) UpdateHealthCheck(organizationID uuid.UUID, req *types.UpdateHealthCheckRequest) (*shared_types.HealthCheck, error) {
-	s.logger.Log(logger.Info, "updating health check", "application_id: "+req.ApplicationID)
+	s.logger.Log(logger.Info, "healthcheck service: UpdateHealthCheck", fmt.Sprintf("application_id=%s org_id=%s", req.ApplicationID, organizationID))
 
 	applicationID, err := uuid.Parse(req.ApplicationID)
 	if err != nil {
@@ -66,7 +67,7 @@ func (s *HealthCheckService) UpdateHealthCheck(organizationID uuid.UUID, req *ty
 	healthCheck.UpdatedAt = time.Now()
 
 	if err := s.storage.UpdateHealthCheck(healthCheck); err != nil {
-		s.logger.Log(logger.Error, "failed to update health check", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("healthcheck service: UpdateHealthCheck: %v", err), fmt.Sprintf("application_id=%s org_id=%s", req.ApplicationID, organizationID))
 		return nil, err
 	}
 

--- a/api/internal/features/healthcheck/storage/init.go
+++ b/api/internal/features/healthcheck/storage/init.go
@@ -2,18 +2,22 @@ package storage
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
 type HealthCheckStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 type HealthCheckRepository interface {
@@ -32,6 +36,13 @@ type HealthCheckRepository interface {
 	UpdateHealthCheckStatus(healthCheckID uuid.UUID, consecutiveFails int, lastCheckedAt time.Time) error
 }
 
+func (s *HealthCheckStorage) storageLog(sev logger.Severity, msg, data string) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Log(sev, msg, data)
+}
+
 type HealthCheckStats struct {
 	TotalChecks      int     `json:"total_checks"`
 	SuccessfulChecks int     `json:"successful_checks"`
@@ -41,11 +52,18 @@ type HealthCheckStats struct {
 }
 
 func (s *HealthCheckStorage) CreateHealthCheck(healthCheck *shared_types.HealthCheck) error {
+	ctxStr := fmt.Sprintf("health_check_id=%s application_id=%s org_id=%s", healthCheck.ID, healthCheck.ApplicationID, healthCheck.OrganizationID)
+	s.storageLog(logger.Debug, "storage: CreateHealthCheck", ctxStr)
 	_, err := s.DB.NewInsert().Model(healthCheck).Exec(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CreateHealthCheck: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *HealthCheckStorage) GetHealthCheckByApplicationID(applicationID uuid.UUID, organizationID uuid.UUID) (*shared_types.HealthCheck, error) {
+	ctxStr := fmt.Sprintf("application_id=%s org_id=%s", applicationID, organizationID)
+	s.storageLog(logger.Debug, "storage: GetHealthCheckByApplicationID", ctxStr)
 	var healthCheck shared_types.HealthCheck
 	err := s.DB.NewSelect().
 		Model(&healthCheck).
@@ -53,12 +71,20 @@ func (s *HealthCheckStorage) GetHealthCheckByApplicationID(applicationID uuid.UU
 		Scan(s.Ctx)
 
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetHealthCheckByApplicationID not found", ctxStr)
+		} else {
+			s.storageLog(logger.Error, fmt.Sprintf("storage: GetHealthCheckByApplicationID: %v", err), ctxStr)
+		}
 		return nil, err
 	}
+	s.storageLog(logger.Debug, "storage: GetHealthCheckByApplicationID ok", fmt.Sprintf("%s id=%s", ctxStr, healthCheck.ID))
 	return &healthCheck, nil
 }
 
 func (s *HealthCheckStorage) GetHealthCheckByID(id uuid.UUID, organizationID uuid.UUID) (*shared_types.HealthCheck, error) {
+	ctxStr := fmt.Sprintf("health_check_id=%s org_id=%s", id, organizationID)
+	s.storageLog(logger.Debug, "storage: GetHealthCheckByID", ctxStr)
 	var healthCheck shared_types.HealthCheck
 	err := s.DB.NewSelect().
 		Model(&healthCheck).
@@ -66,55 +92,81 @@ func (s *HealthCheckStorage) GetHealthCheckByID(id uuid.UUID, organizationID uui
 		Scan(s.Ctx)
 
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			s.storageLog(logger.Debug, "storage: GetHealthCheckByID not found", ctxStr)
+		} else {
+			s.storageLog(logger.Error, fmt.Sprintf("storage: GetHealthCheckByID: %v", err), ctxStr)
+		}
 		return nil, err
 	}
 	return &healthCheck, nil
 }
 
 func (s *HealthCheckStorage) UpdateHealthCheck(healthCheck *shared_types.HealthCheck) error {
+	ctxStr := fmt.Sprintf("health_check_id=%s application_id=%s", healthCheck.ID, healthCheck.ApplicationID)
+	s.storageLog(logger.Debug, "storage: UpdateHealthCheck", ctxStr)
 	_, err := s.DB.NewUpdate().
 		Model(healthCheck).
 		OmitZero().
 		Set("updated_at = CURRENT_TIMESTAMP").
 		WherePK().
 		Exec(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateHealthCheck: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *HealthCheckStorage) DeleteHealthCheck(applicationID uuid.UUID, organizationID uuid.UUID) error {
+	ctxStr := fmt.Sprintf("application_id=%s org_id=%s", applicationID, organizationID)
+	s.storageLog(logger.Debug, "storage: DeleteHealthCheck", ctxStr)
 	result, err := s.DB.NewDelete().
 		Model((*shared_types.HealthCheck)(nil)).
 		Where("application_id = ? AND organization_id = ?", applicationID, organizationID).
 		Exec(s.Ctx)
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: DeleteHealthCheck: %v", err), ctxStr)
 		return err
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
+		s.storageLog(logger.Debug, "storage: DeleteHealthCheck no rows", ctxStr)
 		return fmt.Errorf("health check not found")
 	}
 	return nil
 }
 
 func (s *HealthCheckStorage) ToggleHealthCheck(applicationID uuid.UUID, organizationID uuid.UUID, enabled bool) error {
+	ctxStr := fmt.Sprintf("application_id=%s org_id=%s enabled=%t", applicationID, organizationID, enabled)
+	s.storageLog(logger.Debug, "storage: ToggleHealthCheck", ctxStr)
 	_, err := s.DB.NewUpdate().
 		Model((*shared_types.HealthCheck)(nil)).
 		Set("enabled = ?", enabled).
 		Set("updated_at = CURRENT_TIMESTAMP").
 		Where("application_id = ? AND organization_id = ?", applicationID, organizationID).
 		Exec(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: ToggleHealthCheck: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *HealthCheckStorage) GetEnabledHealthChecks() ([]*shared_types.HealthCheck, error) {
+	s.storageLog(logger.Debug, "storage: GetEnabledHealthChecks", "")
 	var healthChecks []*shared_types.HealthCheck
 	err := s.DB.NewSelect().
 		Model(&healthChecks).
 		Where("enabled = ?", true).
 		Scan(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetEnabledHealthChecks: %v", err), "")
+		return healthChecks, err
+	}
+	s.storageLog(logger.Debug, "storage: GetEnabledHealthChecks ok", fmt.Sprintf("count=%d", len(healthChecks)))
 	return healthChecks, err
 }
 
 func (s *HealthCheckStorage) GetDueHealthChecks() ([]*shared_types.HealthCheck, error) {
+	s.storageLog(logger.Debug, "storage: GetDueHealthChecks", "")
 	var healthChecks []*shared_types.HealthCheck
 	now := time.Now()
 
@@ -124,6 +176,7 @@ func (s *HealthCheckStorage) GetDueHealthChecks() ([]*shared_types.HealthCheck, 
 		Scan(s.Ctx)
 
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetDueHealthChecks select: %v", err), "")
 		return nil, err
 	}
 
@@ -140,15 +193,23 @@ func (s *HealthCheckStorage) GetDueHealthChecks() ([]*shared_types.HealthCheck, 
 		}
 	}
 
+	s.storageLog(logger.Debug, "storage: GetDueHealthChecks ok", fmt.Sprintf("enabled=%d due=%d", len(healthChecks), len(dueChecks)))
 	return dueChecks, nil
 }
 
 func (s *HealthCheckStorage) AddHealthCheckResult(result *shared_types.HealthCheckResult) error {
+	ctxStr := fmt.Sprintf("health_check_id=%s result_id=%s status=%s", result.HealthCheckID, result.ID, result.Status)
+	s.storageLog(logger.Debug, "storage: AddHealthCheckResult", ctxStr)
 	_, err := s.DB.NewInsert().Model(result).Exec(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: AddHealthCheckResult: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *HealthCheckStorage) GetHealthCheckResults(healthCheckID uuid.UUID, limit int, startTime, endTime *time.Time) ([]*shared_types.HealthCheckResult, error) {
+	ctxStr := fmt.Sprintf("health_check_id=%s limit=%d", healthCheckID, limit)
+	s.storageLog(logger.Debug, "storage: GetHealthCheckResults", ctxStr)
 	var results []*shared_types.HealthCheckResult
 	query := s.DB.NewSelect().
 		Model(&results).
@@ -168,10 +229,17 @@ func (s *HealthCheckStorage) GetHealthCheckResults(healthCheckID uuid.UUID, limi
 	}
 
 	err := query.Scan(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetHealthCheckResults: %v", err), ctxStr)
+		return results, err
+	}
+	s.storageLog(logger.Debug, "storage: GetHealthCheckResults ok", fmt.Sprintf("%s count=%d", ctxStr, len(results)))
 	return results, err
 }
 
 func (s *HealthCheckStorage) GetHealthCheckStats(healthCheckID uuid.UUID, startTime, endTime time.Time) (*HealthCheckStats, error) {
+	ctxStr := fmt.Sprintf("health_check_id=%s", healthCheckID)
+	s.storageLog(logger.Debug, "storage: GetHealthCheckStats", ctxStr)
 	var stats HealthCheckStats
 
 	// Get total checks count
@@ -183,6 +251,7 @@ func (s *HealthCheckStorage) GetHealthCheckStats(healthCheckID uuid.UUID, startT
 		Count(s.Ctx)
 
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetHealthCheckStats total count: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -202,6 +271,7 @@ func (s *HealthCheckStorage) GetHealthCheckStats(healthCheckID uuid.UUID, startT
 		Count(s.Ctx)
 
 	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: GetHealthCheckStats success count: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -232,6 +302,8 @@ func (s *HealthCheckStorage) GetHealthCheckStats(healthCheckID uuid.UUID, startT
 }
 
 func (s *HealthCheckStorage) CleanupOldResults(retentionDays int) error {
+	ctxStr := fmt.Sprintf("retention_days=%d", retentionDays)
+	s.storageLog(logger.Debug, "storage: CleanupOldResults", ctxStr)
 	cutoffTime := time.Now().AddDate(0, 0, -retentionDays)
 
 	_, err := s.DB.NewDelete().
@@ -239,10 +311,15 @@ func (s *HealthCheckStorage) CleanupOldResults(retentionDays int) error {
 		Where("checked_at < ?", cutoffTime).
 		Exec(s.Ctx)
 
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: CleanupOldResults: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *HealthCheckStorage) UpdateHealthCheckStatus(healthCheckID uuid.UUID, consecutiveFails int, lastCheckedAt time.Time) error {
+	ctxStr := fmt.Sprintf("health_check_id=%s consecutive_fails=%d", healthCheckID, consecutiveFails)
+	s.storageLog(logger.Debug, "storage: UpdateHealthCheckStatus", ctxStr)
 	_, err := s.DB.NewUpdate().
 		Model((*shared_types.HealthCheck)(nil)).
 		Set("consecutive_fails = ?", consecutiveFails).
@@ -250,5 +327,8 @@ func (s *HealthCheckStorage) UpdateHealthCheckStatus(healthCheckID uuid.UUID, co
 		Set("updated_at = CURRENT_TIMESTAMP").
 		Where("id = ?", healthCheckID).
 		Exec(s.Ctx)
+	if err != nil {
+		s.storageLog(logger.Error, fmt.Sprintf("storage: UpdateHealthCheckStatus: %v", err), ctxStr)
+	}
 	return err
 }

--- a/api/internal/features/healthcheck/validation/validator.go
+++ b/api/internal/features/healthcheck/validation/validator.go
@@ -1,21 +1,37 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/storage"
 	"github.com/nixopus/nixopus/api/internal/features/healthcheck/types"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 type Validator struct {
 	storage storage.HealthCheckRepository
+	Logger  *logger.Logger // optional; nil disables validation logs
 }
 
 func NewValidator(repository storage.HealthCheckRepository) *Validator {
+	return NewValidatorWithLogger(repository, nil)
+}
+
+// NewValidatorWithLogger is like NewValidator but attaches a logger for Debug detail on rule failures.
+func NewValidatorWithLogger(repository storage.HealthCheckRepository, log *logger.Logger) *Validator {
 	return &Validator{
 		storage: repository,
+		Logger:  log,
 	}
+}
+
+func (v *Validator) valog(sev logger.Severity, msg, data string) {
+	if v == nil || v.Logger == nil {
+		return
+	}
+	v.Logger.Log(sev, msg, data)
 }
 
 func (v *Validator) ValidateRequest(req interface{}) error {
@@ -31,16 +47,19 @@ func (v *Validator) ValidateRequest(req interface{}) error {
 	case *types.GetHealthCheckStatsRequest:
 		return v.validateGetHealthCheckStatsRequest(*r)
 	default:
+		v.valog(logger.Debug, "healthcheck validation: invalid request type", fmt.Sprintf("%T", req))
 		return types.ErrInvalidRequestType
 	}
 }
 
 func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheckRequest) error {
 	if req.ApplicationID == "" {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_application_id")
 		return types.ErrInvalidApplicationID
 	}
 
 	if _, err := uuid.Parse(req.ApplicationID); err != nil {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_application_id_parse")
 		return types.ErrInvalidApplicationID
 	}
 
@@ -50,6 +69,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 
 	// Accept either a path (starting with "/") or a full URL (starting with "http://" or "https://")
 	if !strings.HasPrefix(req.Endpoint, "/") && !strings.HasPrefix(req.Endpoint, "http://") && !strings.HasPrefix(req.Endpoint, "https://") {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_endpoint")
 		return types.ErrInvalidEndpoint
 	}
 
@@ -59,6 +79,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 
 	validMethods := map[string]bool{"GET": true, "POST": true, "HEAD": true}
 	if !validMethods[strings.ToUpper(req.Method)] {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_method")
 		return types.ErrInvalidMethod
 	}
 
@@ -66,6 +87,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 		req.TimeoutSeconds = 30
 	}
 	if req.TimeoutSeconds < 5 || req.TimeoutSeconds > 120 {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_timeout")
 		return types.ErrInvalidTimeout
 	}
 
@@ -73,6 +95,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 		req.IntervalSeconds = 60
 	}
 	if req.IntervalSeconds < 30 || req.IntervalSeconds > 3600 {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_interval")
 		return types.ErrInvalidInterval
 	}
 
@@ -80,6 +103,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 		req.FailureThreshold = 3
 	}
 	if req.FailureThreshold < 1 || req.FailureThreshold > 10 {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_threshold_failure")
 		return types.ErrInvalidThreshold
 	}
 
@@ -87,6 +111,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 		req.SuccessThreshold = 1
 	}
 	if req.SuccessThreshold < 1 || req.SuccessThreshold > 10 {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_threshold_success")
 		return types.ErrInvalidThreshold
 	}
 
@@ -94,6 +119,7 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 		req.RetentionDays = 30
 	}
 	if req.RetentionDays < 1 || req.RetentionDays > 365 {
+		v.valog(logger.Debug, "healthcheck validation: create rejected", "reason=invalid_retention_days")
 		return types.ErrInvalidRetentionDays
 	}
 
@@ -106,42 +132,51 @@ func (v *Validator) validateCreateHealthCheckRequest(req types.CreateHealthCheck
 
 func (v *Validator) validateUpdateHealthCheckRequest(req types.UpdateHealthCheckRequest) error {
 	if req.ApplicationID == "" {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_application_id")
 		return types.ErrInvalidApplicationID
 	}
 
 	if _, err := uuid.Parse(req.ApplicationID); err != nil {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_application_id_parse")
 		return types.ErrInvalidApplicationID
 	}
 
 	// Accept either a path (starting with "/") or a full URL (starting with "http://" or "https://")
 	if req.Endpoint != "" && !strings.HasPrefix(req.Endpoint, "/") && !strings.HasPrefix(req.Endpoint, "http://") && !strings.HasPrefix(req.Endpoint, "https://") {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_endpoint")
 		return types.ErrInvalidEndpoint
 	}
 
 	if req.Method != "" {
 		validMethods := map[string]bool{"GET": true, "POST": true, "HEAD": true}
 		if !validMethods[strings.ToUpper(req.Method)] {
+			v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_method")
 			return types.ErrInvalidMethod
 		}
 	}
 
 	if req.TimeoutSeconds != 0 && (req.TimeoutSeconds < 5 || req.TimeoutSeconds > 120) {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_timeout")
 		return types.ErrInvalidTimeout
 	}
 
 	if req.IntervalSeconds != 0 && (req.IntervalSeconds < 30 || req.IntervalSeconds > 3600) {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_interval")
 		return types.ErrInvalidInterval
 	}
 
 	if req.FailureThreshold != 0 && (req.FailureThreshold < 1 || req.FailureThreshold > 10) {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_threshold_failure")
 		return types.ErrInvalidThreshold
 	}
 
 	if req.SuccessThreshold != 0 && (req.SuccessThreshold < 1 || req.SuccessThreshold > 10) {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_threshold_success")
 		return types.ErrInvalidThreshold
 	}
 
 	if req.RetentionDays != 0 && (req.RetentionDays < 1 || req.RetentionDays > 365) {
+		v.valog(logger.Debug, "healthcheck validation: update rejected", "reason=invalid_retention_days")
 		return types.ErrInvalidRetentionDays
 	}
 
@@ -150,10 +185,12 @@ func (v *Validator) validateUpdateHealthCheckRequest(req types.UpdateHealthCheck
 
 func (v *Validator) validateToggleHealthCheckRequest(req types.ToggleHealthCheckRequest) error {
 	if req.ApplicationID == "" {
+		v.valog(logger.Debug, "healthcheck validation: toggle rejected", "reason=invalid_application_id")
 		return types.ErrInvalidApplicationID
 	}
 
 	if _, err := uuid.Parse(req.ApplicationID); err != nil {
+		v.valog(logger.Debug, "healthcheck validation: toggle rejected", "reason=invalid_application_id_parse")
 		return types.ErrInvalidApplicationID
 	}
 
@@ -162,10 +199,12 @@ func (v *Validator) validateToggleHealthCheckRequest(req types.ToggleHealthCheck
 
 func (v *Validator) validateGetHealthCheckResultsRequest(req types.GetHealthCheckResultsRequest) error {
 	if req.ApplicationID == "" {
+		v.valog(logger.Debug, "healthcheck validation: results rejected", "reason=invalid_application_id")
 		return types.ErrInvalidApplicationID
 	}
 
 	if _, err := uuid.Parse(req.ApplicationID); err != nil {
+		v.valog(logger.Debug, "healthcheck validation: results rejected", "reason=invalid_application_id_parse")
 		return types.ErrInvalidApplicationID
 	}
 
@@ -178,10 +217,12 @@ func (v *Validator) validateGetHealthCheckResultsRequest(req types.GetHealthChec
 
 func (v *Validator) validateGetHealthCheckStatsRequest(req types.GetHealthCheckStatsRequest) error {
 	if req.ApplicationID == "" {
+		v.valog(logger.Debug, "healthcheck validation: stats rejected", "reason=invalid_application_id")
 		return types.ErrInvalidApplicationID
 	}
 
 	if _, err := uuid.Parse(req.ApplicationID); err != nil {
+		v.valog(logger.Debug, "healthcheck validation: stats rejected", "reason=invalid_application_id_parse")
 		return types.ErrInvalidApplicationID
 	}
 

--- a/api/internal/features/machine/controller/backup.go
+++ b/api/internal/features/machine/controller/backup.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,17 +19,24 @@ func (c *MachineController) TriggerBackup(f fuego.ContextNoBody) (*types.Trigger
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("TriggerBackup", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("TriggerBackup", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	serverID := parseServerID(r)
 	resp, err := c.backupService.TriggerBackup(r.Context(), user.ID, orgID, serverID)
 	if err != nil {
+		data := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+		if serverID != nil {
+			data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: TriggerBackup: %v", err), data)
 		return nil, mapBackupError(err)
 	}
 
@@ -40,11 +48,13 @@ func (c *MachineController) ListBackups(f fuego.ContextNoBody) (*types.BackupLis
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("ListBackups", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("ListBackups", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -77,7 +87,7 @@ func (c *MachineController) ListBackups(f fuego.ContextNoBody) (*types.BackupLis
 
 	response, err := c.backupService.ListBackups(r.Context(), orgID, params)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: ListBackups: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Detail: "failed to list backups", Status: http.StatusInternalServerError}
 	}
 
@@ -89,18 +99,24 @@ func (c *MachineController) GetBackupSchedule(f fuego.ContextNoBody) (*types.Bac
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("GetBackupSchedule", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetBackupSchedule", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	serverID := parseServerID(r)
 	response, err := c.backupService.GetBackupSchedule(r.Context(), orgID, serverID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		data := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+		if serverID != nil {
+			data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: GetBackupSchedule: %v", err), data)
 		return nil, fuego.HTTPError{Detail: "failed to get backup schedule", Status: http.StatusInternalServerError}
 	}
 
@@ -112,23 +128,30 @@ func (c *MachineController) UpdateBackupSchedule(f fuego.ContextWithBody[types.B
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("UpdateBackupSchedule", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("UpdateBackupSchedule", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMachineDebug("UpdateBackupSchedule", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid request body"}
 	}
 
 	serverID := parseServerID(r)
 	response, err := c.backupService.UpdateBackupSchedule(r.Context(), orgID, serverID, body)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		data := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+		if serverID != nil {
+			data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: UpdateBackupSchedule: %v", err), data)
 		return nil, fuego.BadRequestError{Detail: err.Error()}
 	}
 

--- a/api/internal/features/machine/controller/billing.go
+++ b/api/internal/features/machine/controller/billing.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/machine/types"
@@ -11,11 +13,13 @@ func (c *MachineController) ListMachinePlans(f fuego.ContextNoBody) (*types.List
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("ListMachinePlans", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("ListMachinePlans", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -26,20 +30,24 @@ func (c *MachineController) SelectMachinePlan(f fuego.ContextWithBody[types.Sele
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("SelectMachinePlan", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("SelectMachinePlan", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMachineDebug("SelectMachinePlan", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid request body"}
 	}
 
 	if body.PlanTier == "" {
+		c.logMachineDebug("SelectMachinePlan", "plan_tier required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "plan_tier is required"}
 	}
 
@@ -50,11 +58,13 @@ func (c *MachineController) GetMachineBilling(f fuego.ContextNoBody) (*types.Mac
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("GetMachineBilling", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetMachineBilling", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 

--- a/api/internal/features/machine/controller/init.go
+++ b/api/internal/features/machine/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -40,9 +41,13 @@ func NewMachineController(
 	ts *machine_storage.TimescaleStore,
 ) *MachineController {
 	bs := machine_storage.NewBillingStorage(store.DB, ctx)
+	bs.Logger = &l
 	backupStore := machine_storage.NewBackupStorage(store.DB, ctx)
+	backupStore.Logger = &l
 	regStore := machine_storage.NewRegistrationStorage(store.DB, ctx)
+	regStore.Logger = &l
 	listStore := machine_storage.NewListStorage(store.DB, ctx)
+	listStore.Logger = &l
 	ffStorage := ff_storage.NewFeatureFlagStorage(store.DB, ctx)
 	ffService := ff_service.NewFeatureFlagService(ffStorage, l, ctx)
 	regService := service.NewRegistrationService(regStore, ffService, nil, l, ctx)
@@ -65,12 +70,13 @@ func (c *MachineController) GetSystemStats(f fuego.ContextNoBody) (*types.System
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("GetSystemStats", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
-		c.logger.Log(logger.Error, "Organization ID not found in context", "")
+		c.logMachineDebug("GetSystemStats", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -81,7 +87,7 @@ func (c *MachineController) GetSystemStats(f fuego.ContextNoBody) (*types.System
 
 	response, err := c.service.GetSystemStats(ctx, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: GetSystemStats: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -97,21 +103,24 @@ func (c *MachineController) ExecCommand(f fuego.ContextWithBody[types.HostExecRe
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("ExecCommand", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
-		c.logger.Log(logger.Error, "Organization ID not found in context", "")
+		c.logMachineDebug("ExecCommand", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMachineDebug("ExecCommand", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid request body"}
 	}
 
 	if body.Command == "" {
+		c.logMachineDebug("ExecCommand", "command required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "command is required"}
 	}
 
@@ -122,7 +131,7 @@ func (c *MachineController) ExecCommand(f fuego.ContextWithBody[types.HostExecRe
 
 	response, err := c.service.ExecCommand(ctx, orgID, body.Command)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: ExecCommand: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/machine/controller/lifecycle.go
+++ b/api/internal/features/machine/controller/lifecycle.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -30,23 +31,26 @@ func (c *MachineController) GetMachineStatus(f fuego.ContextNoBody) (*types.Mach
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("GetMachineStatus", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetMachineStatus", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	serverID := parseServerID(r)
 	if serverID == nil {
+		c.logMachineDebug("GetMachineStatus", "server_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
 	ctx := context.WithValue(r.Context(), sharedtypes.ServerIDKey, serverID.String())
 	response, err := c.service.GetMachineStatus(ctx, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: GetMachineStatus: %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, serverID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 	return response, nil
@@ -57,16 +61,19 @@ func (c *MachineController) RestartMachine(f fuego.ContextNoBody) (*types.Machin
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("RestartMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("RestartMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	serverID := parseServerID(r)
 	if serverID == nil {
+		c.logMachineDebug("RestartMachine", "server_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
@@ -75,7 +82,7 @@ func (c *MachineController) RestartMachine(f fuego.ContextNoBody) (*types.Machin
 		ctx := context.WithValue(r.Context(), sharedtypes.ServerIDKey, serverID.String())
 		response, err := c.service.RestartMachine(ctx, orgID)
 		if err != nil {
-			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			c.logger.Log(logger.Error, fmt.Sprintf("machine: RestartMachine (user-owned): %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, serverID))
 			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 		}
 		return response, nil
@@ -83,7 +90,7 @@ func (c *MachineController) RestartMachine(f fuego.ContextNoBody) (*types.Machin
 
 	response, err := c.lifecycleService.Restart(r.Context(), orgID, serverID)
 	if err != nil {
-		return nil, mapLifecycleError(c.logger, err, orgID, "restart")
+		return nil, mapLifecycleError(c.logger, err, orgID, user.ID, serverID, "restart")
 	}
 
 	return response, nil
@@ -94,16 +101,19 @@ func (c *MachineController) PauseMachine(f fuego.ContextNoBody) (*types.MachineA
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("PauseMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("PauseMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	serverID := parseServerID(r)
 	if serverID == nil {
+		c.logMachineDebug("PauseMachine", "server_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
@@ -111,7 +121,7 @@ func (c *MachineController) PauseMachine(f fuego.ContextNoBody) (*types.MachineA
 	if userOwned {
 		response, err := c.service.PauseMachine(r.Context(), orgID, *serverID)
 		if err != nil {
-			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			c.logger.Log(logger.Error, fmt.Sprintf("machine: PauseMachine (user-owned): %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, serverID))
 			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 		}
 		return response, nil
@@ -119,7 +129,7 @@ func (c *MachineController) PauseMachine(f fuego.ContextNoBody) (*types.MachineA
 
 	response, err := c.lifecycleService.Pause(r.Context(), orgID, serverID)
 	if err != nil {
-		return nil, mapLifecycleError(c.logger, err, orgID, "pause")
+		return nil, mapLifecycleError(c.logger, err, orgID, user.ID, serverID, "pause")
 	}
 
 	return response, nil
@@ -130,16 +140,19 @@ func (c *MachineController) ResumeMachine(f fuego.ContextNoBody) (*types.Machine
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logMachineDebug("ResumeMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("ResumeMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	serverID := parseServerID(r)
 	if serverID == nil {
+		c.logMachineDebug("ResumeMachine", "server_id required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server_id is required"}
 	}
 
@@ -147,7 +160,7 @@ func (c *MachineController) ResumeMachine(f fuego.ContextNoBody) (*types.Machine
 	if userOwned {
 		response, err := c.service.ResumeMachine(r.Context(), orgID, *serverID)
 		if err != nil {
-			c.logger.Log(logger.Error, err.Error(), orgID.String())
+			c.logger.Log(logger.Error, fmt.Sprintf("machine: ResumeMachine (user-owned): %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, serverID))
 			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 		}
 		return response, nil
@@ -155,14 +168,18 @@ func (c *MachineController) ResumeMachine(f fuego.ContextNoBody) (*types.Machine
 
 	response, err := c.lifecycleService.Resume(r.Context(), orgID, serverID)
 	if err != nil {
-		return nil, mapLifecycleError(c.logger, err, orgID, "resume")
+		return nil, mapLifecycleError(c.logger, err, orgID, user.ID, serverID, "resume")
 	}
 
 	return response, nil
 }
 
-func mapLifecycleError(l logger.Logger, err error, orgID uuid.UUID, action string) error {
-	l.Log(logger.Error, err.Error(), orgID.String())
+func mapLifecycleError(l logger.Logger, err error, orgID uuid.UUID, userID uuid.UUID, serverID *uuid.UUID, action string) error {
+	data := fmt.Sprintf("org_id=%s user_id=%s", orgID, userID)
+	if serverID != nil {
+		data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+	}
+	l.Log(logger.Error, fmt.Sprintf("machine: lifecycle %s: %v", action, err), data)
 
 	switch {
 	case errors.Is(err, types.ErrMachineNotProvisioned):

--- a/api/internal/features/machine/controller/list.go
+++ b/api/internal/features/machine/controller/list.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,12 +19,13 @@ func (c *MachineController) ListMachines(f fuego.ContextNoBody) (*types.ListMach
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("ListMachines", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
-		c.logger.Log(logger.Error, "Organization ID not found in context", "")
+		c.logMachineDebug("ListMachines", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -59,7 +61,7 @@ func (c *MachineController) ListMachines(f fuego.ContextNoBody) (*types.ListMach
 
 	response, err := c.listService.ListMachines(orgID, params)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: ListMachines: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 
@@ -70,18 +72,19 @@ func (c *MachineController) CheckSSHStatus(f fuego.ContextNoBody) (*types.SSHCon
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("CheckSSHStatus", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
-		c.logger.Log(logger.Error, "Organization ID not found in context", "")
+		c.logMachineDebug("CheckSSHStatus", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	response, err := c.listService.CheckSSHConnection(orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: CheckSSHStatus: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 
@@ -92,16 +95,19 @@ func (c *MachineController) SetDefaultMachine(f fuego.ContextNoBody) (*types.Set
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("SetDefaultMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("SetDefaultMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	machineID, err := uuid.Parse(f.PathParam("id"))
 	if err != nil {
+		c.logMachineDebug("SetDefaultMachine", "invalid machine ID", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid machine ID"}
 	}
 
@@ -113,7 +119,7 @@ func (c *MachineController) SetDefaultMachine(f fuego.ContextNoBody) (*types.Set
 		case errors.Is(err, types.ErrMachineInactive):
 			return nil, fuego.BadRequestError{Detail: err.Error()}
 		default:
-			c.logger.Log(logger.Error, err.Error(), machineID.String())
+			c.logger.Log(logger.Error, fmt.Sprintf("machine: SetDefaultMachine: %v", err), fmt.Sprintf("org_id=%s user_id=%s machine_id=%s", orgID, user.ID, machineID))
 			return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 		}
 	}

--- a/api/internal/features/machine/controller/machine_log.go
+++ b/api/internal/features/machine/controller/machine_log.go
@@ -1,0 +1,11 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func (c *MachineController) logMachineDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("machine: %s: %s", handler, reason), data)
+}

--- a/api/internal/features/machine/controller/metrics.go
+++ b/api/internal/features/machine/controller/metrics.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -43,10 +44,12 @@ func (c *MachineController) GetMachineMetrics(f fuego.ContextNoBody) (*machine_t
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("GetMachineMetrics", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetMachineMetrics", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -56,7 +59,11 @@ func (c *MachineController) GetMachineMetrics(f fuego.ContextNoBody) (*machine_t
 
 	resp, err := c.metricsService.GetMetrics(r.Context(), orgID, serverID, from, to, limit)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		data := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+		if serverID != nil {
+			data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: GetMachineMetrics: %v", err), data)
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 	return resp, nil
@@ -66,10 +73,12 @@ func (c *MachineController) GetMachineEvents(f fuego.ContextNoBody) (*machine_ty
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("GetMachineEvents", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetMachineEvents", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -79,7 +88,11 @@ func (c *MachineController) GetMachineEvents(f fuego.ContextNoBody) (*machine_ty
 
 	resp, err := c.metricsService.GetEvents(r.Context(), orgID, serverID, from, to, limit)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		data := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+		if serverID != nil {
+			data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: GetMachineEvents: %v", err), data)
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 	return resp, nil
@@ -89,10 +102,12 @@ func (c *MachineController) GetMachineMetricsSummary(f fuego.ContextNoBody) (*ma
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("GetMachineMetricsSummary", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetMachineMetricsSummary", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
@@ -101,7 +116,11 @@ func (c *MachineController) GetMachineMetricsSummary(f fuego.ContextNoBody) (*ma
 
 	resp, err := c.metricsService.GetSummary(r.Context(), orgID, serverID, from, to)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), orgID.String())
+		data := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+		if serverID != nil {
+			data = fmt.Sprintf("%s server_id=%s", data, *serverID)
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("machine: GetMachineMetricsSummary: %v", err), data)
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 	return resp, nil

--- a/api/internal/features/machine/controller/registration.go
+++ b/api/internal/features/machine/controller/registration.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,26 +16,30 @@ func (c *MachineController) CreateMachine(f fuego.ContextWithBody[types.CreateMa
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("CreateMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("CreateMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMachineDebug("CreateMachine", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid request body"}
 	}
 
 	if body.Name == "" || body.Host == "" {
+		c.logMachineDebug("CreateMachine", "name and host required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "name and host are required"}
 	}
 
 	response, err := c.registrationService.CreateMachine(orgID, user.ID, body)
 	if err != nil {
-		return nil, mapRegistrationError(c.logger, err, orgID)
+		return nil, mapRegistrationError(c.logger, err, orgID, user.ID, nil)
 	}
 
 	return response, nil
@@ -44,22 +49,25 @@ func (c *MachineController) VerifyMachine(f fuego.ContextNoBody) (*types.VerifyM
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("VerifyMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("VerifyMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	machineID, err := uuid.Parse(f.PathParam("id"))
 	if err != nil {
+		c.logMachineDebug("VerifyMachine", "invalid machine ID", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid machine ID"}
 	}
 
 	response, err := c.registrationService.VerifyMachine(orgID, machineID)
 	if err != nil {
-		return nil, mapRegistrationError(c.logger, err, orgID)
+		return nil, mapRegistrationError(c.logger, err, orgID, user.ID, &machineID)
 	}
 
 	return response, nil
@@ -69,27 +77,31 @@ func (c *MachineController) RenameMachine(f fuego.ContextWithBody[types.RenameMa
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("RenameMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("RenameMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	machineID, err := uuid.Parse(f.PathParam("id"))
 	if err != nil {
+		c.logMachineDebug("RenameMachine", "invalid machine ID", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid machine ID"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMachineDebug("RenameMachine", "invalid body", fmt.Sprintf("org_id=%s user_id=%s machine_id=%s", orgID, user.ID, machineID))
 		return nil, fuego.BadRequestError{Detail: "invalid request body"}
 	}
 
 	response, err := c.registrationService.RenameMachine(orgID, machineID, body.Name)
 	if err != nil {
-		return nil, mapRegistrationError(c.logger, err, orgID)
+		return nil, mapRegistrationError(c.logger, err, orgID, user.ID, &machineID)
 	}
 
 	return response, nil
@@ -99,21 +111,24 @@ func (c *MachineController) DeleteMachine(f fuego.ContextNoBody) (*types.DeleteM
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("DeleteMachine", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("DeleteMachine", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	machineID, err := uuid.Parse(f.PathParam("id"))
 	if err != nil {
+		c.logMachineDebug("DeleteMachine", "invalid machine ID", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid machine ID"}
 	}
 
 	if err := c.registrationService.DeleteMachine(orgID, machineID); err != nil {
-		return nil, mapRegistrationError(c.logger, err, orgID)
+		return nil, mapRegistrationError(c.logger, err, orgID, user.ID, &machineID)
 	}
 
 	return &types.DeleteMachineResponse{Status: "deleted"}, nil
@@ -123,29 +138,36 @@ func (c *MachineController) GetSSHStatus(f fuego.ContextNoBody) (*types.SSHStatu
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMachineDebug("GetSSHStatus", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logMachineDebug("GetSSHStatus", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	machineID, err := uuid.Parse(f.PathParam("id"))
 	if err != nil {
+		c.logMachineDebug("GetSSHStatus", "invalid machine ID", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid machine ID"}
 	}
 
 	response, err := c.registrationService.GetSSHStatus(orgID, machineID)
 	if err != nil {
-		return nil, mapRegistrationError(c.logger, err, orgID)
+		return nil, mapRegistrationError(c.logger, err, orgID, user.ID, &machineID)
 	}
 
 	return response, nil
 }
 
-func mapRegistrationError(l logger.Logger, err error, orgID uuid.UUID) error {
-	l.Log(logger.Error, err.Error(), orgID.String())
+func mapRegistrationError(l logger.Logger, err error, orgID uuid.UUID, userID uuid.UUID, machineID *uuid.UUID) error {
+	data := fmt.Sprintf("org_id=%s user_id=%s", orgID, userID)
+	if machineID != nil {
+		data = fmt.Sprintf("%s machine_id=%s", data, *machineID)
+	}
+	l.Log(logger.Error, fmt.Sprintf("machine: registration: %v", err), data)
 
 	switch {
 	case errors.Is(err, types.ErrFeatureDisabled):

--- a/api/internal/features/machine/controller/trial.go
+++ b/api/internal/features/machine/controller/trial.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -36,9 +37,10 @@ func NewTrailController(
 	c *cache.Cache,
 ) *TrailController {
 	trailStorage := machine_storage.NewTrailStorage(store.DB, ctx)
+	trailStorage.Logger = &l
 
 	return &TrailController{
-		validator: validation.NewValidator(),
+		validator: validation.NewValidatorWithLogger(&l),
 		service:   machine_service.NewTrailService(store, ctx, l, trailStorage),
 		ctx:       ctx,
 		logger:    l,
@@ -75,31 +77,35 @@ func (c *TrailController) ProvisionTrail(f fuego.ContextWithBody[machine_types.P
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logTrialDebug("ProvisionTrail", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := r.Header.Get("X-Organization-Id")
 	if orgID == "" {
+		c.logTrialDebug("ProvisionTrail", "organization header required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.ForbiddenError{Detail: machine_types.ErrOrganizationRequired.Error(), Err: machine_types.ErrOrganizationRequired}
 	}
 
 	if _, err := uuid.Parse(orgID); err != nil {
+		c.logTrialDebug("ProvisionTrail", "invalid organization ID", fmt.Sprintf("user_id=%s org_id=%s", user.ID, orgID))
 		return nil, fuego.BadRequestError{Detail: machine_types.ErrInvalidOrganizationID.Error(), Err: machine_types.ErrInvalidOrganizationID}
 	}
 
 	body, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), user.ID.String())
+		c.logger.Log(logger.Debug, fmt.Sprintf("machine trial: ProvisionTrail body: %v", err), fmt.Sprintf("user_id=%s org_id=%s", user.ID, orgID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if err := c.validator.ValidateRequest(&body); err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("machine trial: ProvisionTrail validation: %v", err), fmt.Sprintf("user_id=%s org_id=%s", user.ID, orgID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	result, err := c.service.ProvisionTrail(user.ID.String(), orgID, body)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), user.ID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine trial: ProvisionTrail: %v", err), fmt.Sprintf("user_id=%s org_id=%s", user.ID, orgID))
 		status := mapTrialErrorToStatus(err)
 		return nil, fuego.HTTPError{
 			Err:    err,
@@ -125,21 +131,24 @@ func (c *TrailController) GetStatus(f fuego.ContextNoBody) (*machine_types.Trail
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logTrialDebug("GetTrailStatus", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	sessionID := f.PathParam("sessionId")
 	if sessionID == "" {
+		c.logTrialDebug("GetTrailStatus", "session_id required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.BadRequestError{Detail: machine_types.ErrInvalidSessionID.Error(), Err: machine_types.ErrInvalidSessionID}
 	}
 
 	if _, err := uuid.Parse(sessionID); err != nil {
+		c.logTrialDebug("GetTrailStatus", "invalid session_id", fmt.Sprintf("user_id=%s session_id=%s", user.ID, sessionID))
 		return nil, fuego.BadRequestError{Detail: machine_types.ErrInvalidSessionID.Error(), Err: machine_types.ErrInvalidSessionID}
 	}
 
 	result, err := c.service.GetStatus(user.ID.String(), sessionID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), user.ID.String())
+		c.logger.Log(logger.Error, fmt.Sprintf("machine trial: GetTrailStatus: %v", err), fmt.Sprintf("user_id=%s session_id=%s", user.ID, sessionID))
 		status := mapTrialErrorToStatus(err)
 		return nil, fuego.HTTPError{
 			Err:    err,
@@ -161,25 +170,28 @@ func (c *TrailController) UpgradeResources(f fuego.ContextWithBody[machine_types
 
 	secret := r.Header.Get("X-Internal-Secret")
 	if secret == "" || secret != config.AppConfig.BetterAuth.Secret {
+		c.logTrialDebug("UpgradeResources", "unauthorized internal call", "")
 		return nil, fuego.UnauthorizedError{Detail: "unauthorized", Err: errors.New("unauthorized")}
 	}
 
 	body, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Debug, fmt.Sprintf("machine trial: UpgradeResources body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if body.UserID == "" || body.OrgID == "" {
+		c.logTrialDebug("UpgradeResources", "user_id and org_id required", "")
 		return nil, fuego.BadRequestError{Detail: "user_id and org_id are required", Err: errors.New("user_id and org_id are required")}
 	}
 
 	if body.VcpuCount <= 0 || body.MemoryMB <= 0 {
+		c.logTrialDebug("UpgradeResources", "invalid vcpu or memory", fmt.Sprintf("user_id=%s org_id=%s", body.UserID, body.OrgID))
 		return nil, fuego.BadRequestError{Detail: "vcpu_count and memory_mb must be positive", Err: errors.New("vcpu_count and memory_mb must be positive")}
 	}
 
 	if err := c.service.UpgradeResources(body.UserID, body.OrgID, body.VcpuCount, body.MemoryMB); err != nil {
-		c.logger.Log(logger.Error, err.Error(), body.UserID)
+		c.logger.Log(logger.Error, fmt.Sprintf("machine trial: UpgradeResources: %v", err), fmt.Sprintf("user_id=%s org_id=%s", body.UserID, body.OrgID))
 		status := mapTrialErrorToStatus(err)
 		return nil, fuego.HTTPError{
 			Err:    err,
@@ -192,4 +204,8 @@ func (c *TrailController) UpgradeResources(f fuego.ContextWithBody[machine_types
 		Status:  "success",
 		Message: "Resource upgrade enqueued",
 	}, nil
+}
+
+func (c *TrailController) logTrialDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("machine trial: %s: %s", handler, reason), data)
 }

--- a/api/internal/features/machine/service/init.go
+++ b/api/internal/features/machine/service/init.go
@@ -82,7 +82,7 @@ func (s *MachineService) GetMachineStatus(ctx context.Context, orgID uuid.UUID) 
 
 	runner, err := s.getSSHRunner(ctx)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: failed to get SSH manager: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}
 
@@ -122,7 +122,7 @@ func (s *MachineService) lazyFillSpecs(ctx context.Context, runner SSHCommandRun
 
 	stats, err := s.collectSystemStats(runner)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("lazy fill: failed to collect stats: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: lazy fill collect stats: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 		return
 	}
 
@@ -135,7 +135,7 @@ func (s *MachineService) lazyFillSpecs(ctx context.Context, runner SSHCommandRun
 	}
 
 	if err := s.regStore.UpdateProvisionResources(serverID, cpuCores, memMB, diskGB); err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("lazy fill: failed to persist specs: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: lazy fill persist specs: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 	}
 }
 
@@ -152,13 +152,13 @@ func ParseUptimeToState(raw string) *types.MachineState {
 func (s *MachineService) GetSystemStats(ctx context.Context, orgID uuid.UUID) (*types.SystemStatsResponse, error) {
 	runner, err := s.getSSHRunner(ctx)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: failed to get SSH manager: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}
 
 	stats, err := s.collectSystemStats(runner)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("failed to collect system stats: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: collect system stats: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fmt.Errorf("failed to collect system stats: %w", err)
 	}
 
@@ -172,7 +172,7 @@ func (s *MachineService) GetSystemStats(ctx context.Context, orgID uuid.UUID) (*
 func (s *MachineService) RestartMachine(ctx context.Context, orgID uuid.UUID) (*types.MachineActionResponse, error) {
 	runner, err := s.getSSHRunner(ctx)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: failed to get SSH manager: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}
 
@@ -186,7 +186,7 @@ func (s *MachineService) RestartMachine(ctx context.Context, orgID uuid.UUID) (*
 
 func (s *MachineService) PauseMachine(ctx context.Context, orgID uuid.UUID, serverID uuid.UUID) (*types.MachineActionResponse, error) {
 	if err := s.regStore.SetMachineActive(serverID, false); err != nil {
-		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: pause machine: %v", err), fmt.Sprintf("org_id=%s server_id=%s", orgID, serverID))
 		return nil, fmt.Errorf("failed to pause machine: %w", err)
 	}
 	return &types.MachineActionResponse{
@@ -197,7 +197,7 @@ func (s *MachineService) PauseMachine(ctx context.Context, orgID uuid.UUID, serv
 
 func (s *MachineService) ResumeMachine(ctx context.Context, orgID uuid.UUID, serverID uuid.UUID) (*types.MachineActionResponse, error) {
 	if err := s.regStore.SetMachineActive(serverID, true); err != nil {
-		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: resume machine: %v", err), fmt.Sprintf("org_id=%s server_id=%s", orgID, serverID))
 		return nil, fmt.Errorf("failed to resume machine: %w", err)
 	}
 	return &types.MachineActionResponse{
@@ -224,7 +224,7 @@ func (s *MachineService) ExecCommand(ctx context.Context, orgID uuid.UUID, comma
 	}
 	runner, err := s.getSSHRunner(ctx)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("failed to get SSH manager: %s", err.Error()), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: failed to get SSH manager: %s", err.Error()), fmt.Sprintf("org_id=%s", orgID))
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}
 	stdout, err := runner.RunCommand(command)

--- a/api/internal/features/machine/service/list.go
+++ b/api/internal/features/machine/service/list.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
@@ -50,7 +51,7 @@ func (s *ListService) ListMachines(orgID uuid.UUID, params types.MachineListPara
 
 	machines, totalCount, err := s.storage.ListMachinesByOrganizationID(orgID, params)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: ListMachines: %v", err), fmt.Sprintf("org_id=%s", orgID))
 		return nil, err
 	}
 
@@ -78,7 +79,7 @@ func (s *ListService) ListMachines(orgID uuid.UUID, params types.MachineListPara
 func (s *ListService) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*shared_types.SSHKey, error) {
 	oldDefaultID, err := s.storage.SetDefaultMachine(orgID, machineID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: SetDefaultMachine: %v", err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		return nil, err
 	}
 
@@ -88,7 +89,7 @@ func (s *ListService) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*
 
 	key, err := s.storage.GetMachineByIDAndOrgID(machineID, orgID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), machineID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: GetMachineByIDAndOrgID: %v", err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		return nil, err
 	}
 	return key, nil
@@ -103,7 +104,7 @@ func (s *ListService) CheckSSHConnection(orgID uuid.UUID) (*types.SSHConnectionS
 	}
 	sshMgr, err := sshProvider(s.ctx, orgID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: CheckSSHConnection ssh manager: %v", err), fmt.Sprintf("org_id=%s", orgID))
 		return &types.SSHConnectionStatusResponse{
 			Status:       "error",
 			Connected:    false,
@@ -124,7 +125,7 @@ func (s *ListService) CheckSSHConnection(orgID uuid.UUID) (*types.SSHConnectionS
 
 	session, err := sshMgr.NewSessionWithRetry("")
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: CheckSSHConnection session: %v", err), fmt.Sprintf("org_id=%s", orgID))
 		return &types.SSHConnectionStatusResponse{
 			Status:       "disconnected",
 			Connected:    false,

--- a/api/internal/features/machine/service/registration.go
+++ b/api/internal/features/machine/service/registration.go
@@ -257,9 +257,9 @@ func (s *RegistrationService) VerifyMachine(orgID uuid.UUID, machineID uuid.UUID
 	addr := fmt.Sprintf("%s:%d", *sshKey.Host, port)
 	client, err := s.getDialSSH()("tcp", addr, config)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("SSH dial failed for machine %s: %v", machineID, err), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: SSH dial failed for machine %s: %v", machineID, err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		if dbErr := s.storage.MarkMachineInactive(machineID); dbErr != nil {
-			s.logger.Log(logger.Error, fmt.Sprintf("Failed to mark machine %s inactive after SSH dial error: %v", machineID, dbErr), orgID.String())
+			s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: mark inactive after SSH dial: %v", dbErr), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		}
 		return &types.VerifyMachineResponse{Status: "failed", IsActive: false}, nil
 	}
@@ -267,18 +267,18 @@ func (s *RegistrationService) VerifyMachine(orgID uuid.UUID, machineID uuid.UUID
 
 	session, err := client.NewSession()
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("SSH session failed for machine %s: %v", machineID, err), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: SSH session failed for machine %s: %v", machineID, err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		if dbErr := s.storage.MarkMachineInactive(machineID); dbErr != nil {
-			s.logger.Log(logger.Error, fmt.Sprintf("Failed to mark machine %s inactive after SSH session error: %v", machineID, dbErr), orgID.String())
+			s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: mark inactive after SSH session: %v", dbErr), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		}
 		return &types.VerifyMachineResponse{Status: "failed", IsActive: false}, nil
 	}
 	defer session.Close()
 
 	if err := session.Run("echo ok"); err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("SSH command failed for machine %s: %v", machineID, err), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: SSH command failed for machine %s: %v", machineID, err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		if dbErr := s.storage.MarkMachineInactive(machineID); dbErr != nil {
-			s.logger.Log(logger.Error, fmt.Sprintf("Failed to mark machine %s inactive after SSH command error: %v", machineID, dbErr), orgID.String())
+			s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: mark inactive after SSH command: %v", dbErr), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		}
 		return &types.VerifyMachineResponse{Status: "failed", IsActive: false}, nil
 	}
@@ -302,19 +302,19 @@ func (s *RegistrationService) RenameMachine(orgID uuid.UUID, machineID uuid.UUID
 	_, err := s.storage.GetSSHKeyByID(machineID, orgID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			s.logger.Log(logger.Error, fmt.Sprintf("Machine not found for rename: machineID=%s, orgID=%s", machineID, orgID), orgID.String())
+			s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: machine not found for rename: machineID=%s orgID=%s", machineID, orgID), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 			return nil, types.ErrMachineNotFound
 		}
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to get machine for rename: machineID=%s, error=%v", machineID, err), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: get machine for rename: %v", err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		return nil, fmt.Errorf("failed to get machine: %w", err)
 	}
 
 	if err := s.storage.UpdateMachineName(machineID, trimmed); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			s.logger.Log(logger.Error, fmt.Sprintf("Machine not found during rename update: machineID=%s", machineID), orgID.String())
+			s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: machine not found during rename update: machineID=%s", machineID), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 			return nil, types.ErrMachineNotFound
 		}
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to update machine name: machineID=%s, error=%v", machineID, err), orgID.String())
+		s.logger.Log(logger.Error, fmt.Sprintf("machine service: registration: update machine name: %v", err), fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID))
 		return nil, fmt.Errorf("failed to rename machine: %w", err)
 	}
 

--- a/api/internal/features/machine/service/trial.go
+++ b/api/internal/features/machine/service/trial.go
@@ -120,13 +120,13 @@ func (s *TrailService) ProvisionTrail(userID, orgID string, req machine_types.Pr
 	}
 
 	if !s.IsImageAllowed(image) {
-		s.logger.Log(logger.Warning, fmt.Sprintf("User %s requested disallowed image: %s", userID, image), userID)
+		s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: User %s requested disallowed image: %s", userID, image), fmt.Sprintf("user_id=%s", userID))
 		return nil, machine_types.ErrImageNotAllowed
 	}
 
 	activeProvision, err := s.storage.GetActiveProvisionByUserAndOrg(userID, orgID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return nil, fmt.Errorf("failed to check active provisions: %w", err)
 	}
 
@@ -136,24 +136,24 @@ func (s *TrailService) ProvisionTrail(userID, orgID string, req machine_types.Pr
 
 	count, err := s.storage.CountActiveProvisions()
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: %v", err), "")
 		return nil, fmt.Errorf("failed to check system capacity: %w", err)
 	}
 
 	if count >= s.config.MaxConcurrentTrails {
-		s.logger.Log(logger.Warning, fmt.Sprintf("Max concurrent trails reached (%d/%d)", count, s.config.MaxConcurrentTrails), "")
+		s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: max concurrent trails reached (%d/%d)", count, s.config.MaxConcurrentTrails), "")
 		return nil, machine_types.ErrSystemAtCapacity
 	}
 
 	subdomain, err := s.GenerateSubdomain()
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return nil, fmt.Errorf("failed to generate subdomain: %w", err)
 	}
 
 	user, err := s.storage.GetUserByID(userID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
 
@@ -193,17 +193,17 @@ func (s *TrailService) ProvisionTrail(userID, orgID string, req machine_types.Pr
 		if strings.Contains(err.Error(), "active_provision_per_user_org") || strings.Contains(err.Error(), "duplicate") {
 			return nil, machine_types.ErrActiveProvisionExists
 		}
-		s.logger.Log(logger.Error, err.Error(), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return nil, fmt.Errorf("failed to create provision record: %w", err)
 	}
 
 	if err := s.storage.UpdateUserProvisionStatus(userID, machine_types.UserProvisionStatusProvisioning); err != nil {
-		s.logger.Log(logger.Warning, fmt.Sprintf("Failed to set user provision_status=provisioning: %v", err), userID)
+		s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: failed to set user provision_status=provisioning: %v", err), fmt.Sprintf("user_id=%s", userID))
 	}
 
 	serverID, err := s.storage.SelectBestServer(1, 1024, 25)
 	if err != nil {
-		s.logger.Log(logger.Warning, fmt.Sprintf("Server scheduling failed, falling back to legacy queue: %v", err), userID)
+		s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: server scheduling failed, falling back to legacy queue: %v", err), fmt.Sprintf("user_id=%s", userID))
 	}
 
 	payload := machine_types.ProvisionPayload{
@@ -218,14 +218,14 @@ func (s *TrailService) ProvisionTrail(userID, orgID string, req machine_types.Pr
 	}
 
 	if err := s.EnqueueProvisionTask(s.ctx, payload); err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to enqueue provision task: %v", err), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: failed to enqueue provision task: %v", err), fmt.Sprintf("user_id=%s", userID))
 
 		if updateErr := s.storage.UpdateUserProvisionDetailsWithError(provisionDetails.ID.String(), fmt.Sprintf("Failed to enqueue task: %v", err)); updateErr != nil {
-			s.logger.Log(logger.Warning, fmt.Sprintf("Failed to update provision details error: %v", updateErr), userID)
+			s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: failed to update provision details error: %v", updateErr), fmt.Sprintf("user_id=%s", userID))
 		}
 
 		if updateErr := s.storage.UpdateUserProvisionStatus(userID, machine_types.UserProvisionStatusFailed); updateErr != nil {
-			s.logger.Log(logger.Warning, fmt.Sprintf("Failed to update user provision_status: %v", updateErr), userID)
+			s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: failed to update user provision_status: %v", updateErr), fmt.Sprintf("user_id=%s", userID))
 		}
 
 		return nil, machine_types.ErrFailedToEnqueueTask
@@ -242,7 +242,7 @@ func (s *TrailService) ProvisionTrail(userID, orgID string, req machine_types.Pr
 func (s *TrailService) GetStatus(userID, sessionID string) (*machine_types.StatusResponse, error) {
 	details, err := s.storage.GetUserProvisionDetailsByID(sessionID)
 	if err != nil {
-		s.logger.Log(logger.Error, err.Error(), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return nil, fmt.Errorf("failed to retrieve status: %w", err)
 	}
 
@@ -256,7 +256,7 @@ func (s *TrailService) GetStatus(userID, sessionID string) (*machine_types.Statu
 
 	userStatus, err := s.storage.GetUserProvisionStatus(userID)
 	if err != nil {
-		s.logger.Log(logger.Warning, fmt.Sprintf("Failed to get user provision status: %v", err), userID)
+		s.logger.Log(logger.Warning, fmt.Sprintf("machine trial: failed to get user provision status: %v", err), fmt.Sprintf("user_id=%s", userID))
 		userStatus = machine_types.UserProvisionStatusPending
 	}
 
@@ -330,17 +330,17 @@ func (s *TrailService) calculateProgress(step *shared_types.ProvisionStep, statu
 func (s *TrailService) UpgradeResources(userID, orgID string, vcpu, memoryMB int) error {
 	provision, err := s.storage.GetCompletedProvisionByUserID(userID)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to look up completed provision: %v", err), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: failed to look up completed provision: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return fmt.Errorf("failed to look up provision: %w", err)
 	}
 
 	if provision == nil {
-		s.logger.Log(logger.Warning, "No completed provision found for resource upgrade", userID)
+		s.logger.Log(logger.Warning, "machine trial: no completed provision found for resource upgrade", fmt.Sprintf("user_id=%s", userID))
 		return machine_types.ErrProvisionNotFound
 	}
 
 	if provision.LXDContainerName == nil || *provision.LXDContainerName == "" {
-		s.logger.Log(logger.Error, "Completed provision has no container name", userID)
+		s.logger.Log(logger.Error, "machine trial: completed provision has no container name", fmt.Sprintf("user_id=%s", userID))
 		return fmt.Errorf("provision missing container name")
 	}
 
@@ -361,11 +361,11 @@ func (s *TrailService) UpgradeResources(userID, orgID string, vcpu, memoryMB int
 		enqueue = s.enqueueResourceFn
 	}
 	if err := enqueue(s.ctx, payload); err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to enqueue resource update: %v", err), userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("machine trial: failed to enqueue resource update: %v", err), fmt.Sprintf("user_id=%s", userID))
 		return machine_types.ErrFailedToEnqueueTask
 	}
 
-	s.logger.Log(logger.Info, fmt.Sprintf("Resource upgrade enqueued: vm=%s vcpu=%d mem=%d", payload.VMName, vcpu, memoryMB), userID)
+	s.logger.Log(logger.Info, fmt.Sprintf("machine trial: resource upgrade enqueued: vm=%s vcpu=%d mem=%d", payload.VMName, vcpu, memoryMB), fmt.Sprintf("user_id=%s", userID))
 	return nil
 }
 

--- a/api/internal/features/machine/storage/backup.go
+++ b/api/internal/features/machine/storage/backup.go
@@ -9,13 +9,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/machine/types"
 	"github.com/uptrace/bun"
 )
 
 type BackupStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 func NewBackupStorage(db *bun.DB, ctx context.Context) *BackupStorage {
@@ -23,6 +25,12 @@ func NewBackupStorage(db *bun.DB, ctx context.Context) *BackupStorage {
 }
 
 func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, serverID *uuid.UUID, params types.BackupListParams) ([]types.MachineBackup, int, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	if serverID != nil {
+		ctxStr = fmt.Sprintf("%s server_id=%s", ctxStr, *serverID)
+	}
+	storageLog(s.Logger, logger.Debug, "storage: ListByOrg backups", ctxStr)
+
 	query := s.DB.NewSelect().
 		Model((*types.MachineBackup)(nil)).
 		Where("mb.organization_id = ?", orgID)
@@ -59,6 +67,7 @@ func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, serverID
 
 	totalCount, err := countQuery.Count(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListByOrg count: %v", err), ctxStr)
 		return nil, 0, fmt.Errorf("failed to count backups: %w", err)
 	}
 
@@ -85,12 +94,19 @@ func (s *BackupStorage) ListByOrg(ctx context.Context, orgID uuid.UUID, serverID
 	var backups []types.MachineBackup
 	err = query.Scan(ctx, &backups)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListByOrg scan: %v", err), ctxStr)
 		return nil, 0, fmt.Errorf("failed to list backups: %w", err)
 	}
 	return backups, totalCount, nil
 }
 
 func (s *BackupStorage) HasInProgressBackup(ctx context.Context, orgID uuid.UUID, serverID *uuid.UUID) (bool, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	if serverID != nil {
+		ctxStr = fmt.Sprintf("%s server_id=%s", ctxStr, *serverID)
+	}
+	storageLog(s.Logger, logger.Debug, "storage: HasInProgressBackup", ctxStr)
+
 	q := s.DB.NewSelect().
 		Model((*types.MachineBackup)(nil)).
 		Where("mb.organization_id = ?", orgID).
@@ -106,12 +122,16 @@ func (s *BackupStorage) HasInProgressBackup(ctx context.Context, orgID uuid.UUID
 
 	exists, err := q.Exists(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: HasInProgressBackup: %v", err), ctxStr)
 		return false, fmt.Errorf("failed to check in-progress backups: %w", err)
 	}
 	return exists, nil
 }
 
 func (s *BackupStorage) GetLatestCompletedBackup(ctx context.Context, orgID uuid.UUID) (*types.MachineBackup, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	storageLog(s.Logger, logger.Debug, "storage: GetLatestCompletedBackup", ctxStr)
+
 	var backup types.MachineBackup
 	err := s.DB.NewSelect().
 		Model(&backup).
@@ -122,14 +142,19 @@ func (s *BackupStorage) GetLatestCompletedBackup(ctx context.Context, orgID uuid
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetLatestCompletedBackup not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetLatestCompletedBackup: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get latest completed backup: %w", err)
 	}
 	return &backup, nil
 }
 
 func (s *BackupStorage) GetByID(ctx context.Context, id uuid.UUID, orgID uuid.UUID) (*types.MachineBackup, error) {
+	ctxStr := fmt.Sprintf("org_id=%s backup_id=%s", orgID, id)
+	storageLog(s.Logger, logger.Debug, "storage: GetBackupByID", ctxStr)
+
 	var backup types.MachineBackup
 	err := s.DB.NewSelect().
 		Model(&backup).
@@ -137,24 +162,36 @@ func (s *BackupStorage) GetByID(ctx context.Context, id uuid.UUID, orgID uuid.UU
 		Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetBackupByID not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetBackupByID: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get backup: %w", err)
 	}
 	return &backup, nil
 }
 
 func (s *BackupStorage) InsertBackup(ctx context.Context, backup *types.MachineBackup) error {
+	ctxStr := fmt.Sprintf("org_id=%s", backup.OrganizationID)
+	if backup.ID != (uuid.UUID{}) {
+		ctxStr = fmt.Sprintf("%s backup_id=%s", ctxStr, backup.ID)
+	}
+	storageLog(s.Logger, logger.Debug, "storage: InsertBackup", ctxStr)
+
 	_, err := s.DB.NewInsert().
 		Model(backup).
 		Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: InsertBackup: %v", err), ctxStr)
 		return fmt.Errorf("failed to insert backup: %w", err)
 	}
 	return nil
 }
 
 func (s *BackupStorage) UpdateBackupStatus(ctx context.Context, id uuid.UUID, status types.MachineBackupStatus, updates map[string]interface{}) error {
+	ctxStr := fmt.Sprintf("backup_id=%s status=%s", id, status)
+	storageLog(s.Logger, logger.Debug, "storage: UpdateBackupStatus", ctxStr)
+
 	q := s.DB.NewUpdate().
 		TableExpr("machine_backups").
 		Where("id = ?", id).
@@ -167,6 +204,7 @@ func (s *BackupStorage) UpdateBackupStatus(ctx context.Context, id uuid.UUID, st
 
 	_, err := q.Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: UpdateBackupStatus: %v", err), ctxStr)
 		return fmt.Errorf("failed to update backup status: %w", err)
 	}
 	return nil
@@ -175,6 +213,9 @@ func (s *BackupStorage) UpdateBackupStatus(ctx context.Context, id uuid.UUID, st
 // GetProvisionIDBySSHKey returns the user_provision_details.id for a BYOS machine,
 // matched by ssh_key_id. Returns nil (no error) if no row is found.
 func (s *BackupStorage) GetProvisionIDBySSHKey(ctx context.Context, orgID, sshKeyID uuid.UUID) (*uuid.UUID, error) {
+	ctxStr := fmt.Sprintf("org_id=%s ssh_key_id=%s", orgID, sshKeyID)
+	storageLog(s.Logger, logger.Debug, "storage: GetProvisionIDBySSHKey", ctxStr)
+
 	var row struct {
 		ID uuid.UUID `bun:"id"`
 	}
@@ -188,8 +229,10 @@ func (s *BackupStorage) GetProvisionIDBySSHKey(ctx context.Context, orgID, sshKe
 		Scan(ctx, &row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetProvisionIDBySSHKey not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetProvisionIDBySSHKey: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get provision ID: %w", err)
 	}
 	return &row.ID, nil

--- a/api/internal/features/machine/storage/billing.go
+++ b/api/internal/features/machine/storage/billing.go
@@ -8,13 +8,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/machine/types"
 	"github.com/uptrace/bun"
 )
 
 type BillingStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 func NewBillingStorage(db *bun.DB, ctx context.Context) *BillingStorage {
@@ -22,6 +24,8 @@ func NewBillingStorage(db *bun.DB, ctx context.Context) *BillingStorage {
 }
 
 func (s *BillingStorage) ListActivePlans() ([]types.MachinePlan, error) {
+	storageLog(s.Logger, logger.Debug, "storage: ListActivePlans", "")
+
 	var plans []types.MachinePlan
 	err := s.DB.NewSelect().
 		Model(&plans).
@@ -29,12 +33,16 @@ func (s *BillingStorage) ListActivePlans() ([]types.MachinePlan, error) {
 		OrderExpr("monthly_cost_cents ASC").
 		Scan(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListActivePlans: %v", err), "")
 		return nil, fmt.Errorf("failed to list machine plans: %w", err)
 	}
 	return plans, nil
 }
 
 func (s *BillingStorage) GetPlanByTier(tier string) (*types.MachinePlan, error) {
+	ctxStr := fmt.Sprintf("tier=%s", tier)
+	storageLog(s.Logger, logger.Debug, "storage: GetPlanByTier", ctxStr)
+
 	var plan types.MachinePlan
 	err := s.DB.NewSelect().
 		Model(&plan).
@@ -43,14 +51,19 @@ func (s *BillingStorage) GetPlanByTier(tier string) (*types.MachinePlan, error) 
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetPlanByTier not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetPlanByTier: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get plan by tier: %w", err)
 	}
 	return &plan, nil
 }
 
 func (s *BillingStorage) GetPlanByID(planID uuid.UUID) (*types.MachinePlan, error) {
+	ctxStr := fmt.Sprintf("plan_id=%s", planID)
+	storageLog(s.Logger, logger.Debug, "storage: GetPlanByID", ctxStr)
+
 	var plan types.MachinePlan
 	err := s.DB.NewSelect().
 		Model(&plan).
@@ -59,14 +72,19 @@ func (s *BillingStorage) GetPlanByID(planID uuid.UUID) (*types.MachinePlan, erro
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetPlanByID not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetPlanByID: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get plan by id: %w", err)
 	}
 	return &plan, nil
 }
 
 func (s *BillingStorage) GetBillingByOrgID(orgID uuid.UUID) (*types.OrgMachineBilling, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	storageLog(s.Logger, logger.Debug, "storage: GetBillingByOrgID", ctxStr)
+
 	var billing types.OrgMachineBilling
 	err := s.DB.NewSelect().
 		Model(&billing).
@@ -75,8 +93,10 @@ func (s *BillingStorage) GetBillingByOrgID(orgID uuid.UUID) (*types.OrgMachineBi
 		Scan(s.Ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetBillingByOrgID not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetBillingByOrgID: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get billing by org: %w", err)
 	}
 	return &billing, nil
@@ -340,6 +360,9 @@ type ProvisionInfo struct {
 }
 
 func (s *BillingStorage) IsServerUserOwned(orgID uuid.UUID, serverID uuid.UUID) (bool, error) {
+	ctxStr := fmt.Sprintf("org_id=%s server_id=%s", orgID, serverID)
+	storageLog(s.Logger, logger.Debug, "storage: IsServerUserOwned", ctxStr)
+
 	exists, err := s.DB.NewSelect().
 		TableExpr("user_provision_details AS upd").
 		Where("upd.organization_id = ?", orgID).
@@ -347,12 +370,19 @@ func (s *BillingStorage) IsServerUserOwned(orgID uuid.UUID, serverID uuid.UUID) 
 		Where("upd.type = 'user_owned'").
 		Exists(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: IsServerUserOwned: %v", err), ctxStr)
 		return false, fmt.Errorf("failed to check server ownership: %w", err)
 	}
 	return exists, nil
 }
 
 func (s *BillingStorage) GetProvisionInfo(ctx context.Context, orgID uuid.UUID, serverID *uuid.UUID) (*ProvisionInfo, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	if serverID != nil {
+		ctxStr = fmt.Sprintf("%s server_id=%s", ctxStr, *serverID)
+	}
+	storageLog(s.Logger, logger.Debug, "storage: GetProvisionInfo", ctxStr)
+
 	var row UserProvisionDetail
 	q := s.DB.NewSelect().Model(&row).Column("user_id", "lxd_container_name", "server_id")
 	if serverID != nil {
@@ -364,8 +394,10 @@ func (s *BillingStorage) GetProvisionInfo(ctx context.Context, orgID uuid.UUID, 
 	err := q.OrderExpr("created_at DESC").Limit(1).Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetProvisionInfo not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetProvisionInfo: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get provision info: %w", err)
 	}
 	info := &ProvisionInfo{UserID: row.UserID}

--- a/api/internal/features/machine/storage/list.go
+++ b/api/internal/features/machine/storage/list.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/machine/types"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type ListStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
-	tx  *bun.Tx
+	DB     *bun.DB
+	Ctx    context.Context
+	tx     *bun.Tx
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 func NewListStorage(db *bun.DB, ctx context.Context) *ListStorage {
@@ -36,6 +39,9 @@ type ListRepository interface {
 }
 
 func (s *ListStorage) ListMachinesByOrganizationID(orgID uuid.UUID, params types.MachineListParams) ([]types.MachineResponse, int, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	storageLog(s.Logger, logger.Debug, "storage: ListMachinesByOrganizationID", ctxStr)
+
 	query := s.getDB().NewSelect().
 		TableExpr("ssh_keys AS sk").
 		Where("sk.organization_id = ?", orgID).
@@ -88,6 +94,7 @@ func (s *ListStorage) ListMachinesByOrganizationID(orgID uuid.UUID, params types
 
 	totalCount, err := countQuery.Count(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListMachinesByOrganizationID: %v", err), ctxStr)
 		return nil, 0, err
 	}
 
@@ -116,6 +123,7 @@ func (s *ListStorage) ListMachinesByOrganizationID(orgID uuid.UUID, params types
 
 	var sshKeys []shared_types.SSHKey
 	if err = query.Scan(s.Ctx, &sshKeys); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListMachinesByOrganizationID scan ssh_keys: %v", err), ctxStr)
 		return nil, 0, err
 	}
 
@@ -134,6 +142,7 @@ func (s *ListStorage) ListMachinesByOrganizationID(orgID uuid.UUID, params types
 		Where("ssh_key_id IN (?)", bun.In(sshKeyIDs)).
 		Where("organization_id = ?", orgID).
 		Scan(s.Ctx); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListMachinesByOrganizationID provision details: %v", err), ctxStr)
 		return nil, 0, err
 	}
 
@@ -161,6 +170,7 @@ func (s *ListStorage) ListMachinesByOrganizationID(orgID uuid.UUID, params types
 		Where("organization_id = ?", orgID).
 		GroupExpr("ssh_key_id").
 		Scan(s.Ctx, &aggregates); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListMachinesByOrganizationID aggregates: %v", err), ctxStr)
 		return nil, 0, err
 	}
 
@@ -187,6 +197,9 @@ func (s *ListStorage) ListMachinesByOrganizationID(orgID uuid.UUID, params types
 }
 
 func (s *ListStorage) GetMachineByIDAndOrgID(machineID uuid.UUID, orgID uuid.UUID) (*shared_types.SSHKey, error) {
+	ctxStr := fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID)
+	storageLog(s.Logger, logger.Debug, "storage: GetMachineByIDAndOrgID", ctxStr)
+
 	var key shared_types.SSHKey
 	err := s.getDB().NewSelect().
 		Model(&key).
@@ -195,14 +208,23 @@ func (s *ListStorage) GetMachineByIDAndOrgID(machineID uuid.UUID, orgID uuid.UUI
 		Where("deleted_at IS NULL").
 		Scan(s.Ctx)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetMachineByIDAndOrgID not found", ctxStr)
+		} else {
+			storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetMachineByIDAndOrgID: %v", err), ctxStr)
+		}
 		return nil, err
 	}
 	return &key, nil
 }
 
 func (s *ListStorage) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*uuid.UUID, error) {
+	ctxStr := fmt.Sprintf("org_id=%s machine_id=%s", orgID, machineID)
+	storageLog(s.Logger, logger.Debug, "storage: SetDefaultMachine", ctxStr)
+
 	tx, err := s.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: SetDefaultMachine begin tx: %v", err), ctxStr)
 		return nil, err
 	}
 	defer tx.Rollback()
@@ -217,6 +239,7 @@ func (s *ListStorage) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*
 		Where("deleted_at IS NULL").
 		Scan(s.Ctx)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: SetDefaultMachine read old default: %v", err), ctxStr)
 		return nil, err
 	}
 	if err == nil {
@@ -233,9 +256,11 @@ func (s *ListStorage) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*
 		Where("deleted_at IS NULL").
 		Scan(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Debug, "storage: SetDefaultMachine target not found", ctxStr)
 		return nil, types.ErrMachineNotFound
 	}
 	if !target.IsActive {
+		storageLog(s.Logger, logger.Debug, "storage: SetDefaultMachine target inactive", ctxStr)
 		return nil, types.ErrMachineInactive
 	}
 
@@ -247,6 +272,7 @@ func (s *ListStorage) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*
 		Where("is_default = ?", true).
 		Exec(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: SetDefaultMachine clear old default: %v", err), ctxStr)
 		return nil, err
 	}
 
@@ -257,6 +283,7 @@ func (s *ListStorage) SetDefaultMachine(orgID uuid.UUID, machineID uuid.UUID) (*
 		Where("id = ?", machineID).
 		Exec(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: SetDefaultMachine set default: %v", err), ctxStr)
 		return nil, err
 	}
 

--- a/api/internal/features/machine/storage/log.go
+++ b/api/internal/features/machine/storage/log.go
@@ -1,0 +1,13 @@
+package storage
+
+import (
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+// storageLog writes only when l is non-nil (optional storage instrumentation).
+func storageLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}

--- a/api/internal/features/machine/storage/registration.go
+++ b/api/internal/features/machine/storage/registration.go
@@ -2,16 +2,21 @@ package storage
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	api_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type RegistrationStorage struct {
-	db  *bun.DB
-	ctx context.Context
+	db     *bun.DB
+	ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 func NewRegistrationStorage(db *bun.DB, ctx context.Context) *RegistrationStorage {
@@ -41,7 +46,12 @@ func (s *RegistrationStorage) HostPortExists(orgID uuid.UUID, host string, port 
 }
 
 func (s *RegistrationStorage) InsertSSHKey(key *api_types.SSHKey) error {
+	ctxStr := fmt.Sprintf("org_id=%s ssh_key_id=%s", key.OrganizationID, key.ID)
+	storageLog(s.Logger, logger.Debug, "storage: InsertSSHKey", ctxStr)
 	_, err := s.db.NewInsert().Model(key).Exec(s.ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: InsertSSHKey: %v", err), ctxStr)
+	}
 	return err
 }
 
@@ -83,6 +93,9 @@ func (s *RegistrationStorage) InsertProvisionDetailsTx(tx bun.Tx, userID, orgID,
 }
 
 func (s *RegistrationStorage) GetSSHKeyByID(id, orgID uuid.UUID) (*api_types.SSHKey, error) {
+	ctxStr := fmt.Sprintf("org_id=%s machine_id=%s", orgID, id)
+	storageLog(s.Logger, logger.Debug, "storage: GetSSHKeyByID", ctxStr)
+
 	var key api_types.SSHKey
 	err := s.db.NewSelect().
 		Model(&key).
@@ -91,6 +104,11 @@ func (s *RegistrationStorage) GetSSHKeyByID(id, orgID uuid.UUID) (*api_types.SSH
 		Where("deleted_at IS NULL").
 		Scan(s.ctx)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetSSHKeyByID not found", ctxStr)
+		} else {
+			storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetSSHKeyByID: %v", err), ctxStr)
+		}
 		return nil, err
 	}
 	return &key, nil
@@ -120,6 +138,8 @@ func (s *RegistrationStorage) HasActiveAppServers(sshKeyID uuid.UUID) (bool, err
 }
 
 func (s *RegistrationStorage) SoftDeleteSSHKey(id uuid.UUID) error {
+	ctxStr := fmt.Sprintf("ssh_key_id=%s", id)
+	storageLog(s.Logger, logger.Debug, "storage: SoftDeleteSSHKey", ctxStr)
 	_, err := s.db.NewUpdate().
 		Model((*api_types.SSHKey)(nil)).
 		Set("deleted_at = ?", time.Now()).
@@ -127,6 +147,9 @@ func (s *RegistrationStorage) SoftDeleteSSHKey(id uuid.UUID) error {
 		Where("id = ?", id).
 		Where("deleted_at IS NULL").
 		Exec(s.ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: SoftDeleteSSHKey: %v", err), ctxStr)
+	}
 	return err
 }
 
@@ -201,6 +224,9 @@ func (s *RegistrationStorage) GetProvisionDetailsBySSHKeyID(sshKeyID uuid.UUID) 
 }
 
 func (s *RegistrationStorage) GetMachineIsActive(serverID uuid.UUID) (bool, error) {
+	ctxStr := fmt.Sprintf("server_id=%s", serverID)
+	storageLog(s.Logger, logger.Debug, "storage: GetMachineIsActive", ctxStr)
+
 	var key api_types.SSHKey
 	err := s.db.NewSelect().
 		Model(&key).
@@ -210,12 +236,19 @@ func (s *RegistrationStorage) GetMachineIsActive(serverID uuid.UUID) (bool, erro
 		Limit(1).
 		Scan(s.ctx)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetMachineIsActive not found", ctxStr)
+		} else {
+			storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetMachineIsActive: %v", err), ctxStr)
+		}
 		return false, err
 	}
 	return key.IsActive, nil
 }
 
 func (s *RegistrationStorage) SetMachineActive(serverID uuid.UUID, active bool) error {
+	ctxStr := fmt.Sprintf("server_id=%s active=%t", serverID, active)
+	storageLog(s.Logger, logger.Debug, "storage: SetMachineActive", ctxStr)
 	_, err := s.db.NewUpdate().
 		Model((*api_types.SSHKey)(nil)).
 		Set("is_active = ?", active).
@@ -223,10 +256,15 @@ func (s *RegistrationStorage) SetMachineActive(serverID uuid.UUID, active bool) 
 		Where("id = ?", serverID).
 		Where("deleted_at IS NULL").
 		Exec(s.ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: SetMachineActive: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s *RegistrationStorage) UpdateMachineName(id uuid.UUID, name string) error {
+	ctxStr := fmt.Sprintf("machine_id=%s", id)
+	storageLog(s.Logger, logger.Debug, "storage: UpdateMachineName", ctxStr)
 	_, err := s.db.NewUpdate().
 		Model((*api_types.SSHKey)(nil)).
 		Set("name = ?", name).
@@ -234,6 +272,9 @@ func (s *RegistrationStorage) UpdateMachineName(id uuid.UUID, name string) error
 		Where("id = ?", id).
 		Where("deleted_at IS NULL").
 		Exec(s.ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: UpdateMachineName: %v", err), ctxStr)
+	}
 	return err
 }
 

--- a/api/internal/features/machine/storage/trial.go
+++ b/api/internal/features/machine/storage/trial.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	machine_types "github.com/nixopus/nixopus/api/internal/features/machine/types"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
@@ -32,8 +33,9 @@ type TrailRepository interface {
 
 // TrailStorage implements TrailRepository using Bun ORM.
 type TrailStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 // NewTrailStorage creates a new TrailStorage instance.
@@ -45,6 +47,9 @@ func NewTrailStorage(db *bun.DB, ctx context.Context) *TrailStorage {
 }
 
 func (s *TrailStorage) GetActiveProvisionByUserAndOrg(userID, orgID string) (*shared_types.UserProvisionDetails, error) {
+	ctxStr := fmt.Sprintf("user_id=%s org_id=%s", userID, orgID)
+	storageLog(s.Logger, logger.Debug, "storage: GetActiveProvisionByUserAndOrg", ctxStr)
+
 	var provision shared_types.UserProvisionDetails
 
 	err := s.DB.NewSelect().
@@ -57,8 +62,10 @@ func (s *TrailStorage) GetActiveProvisionByUserAndOrg(userID, orgID string) (*sh
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetActiveProvisionByUserAndOrg not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetActiveProvisionByUserAndOrg: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get active provision: %w", err)
 	}
 
@@ -66,12 +73,15 @@ func (s *TrailStorage) GetActiveProvisionByUserAndOrg(userID, orgID string) (*sh
 }
 
 func (s *TrailStorage) CountActiveProvisions() (int, error) {
+	storageLog(s.Logger, logger.Debug, "storage: CountActiveProvisions", "")
+
 	count, err := s.DB.NewSelect().
 		Model((*shared_types.UserProvisionDetails)(nil)).
 		Where("step IS NOT NULL AND step != ?", shared_types.ProvisionStepCompleted).
 		Count(s.Ctx)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: CountActiveProvisions: %v", err), "")
 		return 0, fmt.Errorf("failed to count active provisions: %w", err)
 	}
 
@@ -79,21 +89,33 @@ func (s *TrailStorage) CountActiveProvisions() (int, error) {
 }
 
 func (s *TrailStorage) CreateActiveUserProvision(details *shared_types.UserProvisionDetails) error {
+	ctxStr := fmt.Sprintf("user_id=%s org_id=%s", details.UserID, details.OrganizationID)
+	storageLog(s.Logger, logger.Debug, "storage: CreateActiveUserProvision", ctxStr)
+
 	tx, err := s.DB.BeginTx(s.Ctx, nil)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: CreateActiveUserProvision begin tx: %v", err), ctxStr)
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback()
 
 	_, err = tx.NewInsert().Model(details).Exec(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: CreateActiveUserProvision insert: %v", err), ctxStr)
 		return fmt.Errorf("failed to create provision: %w", err)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: CreateActiveUserProvision commit: %v", err), ctxStr)
+		return err
+	}
+	return nil
 }
 
 func (s *TrailStorage) GetUserProvisionDetailsByID(sessionID string) (*shared_types.UserProvisionDetails, error) {
+	ctxStr := fmt.Sprintf("session_id=%s", sessionID)
+	storageLog(s.Logger, logger.Debug, "storage: GetUserProvisionDetailsByID", ctxStr)
+
 	var provision shared_types.UserProvisionDetails
 
 	err := s.DB.NewSelect().
@@ -103,8 +125,10 @@ func (s *TrailStorage) GetUserProvisionDetailsByID(sessionID string) (*shared_ty
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetUserProvisionDetailsByID not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetUserProvisionDetailsByID: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to get provision details: %w", err)
 	}
 

--- a/api/internal/features/machine/validation/trial.go
+++ b/api/internal/features/machine/validation/trial.go
@@ -1,15 +1,32 @@
 package validation
 
 import (
+	"fmt"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	machine_types "github.com/nixopus/nixopus/api/internal/features/machine/types"
 )
 
 // Validator handles validation for trial requests.
-type Validator struct{}
+type Validator struct {
+	Logger *logger.Logger // optional; nil disables validation logs
+}
 
 // NewValidator creates a new Validator instance.
 func NewValidator() *Validator {
-	return &Validator{}
+	return NewValidatorWithLogger(nil)
+}
+
+// NewValidatorWithLogger creates a Validator with optional structured logging.
+func NewValidatorWithLogger(l *logger.Logger) *Validator {
+	return &Validator{Logger: l}
+}
+
+func (v *Validator) valog(sev logger.Severity, msg, data string) {
+	if v.Logger == nil {
+		return
+	}
+	v.Logger.Log(sev, msg, data)
 }
 
 // ValidateRequest validates request objects using type switch.
@@ -18,6 +35,7 @@ func (v *Validator) ValidateRequest(req interface{}) error {
 	case *machine_types.ProvisionRequest:
 		return v.validateProvisionRequest(*r)
 	default:
+		v.valog(logger.Debug, fmt.Sprintf("machine trial validation: invalid type %T", req), "")
 		return machine_types.ErrInvalidRequestType
 	}
 }

--- a/api/internal/features/mcp/controller/add_server.go
+++ b/api/internal/features/mcp/controller/add_server.go
@@ -1,9 +1,11 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/service"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/validation"
@@ -15,17 +17,24 @@ func (c *MCPController) AddServer(f fuego.ContextWithBody[validation.CreateServe
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("AddServer", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("AddServer", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMCPDebug("AddServer", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if err := validation.ValidateCreateRequest(&body); err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("mcp: AddServer validation: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -34,7 +43,7 @@ func (c *MCPController) AddServer(f fuego.ContextWithBody[validation.CreateServe
 		if err == service.ErrDuplicateName {
 			return nil, fuego.ConflictError{Detail: err.Error(), Err: err}
 		}
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: AddServer: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 

--- a/api/internal/features/mcp/controller/call_tool.go
+++ b/api/internal/features/mcp/controller/call_tool.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -19,33 +21,46 @@ func (c *MCPController) CallTool(f fuego.ContextWithBody[validation.CallToolRequ
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("CallTool", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
+	}
+
+	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("CallTool", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
 	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMCPDebug("CallTool", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if err := validation.ValidateCallToolRequest(&body); err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("mcp: CallTool validation: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	serverID, err := uuid.Parse(body.ServerID)
 	if err != nil {
+		c.logMCPDebug("CallTool", "invalid server_id", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "invalid server_id format"}
 	}
 
-	orgID := utils.GetOrganizationID(r)
-
 	srv, err := c.service.GetServerByID(serverID, orgID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
-		return nil, fuego.NotFoundError{Detail: "server not found", Err: err}
+		if errors.Is(err, service.ErrServerNotFound) {
+			c.logMCPDebug("CallTool", "server not found", fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, serverID))
+			return nil, fuego.NotFoundError{Detail: err.Error(), Err: err}
+		}
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: CallTool GetServer: %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, serverID))
+		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 
 	provider := mcp.GetProvider(srv.ProviderID)
 	if provider == nil {
+		c.logger.Log(logger.Error, "mcp: CallTool unknown provider", fmt.Sprintf("org_id=%s server_id=%s provider_id=%s", orgID, serverID, srv.ProviderID))
 		return nil, fuego.HTTPError{Detail: "unknown provider", Status: http.StatusInternalServerError}
 	}
 
@@ -62,7 +77,7 @@ func (c *MCPController) CallTool(f fuego.ContextWithBody[validation.CallToolRequ
 		Arguments: body.Arguments,
 	})
 	if err != nil {
-		c.logger.Log(logger.Warning, "tool call failed: "+err.Error(), body.ToolName)
+		c.logger.Log(logger.Warning, fmt.Sprintf("mcp: CallTool execution failed: %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s tool_name=%s", orgID, user.ID, serverID, body.ToolName))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusBadGateway}
 	}
 

--- a/api/internal/features/mcp/controller/delete_server.go
+++ b/api/internal/features/mcp/controller/delete_server.go
@@ -1,9 +1,11 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/service"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -18,17 +20,24 @@ func (c *MCPController) DeleteServer(f fuego.ContextWithBody[DeleteServerRequest
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("DeleteServer", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("DeleteServer", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMCPDebug("DeleteServer", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if body.ID == "" {
+		c.logMCPDebug("DeleteServer", "server ID required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server ID is required"}
 	}
 
@@ -36,7 +45,7 @@ func (c *MCPController) DeleteServer(f fuego.ContextWithBody[DeleteServerRequest
 		if err == service.ErrServerNotFound {
 			return nil, fuego.NotFoundError{Detail: err.Error(), Err: err}
 		}
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: DeleteServer: %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, body.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 

--- a/api/internal/features/mcp/controller/get_provider_icon.go
+++ b/api/internal/features/mcp/controller/get_provider_icon.go
@@ -11,11 +11,13 @@ import (
 func (c *MCPController) GetProviderIcon(f fuego.ContextNoBody) (any, error) {
 	providerID := f.PathParam("provider_id")
 	if mcp.GetProvider(providerID) == nil {
+		c.logMCPDebug("GetProviderIcon", "unknown provider", fmt.Sprintf("provider_id=%s", providerID))
 		return nil, fuego.NotFoundError{Detail: "provider not found"}
 	}
 
 	data, err := mcp.IconFS.ReadFile(fmt.Sprintf("icons/%s.svg", providerID))
 	if err != nil {
+		c.logMCPDebug("GetProviderIcon", "icon file missing", fmt.Sprintf("provider_id=%s", providerID))
 		return nil, fuego.NotFoundError{Detail: "icon not found"}
 	}
 

--- a/api/internal/features/mcp/controller/init.go
+++ b/api/internal/features/mcp/controller/init.go
@@ -26,7 +26,7 @@ type Response struct {
 }
 
 func NewMCPController(store *shared_storage.Store, ctx context.Context, l logger.Logger) *MCPController {
-	repo := storage.MCPStorage{DB: store.DB, Ctx: ctx}
+	repo := storage.MCPStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	svc := service.NewMCPService(store, ctx, l, repo)
 	return &MCPController{store: store, service: svc, ctx: ctx, logger: l}
 }

--- a/api/internal/features/mcp/controller/list_servers.go
+++ b/api/internal/features/mcp/controller/list_servers.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/storage"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -15,10 +17,16 @@ func (c *MCPController) ListServers(f fuego.ContextNoBody) (*Response, error) {
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("ListServers", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("ListServers", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
+
 	q := r.URL.Query()
 
 	page, _ := strconv.Atoi(q.Get("page"))
@@ -40,7 +48,7 @@ func (c *MCPController) ListServers(f fuego.ContextNoBody) (*Response, error) {
 
 	servers, totalCount, err := c.service.ListServers(orgID, params)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: ListServers: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 
@@ -66,14 +74,19 @@ func (c *MCPController) ListServersInternal(f fuego.ContextNoBody) (*Response, e
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("ListServersInternal", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("ListServersInternal", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
 
 	servers, _, err := c.service.ListServers(orgID, storage.ListServersParams{EnabledOnly: true})
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: ListServersInternal: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 

--- a/api/internal/features/mcp/controller/list_tools.go
+++ b/api/internal/features/mcp/controller/list_tools.go
@@ -2,11 +2,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	mcp "github.com/nixopus/nixopus/api/internal/features/mcp"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/service"
@@ -22,14 +24,19 @@ func (c *MCPController) ListTools(f fuego.ContextNoBody) (*Response, error) {
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("ListTools", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("ListTools", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
 
 	servers, _, err := c.service.ListServers(orgID, storage.ListServersParams{EnabledOnly: true})
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: ListTools list servers: %v", err), fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 
@@ -65,7 +72,7 @@ func (c *MCPController) ListTools(f fuego.ContextNoBody) (*Response, error) {
 
 			tools, err := service.DiscoverServerTools(ctx, provider, customURL, srv.Credentials)
 			if err != nil {
-				c.logger.Log(logger.Warning, "tool discovery failed for "+srv.Name, err.Error())
+				c.logger.Log(logger.Warning, fmt.Sprintf("mcp: ListTools discovery failed for server: %v", err), fmt.Sprintf("org_id=%s server_id=%s server_name=%s", orgID, srv.ID, srv.Name))
 				results[i].Error = err.Error()
 				return
 			}

--- a/api/internal/features/mcp/controller/mcp_log.go
+++ b/api/internal/features/mcp/controller/mcp_log.go
@@ -1,0 +1,11 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func (c *MCPController) logMCPDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("mcp: %s: %s", handler, reason), data)
+}

--- a/api/internal/features/mcp/controller/test_server.go
+++ b/api/internal/features/mcp/controller/test_server.go
@@ -1,17 +1,22 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/validation"
 )
 
 func (c *MCPController) TestServer(f fuego.ContextWithBody[validation.TestServerRequest]) (*Response, error) {
 	body, err := f.Body()
 	if err != nil {
+		c.logMCPDebug("TestServer", "invalid body", "")
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	if err := validation.ValidateTestRequest(&body); err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("mcp: TestServer validation: %v", err), fmt.Sprintf("provider_id=%s", body.ProviderID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 

--- a/api/internal/features/mcp/controller/update_server.go
+++ b/api/internal/features/mcp/controller/update_server.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -16,25 +17,34 @@ func (c *MCPController) UpdateServer(f fuego.ContextWithBody[validation.UpdateSe
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logMCPDebug("UpdateServer", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
 	orgID := utils.GetOrganizationID(r)
+	if orgID == uuid.Nil {
+		c.logMCPDebug("UpdateServer", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
+		return nil, fuego.BadRequestError{Detail: "organization ID is required"}
+	}
 
 	body, err := f.Body()
 	if err != nil {
+		c.logMCPDebug("UpdateServer", "invalid body", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	body.ID = f.PathParam("id")
 	if body.ID == "" {
+		c.logMCPDebug("UpdateServer", "server ID required", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server ID is required"}
 	}
 	if _, err := uuid.Parse(body.ID); err != nil {
+		c.logMCPDebug("UpdateServer", "invalid server UUID", fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID))
 		return nil, fuego.BadRequestError{Detail: "server ID must be a valid UUID"}
 	}
 
 	if err := validation.ValidateUpdateRequest(&body); err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("mcp: UpdateServer validation: %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, body.ID))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
@@ -43,7 +53,7 @@ func (c *MCPController) UpdateServer(f fuego.ContextWithBody[validation.UpdateSe
 		if err == service.ErrServerNotFound {
 			return nil, fuego.NotFoundError{Detail: err.Error(), Err: err}
 		}
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("mcp: UpdateServer: %v", err), fmt.Sprintf("org_id=%s user_id=%s server_id=%s", orgID, user.ID, body.ID))
 		return nil, fuego.HTTPError{Err: err, Detail: err.Error(), Status: http.StatusInternalServerError}
 	}
 

--- a/api/internal/features/mcp/service/add_server.go
+++ b/api/internal/features/mcp/service/add_server.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,7 +11,7 @@ import (
 )
 
 func (s *MCPService) AddServer(req *validation.CreateServerRequest, orgID, userID uuid.UUID) (*shared_types.MCPServer, error) {
-	s.logger.Log(logger.Info, "Adding MCP server", req.Name)
+	s.logger.Log(logger.Info, "mcp service: AddServer", fmt.Sprintf("org_id=%s user_id=%s provider_id=%s name=%s", orgID, userID, req.ProviderID, req.Name))
 
 	existing, err := s.storage.GetServerByName(orgID, req.Name)
 	if err != nil {

--- a/api/internal/features/mcp/service/delete_server.go
+++ b/api/internal/features/mcp/service/delete_server.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 func (s *MCPService) DeleteServer(id string, orgID uuid.UUID) error {
-	s.logger.Log(logger.Info, "Deleting MCP server", id)
+	s.logger.Log(logger.Info, "mcp service: DeleteServer", fmt.Sprintf("org_id=%s server_id=%s", orgID, id))
 
 	serverID, err := uuid.Parse(id)
 	if err != nil {

--- a/api/internal/features/mcp/service/list_servers.go
+++ b/api/internal/features/mcp/service/list_servers.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/mcp/storage"
@@ -8,6 +10,6 @@ import (
 )
 
 func (s *MCPService) ListServers(orgID uuid.UUID, params storage.ListServersParams) ([]shared_types.MCPServer, int, error) {
-	s.logger.Log(logger.Info, "Listing MCP servers", orgID.String())
+	s.logger.Log(logger.Info, "mcp service: ListServers", fmt.Sprintf("org_id=%s enabled_only=%t page=%d limit=%d", orgID, params.EnabledOnly, params.Page, params.Limit))
 	return s.storage.ListServers(orgID, params)
 }

--- a/api/internal/features/mcp/service/test_server.go
+++ b/api/internal/features/mcp/service/test_server.go
@@ -21,7 +21,7 @@ type TestResult struct {
 }
 
 func (s *MCPService) TestServer(req *validation.TestServerRequest) *TestResult {
-	s.logger.Log(logger.Info, "Testing MCP server connection", req.ProviderID)
+	s.logger.Log(logger.Info, "mcp service: TestServer", fmt.Sprintf("provider_id=%s", req.ProviderID))
 
 	provider := mcp.GetProvider(req.ProviderID)
 	if provider == nil {

--- a/api/internal/features/mcp/service/update_server.go
+++ b/api/internal/features/mcp/service/update_server.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,7 +11,7 @@ import (
 )
 
 func (s *MCPService) UpdateServer(req *validation.UpdateServerRequest, orgID uuid.UUID) (*shared_types.MCPServer, error) {
-	s.logger.Log(logger.Info, "Updating MCP server", req.ID)
+	s.logger.Log(logger.Info, "mcp service: UpdateServer", fmt.Sprintf("org_id=%s server_id=%s", orgID, req.ID))
 
 	id, err := uuid.Parse(req.ID)
 	if err != nil {

--- a/api/internal/features/mcp/storage/init.go
+++ b/api/internal/features/mcp/storage/init.go
@@ -3,16 +3,19 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type MCPStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 // ListServersParams controls filtering, sorting, and pagination for ListServers.
@@ -36,11 +39,19 @@ type MCPRepository interface {
 }
 
 func (s MCPStorage) CreateServer(server *shared_types.MCPServer) error {
+	ctxStr := fmt.Sprintf("org_id=%s server_id=%s", server.OrgID, server.ID)
+	storageLog(s.Logger, logger.Debug, "storage: CreateServer", ctxStr)
 	_, err := s.DB.NewInsert().Model(server).Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: CreateServer: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s MCPStorage) ListServers(orgID uuid.UUID, params ListServersParams) ([]shared_types.MCPServer, int, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", orgID)
+	storageLog(s.Logger, logger.Debug, "storage: ListServers", ctxStr)
+
 	var servers []shared_types.MCPServer
 
 	allowedSort := map[string]bool{"name": true, "created_at": true, "provider_id": true}
@@ -64,6 +75,7 @@ func (s MCPStorage) ListServers(orgID uuid.UUID, params ListServersParams) ([]sh
 	}
 	totalCount, err := countQ.Count(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListServers count: %v", err), ctxStr)
 		return nil, 0, err
 	}
 
@@ -88,56 +100,78 @@ func (s MCPStorage) ListServers(orgID uuid.UUID, params ListServersParams) ([]sh
 
 	err = dataQ.Scan(s.Ctx)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: ListServers no rows", ctxStr)
 			return []shared_types.MCPServer{}, totalCount, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: ListServers scan: %v", err), ctxStr)
 		return nil, 0, err
 	}
 	return servers, totalCount, nil
 }
 
 func (s MCPStorage) GetServerByID(id uuid.UUID) (*shared_types.MCPServer, error) {
+	ctxStr := fmt.Sprintf("server_id=%s", id)
+	storageLog(s.Logger, logger.Debug, "storage: GetServerByID", ctxStr)
+
 	server := &shared_types.MCPServer{}
 	err := s.DB.NewSelect().Model(server).
 		Where("ms.id = ? AND ms.deleted_at IS NULL", id).
 		Scan(s.Ctx)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetServerByID not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetServerByID: %v", err), ctxStr)
 		return nil, err
 	}
 	return server, nil
 }
 
 func (s MCPStorage) GetServerByName(orgID uuid.UUID, name string) (*shared_types.MCPServer, error) {
+	ctxStr := fmt.Sprintf("org_id=%s name=%s", orgID, name)
+	storageLog(s.Logger, logger.Debug, "storage: GetServerByName", ctxStr)
+
 	server := &shared_types.MCPServer{}
 	err := s.DB.NewSelect().Model(server).
 		Where("ms.org_id = ? AND ms.name = ? AND ms.deleted_at IS NULL", orgID, name).
 		Scan(s.Ctx)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
+			storageLog(s.Logger, logger.Debug, "storage: GetServerByName not found", ctxStr)
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: GetServerByName: %v", err), ctxStr)
 		return nil, err
 	}
 	return server, nil
 }
 
 func (s MCPStorage) UpdateServer(server *shared_types.MCPServer) error {
+	ctxStr := fmt.Sprintf("server_id=%s org_id=%s", server.ID, server.OrgID)
+	storageLog(s.Logger, logger.Debug, "storage: UpdateServer", ctxStr)
 	_, err := s.DB.NewUpdate().Model(server).
 		Column("name", "credentials", "custom_url", "enabled", "updated_at").
 		Where("id = ? AND deleted_at IS NULL", server.ID).
 		Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: UpdateServer: %v", err), ctxStr)
+	}
 	return err
 }
 
 func (s MCPStorage) DeleteServer(id uuid.UUID) error {
+	ctxStr := fmt.Sprintf("server_id=%s", id)
+	storageLog(s.Logger, logger.Debug, "storage: DeleteServer (soft)", ctxStr)
 	_, err := s.DB.NewUpdate().
 		Model((*shared_types.MCPServer)(nil)).
 		Set("deleted_at = NOW()").
 		Set("updated_at = NOW()").
 		Where("id = ? AND deleted_at IS NULL", id).
 		Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("storage: DeleteServer: %v", err), ctxStr)
+	}
 	return err
 }

--- a/api/internal/features/mcp/storage/log.go
+++ b/api/internal/features/mcp/storage/log.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func storageLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}

--- a/api/internal/features/notification/controller/add_smtp.go
+++ b/api/internal/features/notification/controller/add_smtp.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -22,15 +23,18 @@ func (c *NotificationController) AddSmtp(f fuego.ContextWithBody[notification.Cr
 
 	user := utils.GetUser(w, r)
 	if user == nil {
-		c.logger.Log(logger.Error, "User authentication failed", "")
+		c.logNotificationDebug("AddSmtp", "authentication required", notificationRequestLogData(r, nil))
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s", SMTPConfigs.OrganizationID, user.ID)
+	c.logger.Log(logger.Info, "notification: AddSmtp", ctxStr)
+
 	err := c.service.AddSmtp(SMTPConfigs, user.ID)
 	if err != nil {
-		c.logger.Log(logger.Error, "Failed to add SMTP config", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: AddSmtp: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/create_webhook.go
+++ b/api/internal/features/notification/controller/create_webhook.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -13,6 +15,7 @@ import (
 func (c *NotificationController) CreateWebhookConfig(f fuego.ContextWithBody[notification.CreateWebhookConfigRequest]) (*types.WebhookConfigResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logNotificationDebug("CreateWebhookConfig", "body decode", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -21,6 +24,7 @@ func (c *NotificationController) CreateWebhookConfig(f fuego.ContextWithBody[not
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logNotificationDebug("CreateWebhookConfig", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -28,13 +32,18 @@ func (c *NotificationController) CreateWebhookConfig(f fuego.ContextWithBody[not
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logNotificationDebug("CreateWebhookConfig", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s webhook_type=%s", orgID, user.ID, req.Type)
+	c.logger.Log(logger.Info, "notification: CreateWebhookConfig", ctxStr)
+
 	config, err := c.service.CreateWebhookConfig(f, &req, user.ID, orgID)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: CreateWebhookConfig: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/delete_smtp.go
+++ b/api/internal/features/notification/controller/delete_smtp.go
@@ -1,13 +1,16 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
 )
 
 func (c *NotificationController) DeleteSmtp(f fuego.ContextWithBody[notification.DeleteSMTPConfigRequest]) (*types.MessageResponse, error) {
@@ -20,9 +23,19 @@ func (c *NotificationController) DeleteSmtp(f fuego.ContextWithBody[notification
 		}
 	}
 
+	ctxStr := notificationRequestLogData(r, utils.GetUser(w, r))
+	if SMTPConfigs.ID != uuid.Nil {
+		if ctxStr != "" {
+			ctxStr = fmt.Sprintf("%s smtp_config_id=%s", ctxStr, SMTPConfigs.ID)
+		} else {
+			ctxStr = fmt.Sprintf("smtp_config_id=%s", SMTPConfigs.ID)
+		}
+	}
+	c.logger.Log(logger.Info, "notification: DeleteSmtp", ctxStr)
+
 	err := c.service.DeleteSmtp(SMTPConfigs.ID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: DeleteSmtp: %v", err), ctxStr)
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound

--- a/api/internal/features/notification/controller/delete_webhook.go
+++ b/api/internal/features/notification/controller/delete_webhook.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -13,6 +15,7 @@ import (
 func (c *NotificationController) DeleteWebhookConfig(f fuego.ContextWithBody[notification.DeleteWebhookConfigRequest]) (*types.MessageResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logNotificationDebug("DeleteWebhookConfig", "body decode", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -21,13 +24,18 @@ func (c *NotificationController) DeleteWebhookConfig(f fuego.ContextWithBody[not
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logNotificationDebug("DeleteWebhookConfig", "organization ID required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s webhook_type=%s", orgID, req.Type)
+	c.logger.Log(logger.Info, "notification: DeleteWebhookConfig", ctxStr)
+
 	err = c.service.DeleteWebhookConfig(f, &req, orgID)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: DeleteWebhookConfig: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/get_preferences.go
+++ b/api/internal/features/notification/controller/get_preferences.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -14,14 +15,18 @@ func (c *NotificationController) GetPreferences(f fuego.ContextNoBody) (*types.P
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logNotificationDebug("GetPreferences", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s", user.ID)
+	c.logger.Log(logger.Info, "notification: GetPreferences", ctxStr)
+
 	preferences, err := c.service.GetPreferences(user.ID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: GetPreferences: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/get_smtp.go
+++ b/api/internal/features/notification/controller/get_smtp.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,6 +16,7 @@ import (
 func (c *NotificationController) GetSmtp(f fuego.ContextNoBody) (*types.SMTPConfigResponse, error) {
 	id := f.QueryParam("id")
 	if id == "" {
+		c.logNotificationDebug("GetSmtp", "missing query id", "")
 		return nil, fuego.BadRequestError{
 			Detail: notification.ErrMissingID.Error(),
 			Err:    notification.ErrMissingID,
@@ -24,6 +26,7 @@ func (c *NotificationController) GetSmtp(f fuego.ContextNoBody) (*types.SMTPConf
 	w, r := f.Response(), f.Request()
 	user := utils.GetUser(w, r)
 	if user == nil {
+		c.logNotificationDebug("GetSmtp", "authentication required", fmt.Sprintf("org_param=%s", id))
 		return nil, fuego.UnauthorizedError{
 			Detail: notification.ErrAccessDenied.Error(),
 			Err:    notification.ErrAccessDenied,
@@ -34,12 +37,14 @@ func (c *NotificationController) GetSmtp(f fuego.ContextNoBody) (*types.SMTPConf
 	// Query param id must match the authenticated org to prevent cross-org access.
 	ctxOrg := utils.GetOrganizationID(r)
 	if ctxOrg == uuid.Nil {
+		c.logNotificationDebug("GetSmtp", "organization ID required", fmt.Sprintf("user_id=%s org_param=%s", user.ID, id))
 		return nil, fuego.ForbiddenError{
 			Detail: notification.ErrUserDoesNotBelongToOrganization.Error(),
 			Err:    notification.ErrUserDoesNotBelongToOrganization,
 		}
 	}
 	if ctxOrg.String() != id {
+		c.logNotificationDebug("GetSmtp", "organization context mismatch", fmt.Sprintf("user_id=%s ctx_org=%s org_param=%s", user.ID, ctxOrg, id))
 		return nil, fuego.ForbiddenError{
 			Detail: notification.ErrUserDoesNotBelongToOrganization.Error(),
 			Err:    notification.ErrUserDoesNotBelongToOrganization,
@@ -47,13 +52,16 @@ func (c *NotificationController) GetSmtp(f fuego.ContextNoBody) (*types.SMTPConf
 	}
 	orgID := id
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+	c.logger.Log(logger.Info, "notification: GetSmtp", ctxStr)
+
 	SMTPConfigs, err := c.service.GetSmtp(user.ID.String(), orgID)
 	if err != nil {
 		if errors.Is(err, notification.ErrSMTPConfigNotFound) {
 			return smtpNotFoundResp(), nil
 		}
 
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: GetSmtp: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/get_webhook.go
+++ b/api/internal/features/notification/controller/get_webhook.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -13,6 +15,7 @@ import (
 func (c *NotificationController) GetWebhookConfig(f fuego.ContextNoBody) (*types.WebhookConfigResponse, error) {
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logNotificationDebug("GetWebhookConfig", "organization ID required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -20,8 +23,12 @@ func (c *NotificationController) GetWebhookConfig(f fuego.ContextNoBody) (*types
 
 	webhookType := f.PathParam("type")
 
+	ctxStr := fmt.Sprintf("org_id=%s webhook_type=%s", orgID, webhookType)
+	c.logger.Log(logger.Info, "notification: GetWebhookConfig", ctxStr)
+
 	config, err := c.service.GetWebhookConfig(f, &notification.GetWebhookConfigRequest{Type: webhookType}, orgID)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: GetWebhookConfig: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/init.go
+++ b/api/internal/features/notification/controller/init.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/nixopus/nixopus/api/internal/features/notification/storage"
 	"github.com/nixopus/nixopus/api/internal/features/notification/validation"
 	shared_storage "github.com/nixopus/nixopus/api/internal/storage"
+	"github.com/nixopus/nixopus/api/internal/utils"
 )
 
 type NotificationController struct {
@@ -28,9 +30,9 @@ func NewNotificationController(
 	l logger.Logger,
 	dispatcher *notification.Dispatcher,
 ) *NotificationController {
-	s := storage.NotificationStorage{DB: store.DB, Ctx: ctx}
+	s := storage.NotificationStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	return &NotificationController{
-		validator:  validation.NewValidator(&s),
+		validator:  validation.NewValidatorWithLogger(&s, &l),
 		service:    service.NewNotificationService(store, ctx, l, &s),
 		ctx:        ctx,
 		logger:     l,
@@ -39,20 +41,22 @@ func NewNotificationController(
 }
 
 func (c *NotificationController) parseAndValidate(w http.ResponseWriter, r *http.Request, req interface{}) bool {
+	data := notificationRequestLogData(r, utils.GetUser(w, r))
+
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		c.logger.Log(logger.Error, "Failed to read request body", err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("notification: parseAndValidate: read body: %v", err), data)
 		return false
 	}
 	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	if err := c.validator.ParseRequestBody(r, io.NopCloser(bytes.NewBuffer(bodyBytes)), req); err != nil {
-		c.logger.Log(logger.Error, "Failed to decode request", err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("notification: parseAndValidate: decode JSON: %v", err), data)
 		return false
 	}
 
 	if err := c.validator.ValidateRequest(req); err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("notification: parseAndValidate: validation: %v", err), data)
 		return false
 	}
 

--- a/api/internal/features/notification/controller/notification_log.go
+++ b/api/internal/features/notification/controller/notification_log.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	"github.com/nixopus/nixopus/api/internal/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+)
+
+func (c *NotificationController) logNotificationDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("notification: %s: %s", handler, reason), data)
+}
+
+func notificationRequestLogData(r *http.Request, user *types.User) string {
+	orgID := utils.GetOrganizationID(r)
+	if user != nil && orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+	}
+	if user != nil {
+		return fmt.Sprintf("user_id=%s", user.ID)
+	}
+	if orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s", orgID)
+	}
+	return ""
+}

--- a/api/internal/features/notification/controller/send_notification.go
+++ b/api/internal/features/notification/controller/send_notification.go
@@ -1,8 +1,11 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -11,6 +14,7 @@ import (
 func (c *NotificationController) SendNotification(f fuego.ContextWithBody[notification.SendNotificationRequest]) (*types.SendNotificationResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logNotificationDebug("SendNotification", "body decode", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -19,6 +23,7 @@ func (c *NotificationController) SendNotification(f fuego.ContextWithBody[notifi
 
 	user := utils.GetUser(f.Response(), f.Request())
 	if user == nil {
+		c.logNotificationDebug("SendNotification", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
@@ -26,14 +31,19 @@ func (c *NotificationController) SendNotification(f fuego.ContextWithBody[notifi
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logNotificationDebug("SendNotification", "organization ID required", fmt.Sprintf("user_id=%s", user.ID))
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s channel=%s", orgID, user.ID, req.Channel)
+	c.logger.Log(logger.Info, "notification: SendNotification", ctxStr)
+
 	result := c.dispatcher.SendDirect(req, user.ID.String(), orgID.String())
 
 	if !result.Success {
+		c.logger.Log(logger.Warning, fmt.Sprintf("notification: SendNotification failed: %s", result.Error), ctxStr)
 		return &types.SendNotificationResponse{
 			Status:  "error",
 			Message: result.Error,

--- a/api/internal/features/notification/controller/update_preference.go
+++ b/api/internal/features/notification/controller/update_preference.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -45,14 +46,18 @@ func (c *NotificationController) UpdatePreference(f fuego.ContextWithBody[notifi
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logNotificationDebug("UpdatePreference", "authentication required", notificationRequestLogData(r, nil))
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("user_id=%s category=%s type=%s", user.ID, prefRequest.Category, prefRequest.Type)
+	c.logger.Log(logger.Info, "notification: UpdatePreference", ctxStr)
+
 	err = c.service.UpdatePreference(prefRequest, user.ID)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: UpdatePreference: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/update_smtp.go
+++ b/api/internal/features/notification/controller/update_smtp.go
@@ -3,13 +3,16 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
+	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
 )
 
 func (c *NotificationController) UpdateSmtp(f fuego.ContextWithBody[notification.UpdateSMTPConfigRequest]) (*types.MessageResponse, error) {
@@ -40,9 +43,20 @@ func (c *NotificationController) UpdateSmtp(f fuego.ContextWithBody[notification
 		}
 	}
 
+	user := utils.GetUser(w, r)
+	ctxStr := notificationRequestLogData(r, user)
+	if SMTPConfigs.ID != uuid.Nil {
+		if ctxStr != "" {
+			ctxStr = fmt.Sprintf("%s smtp_config_id=%s", ctxStr, SMTPConfigs.ID)
+		} else {
+			ctxStr = fmt.Sprintf("smtp_config_id=%s", SMTPConfigs.ID)
+		}
+	}
+	c.logger.Log(logger.Info, "notification: UpdateSmtp", ctxStr)
+
 	err = c.service.UpdateSmtp(SMTPConfigs)
 	if err != nil {
-		c.logger.Log(logger.Error, err.Error(), "")
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: UpdateSmtp: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/controller/update_webhook.go
+++ b/api/internal/features/notification/controller/update_webhook.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/controller/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -13,6 +15,7 @@ import (
 func (c *NotificationController) UpdateWebhookConfig(f fuego.ContextWithBody[notification.UpdateWebhookConfigRequest]) (*types.WebhookConfigResponse, error) {
 	req, err := f.Body()
 	if err != nil {
+		c.logNotificationDebug("UpdateWebhookConfig", "body decode", err.Error())
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -21,13 +24,18 @@ func (c *NotificationController) UpdateWebhookConfig(f fuego.ContextWithBody[not
 
 	orgID := utils.GetOrganizationID(f.Request())
 	if orgID == uuid.Nil {
+		c.logNotificationDebug("UpdateWebhookConfig", "organization ID required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("org_id=%s webhook_type=%s", orgID, req.Type)
+	c.logger.Log(logger.Info, "notification: UpdateWebhookConfig", ctxStr)
+
 	config, err := c.service.UpdateWebhookConfig(f, &req, orgID)
 	if err != nil {
+		c.logger.Log(logger.Error, fmt.Sprintf("notification: UpdateWebhookConfig: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/notification/dispatcher.go
+++ b/api/internal/features/notification/dispatcher.go
@@ -51,15 +51,17 @@ func (d *Dispatcher) SetupQueue() {
 // Emit processes a notification event: checks user preferences,
 // resolves which channels to use, and enqueues delivery tasks.
 func (d *Dispatcher) Emit(event shared_types.NotificationEvent) error {
+	evData := fmt.Sprintf("user_id=%s org_id=%s event_type=%s", event.UserID, event.OrganizationID, event.Type)
+
 	if !skipPreferenceCheck[event.Type] {
 		pref, ok := eventPreferenceMap[event.Type]
 		if ok {
 			shouldSend, err := d.prefManager.CheckUserNotificationPreferences(event.UserID, pref.Category, pref.Type)
 			if err != nil {
-				d.logger.Log(logger.Error, fmt.Sprintf("preference check failed for event %s: %s", event.Type, err.Error()), event.UserID)
+				d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: preference check failed: %v", err), evData)
 			}
 			if !shouldSend {
-				d.logger.Log(logger.Info, fmt.Sprintf("notification suppressed by preference for event %s", event.Type), event.UserID)
+				d.logger.Log(logger.Info, "notification dispatcher: suppressed by user preference", evData)
 				return nil
 			}
 		}
@@ -72,19 +74,19 @@ func (d *Dispatcher) Emit(event shared_types.NotificationEvent) error {
 
 	userEmail, err := d.resolveUserEmail(event.UserID)
 	if err != nil {
-		d.logger.Log(logger.Error, fmt.Sprintf("failed to resolve user email: %s", err.Error()), event.UserID)
+		d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: resolve user email: %v", err), evData)
 		userEmail = ""
 	}
 
 	var firstErr error
 	for _, chName := range targetChannels {
 		if _, ok := d.channels[chName]; !ok {
-			d.logger.Log(logger.Error, fmt.Sprintf("channel %s not registered, skipping", chName), "")
+			d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: channel %q not registered, skipping", chName), evData)
 			continue
 		}
 
 		if chName == "agent" && !d.isAgentEnabledForOrg(event.OrganizationID) {
-			d.logger.Log(logger.Info, fmt.Sprintf("agent channel disabled for org %s, skipping", event.OrganizationID), event.UserID)
+			d.logger.Log(logger.Info, fmt.Sprintf("notification dispatcher: agent channel disabled for org %s, skipping", event.OrganizationID), evData)
 			continue
 		}
 
@@ -96,7 +98,7 @@ func (d *Dispatcher) Emit(event shared_types.NotificationEvent) error {
 			UserID:         event.UserID,
 			Message:        msg,
 		}); err != nil {
-			d.logger.Log(logger.Error, fmt.Sprintf("failed to enqueue %s notification: %s", chName, err.Error()), event.UserID)
+			d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: enqueue %s failed: %v", chName, err), fmt.Sprintf("%s channel=%s", evData, chName))
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -110,7 +112,9 @@ func (d *Dispatcher) Emit(event shared_types.NotificationEvent) error {
 // or queue. Used by the /send API endpoint for explicit user-initiated sends.
 func (d *Dispatcher) SendDirect(req SendNotificationRequest, userID string, organizationID string) SendNotificationResponse {
 	ch, ok := d.channels[req.Channel]
+	ctxStr := fmt.Sprintf("user_id=%s org_id=%s channel=%s", userID, organizationID, req.Channel)
 	if !ok {
+		d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: SendDirect unsupported channel %q", req.Channel), ctxStr)
 		return SendNotificationResponse{
 			Channel: req.Channel,
 			Success: false,
@@ -122,6 +126,7 @@ func (d *Dispatcher) SendDirect(req SendNotificationRequest, userID string, orga
 	if recipient == "" && req.Channel == "email" {
 		email, err := d.resolveUserEmail(userID)
 		if err != nil {
+			d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: SendDirect resolve recipient: %v", err), ctxStr)
 			return SendNotificationResponse{
 				Channel: req.Channel,
 				Success: false,
@@ -144,6 +149,7 @@ func (d *Dispatcher) SendDirect(req SendNotificationRequest, userID string, orga
 	}
 
 	if err := ch.Send(d.ctx, msg); err != nil {
+		d.logger.Log(logger.Error, fmt.Sprintf("notification dispatcher: SendDirect send failed: %v", err), ctxStr)
 		return SendNotificationResponse{
 			Channel: req.Channel,
 			Success: false,

--- a/api/internal/features/notification/service/add_smtp.go
+++ b/api/internal/features/notification/service/add_smtp.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
@@ -14,7 +16,8 @@ import (
 // It calls s.storage.AddSmtp with the new config.
 // It returns an error if the storage operation fails.
 func (s *NotificationService) AddSmtp(SMTPConfigs notification.CreateSMTPConfigRequest, userID uuid.UUID) error {
-	s.logger.Log(logger.Info, "Adding SMTP configuration", "")
+	data := fmt.Sprintf("org_id=%s user_id=%s", SMTPConfigs.OrganizationID, userID)
+	s.logger.Log(logger.Info, "notification service: AddSmtp", data)
 
 	existing_smtp, _ := s.storage.GetSmtp(userID.String())
 	if existing_smtp != nil {

--- a/api/internal/features/notification/service/delete_smtp.go
+++ b/api/internal/features/notification/service/delete_smtp.go
@@ -1,6 +1,10 @@
 package service
 
-import "github.com/nixopus/nixopus/api/internal/features/logger"
+import (
+	"fmt"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
 
 // DeleteSmtp deletes a SMTP configuration.
 //
@@ -8,6 +12,6 @@ import "github.com/nixopus/nixopus/api/internal/features/logger"
 //
 // It logs an info message to the logger before calling the storage layer.
 func (s *NotificationService) DeleteSmtp(ID string) error {
-	s.logger.Log(logger.Info, "Deleting SMTP configuration", "")
+	s.logger.Log(logger.Info, "notification service: DeleteSmtp", fmt.Sprintf("smtp_config_id=%s", ID))
 	return s.storage.DeleteSmtp(ID)
 }

--- a/api/internal/features/notification/service/get_preferences.go
+++ b/api/internal/features/notification/service/get_preferences.go
@@ -1,7 +1,10 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 )
 
@@ -10,5 +13,6 @@ import (
 // If the user has not set any preferences before, this will return an empty
 // response. If the user has no preferences, this will return an error.
 func (s *NotificationService) GetPreferences(userID uuid.UUID) (*notification.GetPreferencesResponse, error) {
+	s.logger.Log(logger.Info, "notification service: GetPreferences", fmt.Sprintf("user_id=%s", userID))
 	return s.storage.GetPreferences(s.Ctx, userID)
 }

--- a/api/internal/features/notification/service/get_smtp.go
+++ b/api/internal/features/notification/service/get_smtp.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
@@ -10,7 +12,8 @@ import (
 //
 // It logs an info message to the logger before calling the same method on the storage layer.
 func (s *NotificationService) GetSmtp(ID string, organizationID string) (*shared_types.SMTPConfigs, error) {
-	s.logger.Log(logger.Info, "Getting SMTP configuration", "")
+	data := fmt.Sprintf("query_user_id=%s org_id=%s", ID, organizationID)
+	s.logger.Log(logger.Info, "notification service: GetSmtp", data)
 
 	smtp, err := s.storage.GetSmtp(ID)
 	if err != nil {
@@ -22,7 +25,7 @@ func (s *NotificationService) GetSmtp(ID string, organizationID string) (*shared
 
 	smtpConfigs, err := s.storage.GetOrganizationsSmtp(organizationID)
 	if err != nil {
-		s.logger.Log(logger.Warning, "org SMTP lookup failed (migration pending?)", err.Error())
+		s.logger.Log(logger.Warning, fmt.Sprintf("notification service: GetSmtp org lookup failed (migration pending?): %v", err), data)
 		return nil, notification.ErrSMTPConfigNotFound
 	}
 

--- a/api/internal/features/notification/service/update_preference.go
+++ b/api/internal/features/notification/service/update_preference.go
@@ -29,12 +29,13 @@ func (s *NotificationService) UpdatePreference(preferences notification.UpdatePr
 		return fmt.Errorf("userID cannot be empty")
 	}
 
-	s.logger.Log(logger.Info, fmt.Sprintf("Updating preference: Category=%s, Type=%s, Enabled=%v",
-		preferences.Category, preferences.Type, preferences.Enabled), "")
+	data := fmt.Sprintf("user_id=%s category=%s type=%s enabled=%v",
+		userID, preferences.Category, preferences.Type, preferences.Enabled)
+	s.logger.Log(logger.Info, "notification service: UpdatePreference", data)
 
 	err := s.storage.UpdatePreference(s.Ctx, preferences, userID)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to update preference: %v", err), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: UpdatePreference: %v", err), data)
 		return fmt.Errorf("failed to update preference: %w", err)
 	}
 

--- a/api/internal/features/notification/service/update_smtp.go
+++ b/api/internal/features/notification/service/update_smtp.go
@@ -16,15 +16,16 @@ func (s *NotificationService) UpdateSmtp(config notification.UpdateSMTPConfigReq
 		return fmt.Errorf("storage layer not initialized")
 	}
 
+	data := fmt.Sprintf("smtp_config_id=%s", config.ID)
 	hostInfo := "(unchanged)"
 	if config.Host != nil {
 		hostInfo = *config.Host
 	}
-	s.logger.Log(logger.Info, fmt.Sprintf("Updating SMTP configuration: Host=%s", hostInfo), "")
+	s.logger.Log(logger.Info, fmt.Sprintf("notification service: UpdateSmtp host=%s", hostInfo), data)
 
 	err := s.storage.UpdateSmtp(&config)
 	if err != nil {
-		s.logger.Log(logger.Error, fmt.Sprintf("Failed to update SMTP configuration: %v", err), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: UpdateSmtp: %v", err), data)
 		return fmt.Errorf("failed to update SMTP configuration: %w", err)
 	}
 

--- a/api/internal/features/notification/service/webhook.go
+++ b/api/internal/features/notification/service/webhook.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
@@ -26,6 +27,7 @@ func (s *NotificationService) CreateWebhookConfig(ctx context.Context, req *noti
 
 	err := s.storage.CreateWebhookConfig(ctx, config)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: CreateWebhookConfig: %v", err), fmt.Sprintf("org_id=%s user_id=%s type=%s", organizationID, userID, req.Type))
 		return nil, fmt.Errorf("failed to create webhook config: %w", err)
 	}
 
@@ -35,6 +37,7 @@ func (s *NotificationService) CreateWebhookConfig(ctx context.Context, req *noti
 func (s *NotificationService) UpdateWebhookConfig(ctx context.Context, req *notification.UpdateWebhookConfigRequest, organizationID uuid.UUID) (*shared_types.WebhookConfig, error) {
 	config, err := s.storage.GetWebhookConfig(ctx, req.Type, organizationID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: UpdateWebhookConfig load: %v", err), fmt.Sprintf("org_id=%s type=%s", organizationID, req.Type))
 		return nil, fmt.Errorf("webhook config not found: %w", err)
 	}
 
@@ -48,6 +51,7 @@ func (s *NotificationService) UpdateWebhookConfig(ctx context.Context, req *noti
 
 	err = s.storage.UpdateWebhookConfig(ctx, config)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: UpdateWebhookConfig: %v", err), fmt.Sprintf("org_id=%s type=%s webhook_id=%s", organizationID, req.Type, config.ID))
 		return nil, fmt.Errorf("failed to update webhook config: %w", err)
 	}
 
@@ -57,6 +61,7 @@ func (s *NotificationService) UpdateWebhookConfig(ctx context.Context, req *noti
 func (s *NotificationService) DeleteWebhookConfig(ctx context.Context, req *notification.DeleteWebhookConfigRequest, organizationID uuid.UUID) error {
 	err := s.storage.DeleteWebhookConfig(ctx, req.Type, organizationID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: DeleteWebhookConfig: %v", err), fmt.Sprintf("org_id=%s type=%s", organizationID, req.Type))
 		return fmt.Errorf("failed to delete webhook config: %w", err)
 	}
 	return nil
@@ -65,6 +70,7 @@ func (s *NotificationService) DeleteWebhookConfig(ctx context.Context, req *noti
 func (s *NotificationService) GetWebhookConfig(ctx context.Context, req *notification.GetWebhookConfigRequest, organizationID uuid.UUID) (*shared_types.WebhookConfig, error) {
 	config, err := s.storage.GetWebhookConfig(ctx, req.Type, organizationID)
 	if err != nil {
+		s.logger.Log(logger.Error, fmt.Sprintf("notification service: GetWebhookConfig: %v", err), fmt.Sprintf("org_id=%s type=%s", organizationID, req.Type))
 		return nil, fmt.Errorf("webhook config not found: %w", err)
 	}
 	return config, nil

--- a/api/internal/features/notification/storage/init.go
+++ b/api/internal/features/notification/storage/init.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
@@ -25,8 +26,9 @@ func commitNotificationBunTx(tx bun.Tx) error {
 }
 
 type NotificationStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 type NotificationRepository interface {
@@ -48,13 +50,20 @@ type NotificationRepository interface {
 // It takes a shared_types.SMTPConfigs as a parameter and inserts it into the database.
 // It returns an error if the database operation fails.
 func (s NotificationStorage) AddSmtp(config *shared_types.SMTPConfigs) error {
+	ctxStr := fmt.Sprintf("org_id=%s user_id=%s config_id=%s", config.OrganizationID, config.UserID, config.ID)
+	storageLog(s.Logger, logger.Debug, "notification storage: AddSmtp", ctxStr)
 	_, err := s.DB.NewInsert().Model(config).Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: AddSmtp: %v", err), ctxStr)
+	}
 	return err
 }
 
 // UpdateSmtp updates an existing SMTP configuration in the database.
 // Only non-nil fields are updated (partial update).
 func (s NotificationStorage) UpdateSmtp(config *notification.UpdateSMTPConfigRequest) error {
+	ctxStr := fmt.Sprintf("smtp_config_id=%s", config.ID)
+	storageLog(s.Logger, logger.Debug, "notification storage: UpdateSmtp", ctxStr)
 	q := s.DB.NewUpdate().TableExpr("smtp_configs").Where("id = ?", config.ID)
 
 	if config.Host != nil {
@@ -77,6 +86,9 @@ func (s NotificationStorage) UpdateSmtp(config *notification.UpdateSMTPConfigReq
 	}
 
 	_, err := q.Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: UpdateSmtp: %v", err), ctxStr)
+	}
 	return err
 }
 
@@ -85,14 +97,21 @@ func (s NotificationStorage) UpdateSmtp(config *notification.UpdateSMTPConfigReq
 // It takes an ID as a parameter, deletes the corresponding SMTP configuration
 // from the database, and returns an error if the database operation fails.
 func (s NotificationStorage) DeleteSmtp(ID string) error {
+	ctxStr := fmt.Sprintf("smtp_config_id=%s", ID)
+	storageLog(s.Logger, logger.Debug, "notification storage: DeleteSmtp", ctxStr)
 	exists, err := s.DB.NewSelect().Model((*shared_types.SMTPConfigs)(nil)).Where("id = ?", ID).Exists(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: DeleteSmtp exists check: %v", err), ctxStr)
 		return err
 	}
 	if !exists {
+		storageLog(s.Logger, logger.Debug, "notification storage: DeleteSmtp: not found", ctxStr)
 		return fmt.Errorf("smtp config not found")
 	}
 	_, err = s.DB.NewDelete().Model((*shared_types.SMTPConfigs)(nil)).Where("id = ?", ID).Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: DeleteSmtp: %v", err), ctxStr)
+	}
 	return err
 }
 
@@ -102,12 +121,15 @@ func (s NotificationStorage) DeleteSmtp(ID string) error {
 // SMTP configuration, and returns it. It returns an error if the database
 // operation fails.
 func (s NotificationStorage) GetSmtp(ID string) (*shared_types.SMTPConfigs, error) {
+	ctxStr := fmt.Sprintf("query_user_id=%s", ID)
+	storageLog(s.Logger, logger.Debug, "notification storage: GetSmtp", ctxStr)
 	config := &shared_types.SMTPConfigs{}
 	err := s.DB.NewSelect().Model(config).Where("user_id = ?", ID).Scan(s.Ctx)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetSmtp: %v", err), ctxStr)
 		return nil, err
 	}
 	return config, nil
@@ -119,9 +141,12 @@ func (s NotificationStorage) GetSmtp(ID string) (*shared_types.SMTPConfigs, erro
 // corresponding SMTP configurations, and returns them. It returns an error
 // if the database operation fails.
 func (s NotificationStorage) GetOrganizationsSmtp(organizationID string) ([]shared_types.SMTPConfigs, error) {
+	ctxStr := fmt.Sprintf("org_id=%s", organizationID)
+	storageLog(s.Logger, logger.Debug, "notification storage: GetOrganizationsSmtp", ctxStr)
 	configs := []shared_types.SMTPConfigs{}
 	err := s.DB.NewSelect().Model(&configs).Where("organization_id = ?", organizationID).Scan(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetOrganizationsSmtp: %v", err), ctxStr)
 		return nil, err
 	}
 	return configs, nil
@@ -136,6 +161,8 @@ func (s NotificationStorage) GetOrganizationsSmtp(organizationID string) ([]shar
 //
 // The function will log an info message with the details of the preference update.
 func (s *NotificationStorage) UpdatePreference(ctx context.Context, req notification.UpdatePreferenceRequest, userID uuid.UUID) error {
+	ctxStr := fmt.Sprintf("user_id=%s category=%s type=%s", userID, req.Category, req.Type)
+	storageLog(s.Logger, logger.Debug, "notification storage: UpdatePreference", ctxStr)
 	var preferenceID uuid.UUID
 	err := s.DB.NewSelect().
 		Model((*shared_types.NotificationPreferences)(nil)).
@@ -148,6 +175,7 @@ func (s *NotificationStorage) UpdatePreference(ctx context.Context, req notifica
 		if errors.Is(err, sql.ErrNoRows) {
 			return s.initUserPreferences(ctx, userID, req)
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: UpdatePreference fetch prefs: %v", err), ctxStr)
 		return fmt.Errorf("failed to fetch user preferences: %w", err)
 	}
 
@@ -161,6 +189,7 @@ func (s *NotificationStorage) UpdatePreference(ctx context.Context, req notifica
 		Exec(ctx)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: UpdatePreference update item: %v", err), ctxStr)
 		return fmt.Errorf("failed to update preference: %w", err)
 	}
 
@@ -176,6 +205,8 @@ func (s *NotificationStorage) UpdatePreference(ctx context.Context, req notifica
 // It returns a GetPreferencesResponse containing the user's preferences or an
 // error if any database operation fails.
 func (s *NotificationStorage) GetPreferences(ctx context.Context, userID uuid.UUID) (*notification.GetPreferencesResponse, error) {
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "notification storage: GetPreferences", ctxStr)
 	var preferenceID uuid.UUID
 	err := s.DB.NewSelect().
 		Model((*shared_types.NotificationPreferences)(nil)).
@@ -187,6 +218,7 @@ func (s *NotificationStorage) GetPreferences(ctx context.Context, userID uuid.UU
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			if err := s.initDefaultPreferences(ctx, userID); err != nil {
+				storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetPreferences init defaults: %v", err), ctxStr)
 				return nil, fmt.Errorf("failed to initialize preferences: %w", err)
 			}
 
@@ -198,9 +230,11 @@ func (s *NotificationStorage) GetPreferences(ctx context.Context, userID uuid.UU
 				Scan(ctx, &preferenceID)
 
 			if err != nil {
+				storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetPreferences refetch after init: %v", err), ctxStr)
 				return nil, fmt.Errorf("failed to fetch newly created preferences: %w", err)
 			}
 		} else {
+			storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetPreferences fetch prefs: %v", err), ctxStr)
 			return nil, fmt.Errorf("failed to fetch user preferences: %w", err)
 		}
 	}
@@ -212,6 +246,7 @@ func (s *NotificationStorage) GetPreferences(ctx context.Context, userID uuid.UU
 		Scan(ctx, &items)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetPreferences fetch items: %v", err), ctxStr)
 		return nil, fmt.Errorf("failed to fetch preference items: %w", err)
 	}
 
@@ -233,8 +268,10 @@ func (s *NotificationStorage) GetPreferences(ctx context.Context, userID uuid.UU
 // is returned. Otherwise, the transaction is committed, and nil is returned
 // to indicate success.
 func (s *NotificationStorage) initUserPreferences(ctx context.Context, userID uuid.UUID, update notification.UpdatePreferenceRequest) error {
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initUserPreferences begin tx: %v", err), ctxStr)
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer tx.Rollback()
@@ -250,6 +287,7 @@ func (s *NotificationStorage) initUserPreferences(ctx context.Context, userID uu
 
 	_, err = tx.NewInsert().Model(preferences).Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initUserPreferences insert prefs: %v", err), ctxStr)
 		return fmt.Errorf("failed to insert preferences: %w", err)
 	}
 
@@ -263,10 +301,12 @@ func (s *NotificationStorage) initUserPreferences(ctx context.Context, userID uu
 
 	_, err = tx.NewInsert().Model(&items).Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initUserPreferences insert items: %v", err), ctxStr)
 		return fmt.Errorf("failed to insert preference items: %w", err)
 	}
 
 	if err = commitNotificationBunTx(tx); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initUserPreferences commit: %v", err), ctxStr)
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
@@ -279,8 +319,10 @@ func (s *NotificationStorage) initUserPreferences(ctx context.Context, userID uu
 //
 // The function will log an info message with the details of the preference initialization.
 func (s *NotificationStorage) initDefaultPreferences(ctx context.Context, userID uuid.UUID) error {
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initDefaultPreferences begin tx: %v", err), ctxStr)
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer tx.Rollback()
@@ -296,6 +338,7 @@ func (s *NotificationStorage) initDefaultPreferences(ctx context.Context, userID
 
 	_, err = tx.NewInsert().Model(preferences).Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initDefaultPreferences insert prefs: %v", err), ctxStr)
 		return fmt.Errorf("failed to insert preferences: %w", err)
 	}
 
@@ -303,10 +346,12 @@ func (s *NotificationStorage) initDefaultPreferences(ctx context.Context, userID
 
 	_, err = tx.NewInsert().Model(&items).Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initDefaultPreferences insert items: %v", err), ctxStr)
 		return fmt.Errorf("failed to insert preference items: %w", err)
 	}
 
 	if err = commitNotificationBunTx(tx); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: initDefaultPreferences commit: %v", err), ctxStr)
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
@@ -459,8 +504,11 @@ func MapToResponse(items []shared_types.PreferenceItem) notification.GetPreferen
 
 // CreateWebhookConfig creates a new webhook configuration in the database.
 func (s NotificationStorage) CreateWebhookConfig(ctx context.Context, config *shared_types.WebhookConfig) error {
+	ctxStr := fmt.Sprintf("org_id=%s type=%s webhook_id=%s", config.OrganizationID, config.Type, config.ID)
+	storageLog(s.Logger, logger.Debug, "notification storage: CreateWebhookConfig", ctxStr)
 	_, err := s.DB.NewInsert().Model(config).Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: CreateWebhookConfig: %v", err), ctxStr)
 		return fmt.Errorf("failed to create webhook config: %w", err)
 	}
 	return nil
@@ -468,8 +516,11 @@ func (s NotificationStorage) CreateWebhookConfig(ctx context.Context, config *sh
 
 // UpdateWebhookConfig updates an existing webhook configuration in the database.
 func (s NotificationStorage) UpdateWebhookConfig(ctx context.Context, config *shared_types.WebhookConfig) error {
+	ctxStr := fmt.Sprintf("org_id=%s type=%s webhook_id=%s", config.OrganizationID, config.Type, config.ID)
+	storageLog(s.Logger, logger.Debug, "notification storage: UpdateWebhookConfig", ctxStr)
 	_, err := s.DB.NewUpdate().Model(config).WherePK().Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: UpdateWebhookConfig: %v", err), ctxStr)
 		return fmt.Errorf("failed to update webhook config: %w", err)
 	}
 	return nil
@@ -477,10 +528,13 @@ func (s NotificationStorage) UpdateWebhookConfig(ctx context.Context, config *sh
 
 // DeleteWebhookConfig deletes a webhook configuration from the database.
 func (s NotificationStorage) DeleteWebhookConfig(ctx context.Context, webhookType string, organizationID uuid.UUID) error {
+	ctxStr := fmt.Sprintf("org_id=%s type=%s", organizationID, webhookType)
+	storageLog(s.Logger, logger.Debug, "notification storage: DeleteWebhookConfig", ctxStr)
 	_, err := s.DB.NewDelete().Model((*shared_types.WebhookConfig)(nil)).
 		Where("type = ? AND organization_id = ?", webhookType, organizationID).
 		Exec(ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: DeleteWebhookConfig: %v", err), ctxStr)
 		return fmt.Errorf("failed to delete webhook config: %w", err)
 	}
 	return nil
@@ -488,6 +542,8 @@ func (s NotificationStorage) DeleteWebhookConfig(ctx context.Context, webhookTyp
 
 // GetWebhookConfig retrieves a webhook configuration from the database.
 func (s NotificationStorage) GetWebhookConfig(ctx context.Context, webhookType string, organizationID uuid.UUID) (*shared_types.WebhookConfig, error) {
+	ctxStr := fmt.Sprintf("org_id=%s type=%s", organizationID, webhookType)
+	storageLog(s.Logger, logger.Debug, "notification storage: GetWebhookConfig", ctxStr)
 	config := &shared_types.WebhookConfig{}
 	err := s.DB.NewSelect().Model(config).
 		Where("type = ? AND organization_id = ?", webhookType, organizationID).
@@ -496,6 +552,7 @@ func (s NotificationStorage) GetWebhookConfig(ctx context.Context, webhookType s
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("notification storage: GetWebhookConfig: %v", err), ctxStr)
 		return nil, fmt.Errorf("webhook config not found: %w", err)
 	}
 	return config, nil

--- a/api/internal/features/notification/storage/log.go
+++ b/api/internal/features/notification/storage/log.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func storageLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}

--- a/api/internal/features/notification/validation/validator.go
+++ b/api/internal/features/notification/validation/validator.go
@@ -3,21 +3,31 @@ package validation
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/notification"
 	"github.com/nixopus/nixopus/api/internal/features/notification/storage"
 )
 
 type Validator struct {
 	storage storage.NotificationRepository
+	Logger  *logger.Logger // optional; nil skips validation debug logs
 }
 
 func NewValidator(storage storage.NotificationRepository) *Validator {
 	return &Validator{
 		storage: storage,
+	}
+}
+
+func NewValidatorWithLogger(storage storage.NotificationRepository, l *logger.Logger) *Validator {
+	return &Validator{
+		storage: storage,
+		Logger:  l,
 	}
 }
 
@@ -35,6 +45,9 @@ func (v *Validator) ValidateRequest(req any) error {
 	case *notification.UpdatePreferenceRequest:
 		return v.validateUpdatePreferenceRequest(*r)
 	default:
+		if v.Logger != nil {
+			v.Logger.Log(logger.Debug, fmt.Sprintf("notification validation: invalid request type %T", req), "")
+		}
 		return notification.ErrInvalidRequestType
 	}
 }

--- a/api/internal/features/telemetry/controller/init.go
+++ b/api/internal/features/telemetry/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -21,10 +22,10 @@ type TelemetryController struct {
 }
 
 func NewTelemetryController(db *bun.DB, ctx context.Context, l logger.Logger) *TelemetryController {
-	repo := storage.NewTelemetryStorage(db, ctx)
+	repo := storage.NewTelemetryStorage(db, ctx, &l)
 	return &TelemetryController{
 		service:   service.NewTelemetryService(repo, ctx, l),
-		validator: validation.NewValidator(),
+		validator: validation.NewValidatorWithLogger(&l),
 		logger:    l,
 	}
 }
@@ -32,21 +33,23 @@ func NewTelemetryController(db *bun.DB, ctx context.Context, l logger.Logger) *T
 func (c *TelemetryController) HandleTrackInstall(f fuego.ContextWithBody[types.TrackInstallRequest]) (*types.TrackInstallResponse, error) {
 	body, err := f.Body()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to parse telemetry request body", err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("telemetry: TrackInstall: parse body: %v", err), "")
 		return nil, fuego.BadRequestError{Detail: "invalid request body", Err: err}
 	}
 
 	if err := c.validator.ValidateRequest(&body); err != nil {
+		c.logger.Log(logger.Debug, fmt.Sprintf("telemetry: TrackInstall: validation: %v", err), trackInstallRequestData(&body))
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	clientIP := extractClientIP(f.Request())
 
 	if err := c.service.TrackInstall(&body, clientIP); err != nil {
-		c.logger.Log(logger.Error, "failed to track install event", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("telemetry: TrackInstall: %v", err), trackInstallRequestData(&body))
 		return nil, fuego.HTTPError{Err: err, Detail: "failed to record event", Status: http.StatusInternalServerError}
 	}
 
+	c.logger.Log(logger.Info, "telemetry: TrackInstall", trackInstallRequestData(&body))
 	return &types.TrackInstallResponse{
 		Status:  "success",
 		Message: "event recorded",

--- a/api/internal/features/telemetry/controller/telemetry_log.go
+++ b/api/internal/features/telemetry/controller/telemetry_log.go
@@ -1,0 +1,16 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/nixopus/nixopus/api/internal/features/telemetry/types"
+)
+
+// trackInstallRequestData builds log context without user-supplied error text (paths, secrets).
+func trackInstallRequestData(req *types.TrackInstallRequest) string {
+	if req == nil {
+		return ""
+	}
+	return fmt.Sprintf("event_type=%s os=%s arch=%s version=%s duration=%d error_len=%d",
+		req.EventType, req.OS, req.Arch, req.Version, req.Duration, len(req.Error))
+}

--- a/api/internal/features/telemetry/service/init.go
+++ b/api/internal/features/telemetry/service/init.go
@@ -47,7 +47,9 @@ func (s *TelemetryService) TrackInstall(req *types.TrackInstallRequest, clientIP
 	}
 
 	if err := s.storage.CreateInstallEvent(event); err != nil {
-		s.logger.Log(logger.Error, "failed to store install event", err.Error())
+		data := fmt.Sprintf("event_type=%s os=%s arch=%s version=%s duration=%d error_len=%d event_id=%s",
+			req.EventType, req.OS, req.Arch, req.Version, req.Duration, len(req.Error), event.ID)
+		s.logger.Log(logger.Error, fmt.Sprintf("telemetry service: TrackInstall: %v", err), data)
 		return err
 	}
 

--- a/api/internal/features/telemetry/storage/init.go
+++ b/api/internal/features/telemetry/storage/init.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/telemetry/types"
 	"github.com/uptrace/bun"
 )
@@ -12,18 +14,25 @@ type TelemetryRepository interface {
 }
 
 type TelemetryStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
-func NewTelemetryStorage(db *bun.DB, ctx context.Context) *TelemetryStorage {
+func NewTelemetryStorage(db *bun.DB, ctx context.Context, l *logger.Logger) *TelemetryStorage {
 	return &TelemetryStorage{
-		DB:  db,
-		Ctx: ctx,
+		DB:     db,
+		Ctx:    ctx,
+		Logger: l,
 	}
 }
 
 func (s *TelemetryStorage) CreateInstallEvent(event *types.CliInstallation) error {
+	data := fmt.Sprintf("event_id=%s event_type=%s os=%s arch=%s version=%s", event.ID, event.EventType, event.OS, event.Arch, event.Version)
+	storageLog(s.Logger, logger.Debug, "telemetry storage: CreateInstallEvent", data)
 	_, err := s.DB.NewInsert().Model(event).Exec(s.Ctx)
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("telemetry storage: CreateInstallEvent: %v", err), data)
+	}
 	return err
 }

--- a/api/internal/features/telemetry/storage/init_test.go
+++ b/api/internal/features/telemetry/storage/init_test.go
@@ -46,7 +46,7 @@ func sqliteTelemetryDB(t *testing.T) (*bun.DB, context.Context) {
 func TestNewTelemetryStorage(t *testing.T) {
 	t.Parallel()
 	db, ctx := sqliteTelemetryDB(t)
-	s := storage.NewTelemetryStorage(db, ctx)
+	s := storage.NewTelemetryStorage(db, ctx, nil)
 	require.NotNil(t, s)
 	assert.Equal(t, db, s.DB)
 	assert.Equal(t, ctx, s.Ctx)
@@ -55,7 +55,7 @@ func TestNewTelemetryStorage(t *testing.T) {
 func TestCreateInstallEvent_success(t *testing.T) {
 	t.Parallel()
 	db, ctx := sqliteTelemetryDB(t)
-	s := storage.NewTelemetryStorage(db, ctx)
+	s := storage.NewTelemetryStorage(db, ctx, nil)
 
 	event := &types.CliInstallation{
 		ID:        uuid.New(),
@@ -81,7 +81,7 @@ func TestCreateInstallEvent_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := sqliteTelemetryDB(t)
 	require.NoError(t, db.Close())
-	s := storage.NewTelemetryStorage(db, ctx)
+	s := storage.NewTelemetryStorage(db, ctx, nil)
 
 	err := s.CreateInstallEvent(&types.CliInstallation{ID: uuid.New()})
 	require.Error(t, err)

--- a/api/internal/features/telemetry/storage/log.go
+++ b/api/internal/features/telemetry/storage/log.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func storageLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}

--- a/api/internal/features/telemetry/validation/validator.go
+++ b/api/internal/features/telemetry/validation/validator.go
@@ -1,17 +1,25 @@
 package validation
 
 import (
+	"fmt"
 	"regexp"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/telemetry/types"
 )
 
 var semverRegex = regexp.MustCompile(`^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$`)
 
-type Validator struct{}
+type Validator struct {
+	Logger *logger.Logger // optional; nil skips validation debug logs
+}
 
 func NewValidator() *Validator {
 	return &Validator{}
+}
+
+func NewValidatorWithLogger(l *logger.Logger) *Validator {
+	return &Validator{Logger: l}
 }
 
 func (v *Validator) ValidateRequest(req any) error {
@@ -19,6 +27,9 @@ func (v *Validator) ValidateRequest(req any) error {
 	case *types.TrackInstallRequest:
 		return v.validateTrackInstall(*r)
 	default:
+		if v.Logger != nil {
+			v.Logger.Log(logger.Debug, fmt.Sprintf("telemetry validation: invalid request type %T", req), "")
+		}
 		return types.ErrInvalidRequestType
 	}
 }

--- a/api/internal/features/update/controller/update_controller.go
+++ b/api/internal/features/update/controller/update_controller.go
@@ -32,15 +32,18 @@ func (c *UpdateController) CheckForUpdates(s fuego.ContextNoBody) (*types.Update
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUpdateDebug("CheckForUpdates", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
+
+	ctxStr := updateRequestData(r, user)
 
 	// If the environment is development, return current version but skip remote check
 	if config.AppConfig.App.Environment == "development" {
 		currentVersion, err := c.service.GetCurrentVersion()
 		if err != nil {
 			// In development, log the error but don't fail the request
-			c.logger.Log(logger.Warning, "Failed to get current version in development", err.Error())
+			c.logger.Log(logger.Warning, fmt.Sprintf("update: CheckForUpdates: get current version (dev): %v", err), ctxStr)
 			currentVersion = "unknown"
 		}
 		return &types.UpdateCheckResponse{
@@ -53,7 +56,7 @@ func (c *UpdateController) CheckForUpdates(s fuego.ContextNoBody) (*types.Update
 
 	response, err := c.service.CheckForUpdates()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to check for updates", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("update: CheckForUpdates: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -61,11 +64,13 @@ func (c *UpdateController) CheckForUpdates(s fuego.ContextNoBody) (*types.Update
 		}
 	}
 
+	c.logger.Log(logger.Debug, "update: CheckForUpdates ok", fmt.Sprintf("%s update_available=%v current=%s latest=%s", ctxStr, response.UpdateAvailable, response.CurrentVersion, response.LatestVersion))
+
 	// If update is available and user has auto update enabled, perform the update
 	if response.UpdateAvailable {
 		autoUpdate, err := c.service.GetUserAutoUpdatePreference(user.ID)
 		if err != nil {
-			c.logger.Log(logger.Error, "failed to get user auto-update preference", err.Error())
+			c.logger.Log(logger.Error, fmt.Sprintf("update: CheckForUpdates: auto-update preference: %v", err), ctxStr)
 			return response, nil
 		}
 
@@ -74,7 +79,7 @@ func (c *UpdateController) CheckForUpdates(s fuego.ContextNoBody) (*types.Update
 				// Get organization ID from request context
 				orgID := utils.GetOrganizationID(r)
 				if orgID == uuid.Nil {
-					c.logger.Log(logger.Error, "failed to perform auto-update", "organization ID not found in context")
+					c.logger.Log(logger.Error, "update: CheckForUpdates: auto-update skipped: organization ID required", ctxStr)
 					return
 				}
 				orgCtx := r.Context()
@@ -82,8 +87,9 @@ func (c *UpdateController) CheckForUpdates(s fuego.ContextNoBody) (*types.Update
 					orgCtx = context.Background()
 				}
 				orgCtx = context.WithValue(orgCtx, shared_types.OrganizationIDKey, orgID.String())
+				autoData := fmt.Sprintf("%s org_id=%s", ctxStr, orgID)
 				if err := c.service.PerformUpdate(orgCtx); err != nil {
-					c.logger.Log(logger.Error, "failed to perform auto-update", err.Error())
+					c.logger.Log(logger.Error, fmt.Sprintf("update: CheckForUpdates: auto-update: %v", err), autoData)
 				}
 			}()
 		}
@@ -98,6 +104,7 @@ func (c *UpdateController) PerformUpdate(s fuego.ContextWithBody[types.UpdateReq
 
 	// If the environment is development, we will not perform updates
 	if config.AppConfig.App.Environment == "development" {
+		c.logUpdateDebug("PerformUpdate", "skipped in development", updateRequestData(r, user))
 		return &types.UpdateResponse{
 			Success: true,
 			Message: "Update completed successfully",
@@ -105,17 +112,21 @@ func (c *UpdateController) PerformUpdate(s fuego.ContextWithBody[types.UpdateReq
 	}
 
 	if user == nil {
+		c.logUpdateDebug("PerformUpdate", "authentication required", "")
 		return nil, fuego.UnauthorizedError{Detail: "authentication required"}
 	}
 
+	ctxStr := updateRequestData(r, user)
+
 	req, err := s.Body()
 	if err != nil {
+		c.logUpdateDebug("PerformUpdate", fmt.Sprintf("parse body: %v", err), ctxStr)
 		return nil, fuego.BadRequestError{Detail: err.Error(), Err: err}
 	}
 
 	updateInfo, err := c.service.CheckForUpdates()
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to check for updates", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("update: PerformUpdate: check: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -124,6 +135,7 @@ func (c *UpdateController) PerformUpdate(s fuego.ContextWithBody[types.UpdateReq
 	}
 
 	if !updateInfo.UpdateAvailable && !req.Force {
+		c.logger.Log(logger.Info, "update: PerformUpdate: no update available", fmt.Sprintf("%s force=%v", ctxStr, req.Force))
 		return &types.UpdateResponse{
 			Success: false,
 			Message: "No updates available",
@@ -133,18 +145,22 @@ func (c *UpdateController) PerformUpdate(s fuego.ContextWithBody[types.UpdateReq
 	// Get organization ID from request context
 	orgID := utils.GetOrganizationID(r)
 	if orgID == uuid.Nil {
+		c.logUpdateDebug("PerformUpdate", "organization ID required", ctxStr)
 		return nil, fuego.BadRequestError{Detail: "organization ID not found in context", Err: fmt.Errorf("organization ID not found in context")}
 	}
 	orgCtx := r.Context()
-	orgCtx = context.WithValue(orgCtx, "organization_id", orgID.String())
+	orgCtx = context.WithValue(orgCtx, shared_types.OrganizationIDKey, orgID.String())
+	execCtx := fmt.Sprintf("%s org_id=%s force=%v", ctxStr, orgID, req.Force)
 	if err := c.service.PerformUpdate(orgCtx); err != nil {
-		c.logger.Log(logger.Error, "failed to perform update", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("update: PerformUpdate: %v", err), execCtx)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
 			Status: http.StatusInternalServerError,
 		}
 	}
+
+	c.logger.Log(logger.Info, "update: PerformUpdate completed", execCtx)
 
 	return &types.UpdateResponse{
 		Success: true,

--- a/api/internal/features/update/controller/update_log.go
+++ b/api/internal/features/update/controller/update_log.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+)
+
+func (c *UpdateController) logUpdateDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("update: %s: %s", handler, reason), data)
+}
+
+func updateRequestData(r *http.Request, user *shared_types.User) string {
+	orgID := utils.GetOrganizationID(r)
+	if user != nil && orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+	}
+	if user != nil {
+		return fmt.Sprintf("user_id=%s", user.ID)
+	}
+	if orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s", orgID)
+	}
+	return ""
+}

--- a/api/internal/features/update/service/update_service.go
+++ b/api/internal/features/update/service/update_service.go
@@ -126,7 +126,7 @@ func (s *UpdateService) tryReadVersionFile(path string) (string, error) {
 		return "", fmt.Errorf("version.txt is empty")
 	}
 
-	s.logger.Log(logger.Info, "Read version from file", fmt.Sprintf("path: %s, version: %s", path, version))
+	s.logger.Log(logger.Info, "update service: read version from file", fmt.Sprintf("path=%s version=%s", path, version))
 	return version, nil
 }
 
@@ -214,32 +214,31 @@ func (s *UpdateService) isRepositoryRoot(dir string) bool {
 // fetchLatestVersion fetches the latest version from the appropriate branch from our repo
 func (s *UpdateService) fetchLatestVersion() (string, error) {
 	branch := s.getBranch()
-	s.logger.Log(logger.Info, "Fetching latest version", fmt.Sprintf("Using branch: %s", branch))
+	s.logger.Log(logger.Info, "update service: fetchLatestVersion", fmt.Sprintf("branch=%s", branch))
 
 	url := fmt.Sprintf("https://raw.githubusercontent.com/nixopus/nixopus/refs/heads/%s/version.txt", branch)
-	s.logger.Log(logger.Info, "Constructed version URL", url)
 
 	resp, err := http.Get(url)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to fetch version", fmt.Sprintf("Error: %v", err))
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: fetchLatestVersion request: %v", err), fmt.Sprintf("branch=%s", branch))
 		return "", err
 	}
 	defer resp.Body.Close()
 
-	s.logger.Log(logger.Info, "Version fetch response", fmt.Sprintf("Status: %d", resp.StatusCode))
+	s.logger.Log(logger.Debug, "update service: fetchLatestVersion response", fmt.Sprintf("branch=%s status=%d", branch, resp.StatusCode))
 	if resp.StatusCode != http.StatusOK {
-		s.logger.Log(logger.Error, "Failed to fetch version", fmt.Sprintf("Status code: %d", resp.StatusCode))
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: fetchLatestVersion: HTTP %d", resp.StatusCode), fmt.Sprintf("branch=%s", branch))
 		return "", fmt.Errorf("failed to fetch version: status %d", resp.StatusCode)
 	}
 
 	versionBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to read version response", fmt.Sprintf("Error: %v", err))
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: fetchLatestVersion read body: %v", err), fmt.Sprintf("branch=%s", branch))
 		return "", err
 	}
 
 	version := strings.TrimSpace(string(versionBytes))
-	s.logger.Log(logger.Info, "Successfully fetched version", version)
+	s.logger.Log(logger.Info, "update service: fetchLatestVersion ok", fmt.Sprintf("branch=%s version=%s", branch, version))
 	return version, nil
 }
 
@@ -254,9 +253,6 @@ func (s *UpdateService) getBranch() string {
 // PerformUpdate performs an update by running the nixopus update CLI command via SSH on the host
 // Requires organization context to get organization-specific SSH configuration
 func (s *UpdateService) PerformUpdate(ctx context.Context) error {
-	s.logger.Log(logger.Info, "Starting Nixopus update", "Connecting via SSH to run nixopus update")
-
-	// Get organization ID from context
 	orgIDAny := ctx.Value(shared_types.OrganizationIDKey)
 	if orgIDAny == nil {
 		return fmt.Errorf("organization ID not found in context - system updates require organization context")
@@ -276,35 +272,39 @@ func (s *UpdateService) PerformUpdate(ctx context.Context) error {
 		return fmt.Errorf("unexpected organization ID type: %T", orgIDAny)
 	}
 
+	orgData := fmt.Sprintf("org_id=%s", orgID)
+
+	s.logger.Log(logger.Info, "update service: PerformUpdate starting", orgData)
+
 	// Get organization-specific SSH manager
 	manager, err := ssh.GetSSHManagerForOrganization(ctx, orgID)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to get SSH manager", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: PerformUpdate SSH manager: %v", err), orgData)
 		return fmt.Errorf("failed to get SSH manager: %w", err)
 	}
 
 	sshClient, err := manager.GetOrganizationSSH()
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to get SSH client", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: PerformUpdate SSH client config: %v", err), orgData)
 		return fmt.Errorf("failed to get SSH client: %w", err)
 	}
 
 	client, err := sshClient.Connect()
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to connect via SSH", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: PerformUpdate SSH connect: %v", err), orgData)
 		return fmt.Errorf("failed to connect via SSH: %w", err)
 	}
 	defer client.Close()
 
-	s.logger.Log(logger.Info, "SSH connected", "Running nixopus update command")
+	s.logger.Log(logger.Info, "update service: PerformUpdate running remote command", orgData)
 
 	output, err := sshClient.RunCommand("nixopus update")
 	if err != nil {
-		s.logger.Log(logger.Error, "Update failed", fmt.Sprintf("error: %v, output: %s", err, output))
+		s.logger.Log(logger.Error, fmt.Sprintf("update service: PerformUpdate command failed: %v", err), fmt.Sprintf("%s output_len=%d", orgData, len(output)))
 		return fmt.Errorf("failed to run nixopus update: %w (output: %s)", err, output)
 	}
 
-	s.logger.Log(logger.Info, "Update completed successfully", output)
+	s.logger.Log(logger.Info, "update service: PerformUpdate completed", fmt.Sprintf("%s output_len=%d", orgData, len(output)))
 	return nil
 }
 

--- a/api/internal/features/user/controller/avatar.go
+++ b/api/internal/features/user/controller/avatar.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -10,10 +11,9 @@ import (
 )
 
 func (u *UserController) UpdateAvatar(s fuego.ContextWithBody[types.UpdateAvatarRequest]) (*types.MessageResponse, error) {
-	u.logger.Log(logger.Info, "updating user avatar", "")
-
 	req, err := s.Body()
 	if err != nil {
+		u.logUserDebug("UpdateAvatar", fmt.Sprintf("parse body: %v", err), "")
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -31,14 +31,18 @@ func (u *UserController) UpdateAvatar(s fuego.ContextWithBody[types.UpdateAvatar
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		u.logUserDebug("UpdateAvatar", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := fmt.Sprintf("%s avatar_payload_len=%d", userRequestData(r, user), len(req.AvatarData))
+	u.logger.Log(logger.Info, "user: UpdateAvatar", ctxStr)
+
 	err = u.service.UpdateAvatar(s.Request().Context(), user.ID.String(), &req)
 	if err != nil {
-		u.logger.Log(logger.Error, err.Error(), "")
+		u.logger.Log(logger.Error, fmt.Sprintf("user: UpdateAvatar: %v", err), userRequestData(r, user))
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/get_user_details.go
+++ b/api/internal/features/user/controller/get_user_details.go
@@ -12,13 +12,15 @@ func (u *UserController) GetUserDetails(s fuego.ContextNoBody) (*types.UserRespo
 
 	user := utils.GetUser(w, r)
 
-	u.logger.Log(logger.Info, "getting user details", "")
-
 	if user == nil {
+		u.logUserDebug("GetUserDetails", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
+
+	ctxStr := userRequestData(r, user)
+	u.logger.Log(logger.Info, "user: GetUserDetails", ctxStr)
 
 	return &types.UserResponse{
 		Status:  "success",

--- a/api/internal/features/user/controller/get_user_orgs.go
+++ b/api/internal/features/user/controller/get_user_orgs.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -11,19 +12,22 @@ import (
 
 func (u *UserController) GetUserOrganizations(s fuego.ContextNoBody) (*types.UserOrganizationsListResponse, error) {
 	w, r := s.Response(), s.Request()
-	u.logger.Log(logger.Info, "getting user organizations", "")
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		u.logUserDebug("GetUserOrganizations", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+	u.logger.Log(logger.Info, "user: GetUserOrganizations", ctxStr)
+
 	organizations, err := u.service.GetUserOrganizations(user.ID.String())
 
 	if err != nil {
-		u.logger.Log(logger.Error, err.Error(), "")
+		u.logger.Log(logger.Error, fmt.Sprintf("user: GetUserOrganizations: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/init.go
+++ b/api/internal/features/user/controller/init.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	cache "github.com/nixopus/nixopus/api/internal/cache"
@@ -29,8 +30,8 @@ func NewUserController(
 	cache *cache.Cache,
 ) *UserController {
 	return &UserController{
-		validator: validation.NewValidator(),
-		service:   service.NewUserService(store, ctx, l, &storage.UserStorage{DB: store.DB, Ctx: ctx}),
+		validator: validation.NewValidatorWithLogger(&l),
+		service:   service.NewUserService(store, ctx, l, &storage.UserStorage{DB: store.DB, Ctx: ctx, Logger: &l}),
 		ctx:       ctx,
 		logger:    l,
 		cache:     cache,
@@ -41,11 +42,12 @@ func (c *UserController) parseAndValidate(w http.ResponseWriter, r *http.Request
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logger.Log(logger.Debug, "user: parseAndValidate: authentication required", "")
 		return errors.New("authentication required")
 	}
 
 	if err := c.validator.ValidateRequest(req, *user); err != nil {
-		c.logger.Log(logger.Error, err.Error(), err.Error())
+		c.logger.Log(logger.Debug, fmt.Sprintf("user: parseAndValidate: validation: %v", err), fmt.Sprintf("user_id=%s", user.ID))
 		return err
 	}
 

--- a/api/internal/features/user/controller/is_onboarded.go
+++ b/api/internal/features/user/controller/is_onboarded.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -14,16 +15,18 @@ func (u *UserController) GetIsOnboarded(s fuego.ContextNoBody) (*types.IsOnboard
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		u.logUserDebug("GetIsOnboarded", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
-	u.logger.Log(logger.Info, "checking onboarding status", user.ID.String())
+	ctxStr := userRequestData(r, user)
+	u.logger.Log(logger.Info, "user: GetIsOnboarded", ctxStr)
 
 	isOnboarded, err := u.service.IsOnboarded(user.ID.String())
 	if err != nil {
-		u.logger.Log(logger.Error, err.Error(), user.ID.String())
+		u.logger.Log(logger.Error, fmt.Sprintf("user: GetIsOnboarded: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/mark_onboarding_complete.go
+++ b/api/internal/features/user/controller/mark_onboarding_complete.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -15,16 +16,18 @@ func (u *UserController) MarkOnboardingComplete(s fuego.ContextNoBody) (*types.M
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		u.logUserDebug("MarkOnboardingComplete", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
-	u.logger.Log(logger.Info, "marking onboarding as complete", user.ID.String())
+	ctxStr := userRequestData(r, user)
+	u.logger.Log(logger.Info, "user: MarkOnboardingComplete", ctxStr)
 
 	err := u.service.MarkOnboardingComplete(user.ID.String())
 	if err != nil {
-		u.logger.Log(logger.Error, err.Error(), user.ID.String())
+		u.logger.Log(logger.Error, fmt.Sprintf("user: MarkOnboardingComplete: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/preferences.go
+++ b/api/internal/features/user/controller/preferences.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -16,14 +17,17 @@ func (c *UserController) GetUserPreferences(s fuego.ContextNoBody) (*types.UserP
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("GetUserPreferences", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	prefs, err := c.service.GetUserPreferences(user.ID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to get user preferences", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: GetUserPreferences: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -44,13 +48,17 @@ func (c *UserController) UpdateUserPreferences(s fuego.ContextWithBody[shared_ty
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("UpdateUserPreferences", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	req, err := s.Body()
 	if err != nil {
+		c.logUserDebug("UpdateUserPreferences", fmt.Sprintf("parse body: %v", err), ctxStr)
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -59,7 +67,7 @@ func (c *UserController) UpdateUserPreferences(s fuego.ContextWithBody[shared_ty
 
 	prefs, err := c.service.UpdateUserPreferences(user.ID.String(), req)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to update user preferences", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: UpdateUserPreferences: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/settings.go
+++ b/api/internal/features/user/controller/settings.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -19,13 +20,17 @@ func (c *UserController) UpdateFont(s fuego.ContextWithBody[UpdateFontRequest]) 
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("UpdateFont", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	req, err := s.Body()
 	if err != nil {
+		c.logUserDebug("UpdateFont", fmt.Sprintf("parse body: %v", err), ctxStr)
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -34,7 +39,7 @@ func (c *UserController) UpdateFont(s fuego.ContextWithBody[UpdateFontRequest]) 
 
 	settings, err := c.service.UpdateFont(user.ID.String(), req.FontFamily, req.FontSize)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to update font settings", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: UpdateFont: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -58,13 +63,17 @@ func (c *UserController) UpdateTheme(s fuego.ContextWithBody[UpdateThemeRequest]
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("UpdateTheme", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	req, err := s.Body()
 	if err != nil {
+		c.logUserDebug("UpdateTheme", fmt.Sprintf("parse body: %v", err), ctxStr)
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -73,7 +82,7 @@ func (c *UserController) UpdateTheme(s fuego.ContextWithBody[UpdateThemeRequest]
 
 	settings, err := c.service.UpdateTheme(user.ID.String(), req.Theme)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to update theme", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: UpdateTheme: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -97,13 +106,17 @@ func (c *UserController) UpdateLanguage(s fuego.ContextWithBody[UpdateLanguageRe
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("UpdateLanguage", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	req, err := s.Body()
 	if err != nil {
+		c.logUserDebug("UpdateLanguage", fmt.Sprintf("parse body: %v", err), ctxStr)
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -112,7 +125,7 @@ func (c *UserController) UpdateLanguage(s fuego.ContextWithBody[UpdateLanguageRe
 
 	settings, err := c.service.UpdateLanguage(user.ID.String(), req.Language)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to update language", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: UpdateLanguage: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -136,13 +149,17 @@ func (c *UserController) UpdateAutoUpdate(s fuego.ContextWithBody[UpdateAutoUpda
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("UpdateAutoUpdate", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	req, err := s.Body()
 	if err != nil {
+		c.logUserDebug("UpdateAutoUpdate", fmt.Sprintf("parse body: %v", err), ctxStr)
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -151,7 +168,7 @@ func (c *UserController) UpdateAutoUpdate(s fuego.ContextWithBody[UpdateAutoUpda
 
 	settings, err := c.service.UpdateAutoUpdate(user.ID.String(), req.AutoUpdate)
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to update auto update setting", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: UpdateAutoUpdate: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),
@@ -171,14 +188,17 @@ func (c *UserController) GetSettings(s fuego.ContextNoBody) (*types.UserSettings
 	user := utils.GetUser(w, r)
 
 	if user == nil {
+		c.logUserDebug("GetSettings", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+
 	settings, err := c.service.GetSettings(user.ID.String())
 	if err != nil {
-		c.logger.Log(logger.Error, "failed to get user settings", err.Error())
+		c.logger.Log(logger.Error, fmt.Sprintf("user: GetSettings: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/update_username.go
+++ b/api/internal/features/user/controller/update_username.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-fuego/fuego"
@@ -10,10 +11,9 @@ import (
 )
 
 func (u *UserController) UpdateUserName(s fuego.ContextWithBody[types.UpdateUserNameRequest]) (*types.UpdateUsernameResponse, error) {
-	u.logger.Log(logger.Info, "updating user name", "")
-
 	req, err := s.Body()
 	if err != nil {
+		u.logUserDebug("UpdateUserName", fmt.Sprintf("parse body: %v", err), "")
 		return nil, fuego.BadRequestError{
 			Detail: err.Error(),
 			Err:    err,
@@ -31,15 +31,19 @@ func (u *UserController) UpdateUserName(s fuego.ContextWithBody[types.UpdateUser
 
 	user := utils.GetUser(w, r)
 	if user == nil {
+		u.logUserDebug("UpdateUserName", "authentication required", "")
 		return nil, fuego.UnauthorizedError{
 			Detail: "authentication required",
 		}
 	}
 
+	ctxStr := userRequestData(r, user)
+	u.logger.Log(logger.Info, "user: UpdateUserName", ctxStr)
+
 	err = u.service.UpdateUsername(user.ID.String(), &req)
 
 	if err != nil {
-		u.logger.Log(logger.Error, err.Error(), "")
+		u.logger.Log(logger.Error, fmt.Sprintf("user: UpdateUserName: %v", err), ctxStr)
 		return nil, fuego.HTTPError{
 			Err:    err,
 			Detail: err.Error(),

--- a/api/internal/features/user/controller/user_log.go
+++ b/api/internal/features/user/controller/user_log.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+	shared_types "github.com/nixopus/nixopus/api/internal/types"
+	"github.com/nixopus/nixopus/api/internal/utils"
+)
+
+func (c *UserController) logUserDebug(handler, reason, data string) {
+	c.logger.Log(logger.Debug, fmt.Sprintf("user: %s: %s", handler, reason), data)
+}
+
+func userRequestData(r *http.Request, user *shared_types.User) string {
+	orgID := utils.GetOrganizationID(r)
+	if user != nil && orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s user_id=%s", orgID, user.ID)
+	}
+	if user != nil {
+		return fmt.Sprintf("user_id=%s", user.ID)
+	}
+	if orgID != uuid.Nil {
+		return fmt.Sprintf("org_id=%s", orgID)
+	}
+	return ""
+}

--- a/api/internal/features/user/service/avatar.go
+++ b/api/internal/features/user/service/avatar.go
@@ -2,20 +2,23 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/user/types"
 )
 
 func (s *UserService) UpdateAvatar(ctx context.Context, userID string, req *types.UpdateAvatarRequest) error {
+	ctxStr := fmt.Sprintf("user_id=%s", userID)
 	if req == nil {
-		s.logger.Log(logger.Error, "invalid request type", "request is nil")
+		s.logger.Log(logger.Error, "user service: UpdateAvatar: nil request", ctxStr)
 		return types.ErrInvalidRequestType
 	}
 
-	s.logger.Log(logger.Info, "Updating avatar for user", userID)
+	payload := fmt.Sprintf("%s payload_len=%d", ctxStr, len(req.AvatarData))
+	s.logger.Log(logger.Info, "user service: UpdateAvatar", payload)
 	if err := s.storage.UpdateUserAvatar(ctx, userID, req.AvatarData); err != nil {
-		s.logger.Log(logger.Error, "failed to update avatar", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("user service: UpdateAvatar: %v", err), ctxStr)
 		return err
 	}
 

--- a/api/internal/features/user/service/is_onboarded.go
+++ b/api/internal/features/user/service/is_onboarded.go
@@ -1,14 +1,17 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 // IsOnboarded checks if a user is onboarded by reading the is_onboarded field from the database.
 func (s *UserService) IsOnboarded(userID string) (bool, error) {
+	logData := fmt.Sprintf("user_id=%s", userID)
 	isOnboarded, err := s.storage.GetIsOnboarded(userID)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to get onboarding status", userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("user service: IsOnboarded: %v", err), logData)
 		return false, err
 	}
 

--- a/api/internal/features/user/service/mark_onboarding_complete.go
+++ b/api/internal/features/user/service/mark_onboarding_complete.go
@@ -1,17 +1,20 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
 // MarkOnboardingComplete marks a user's onboarding as complete by setting is_onboarded to true.
 func (s *UserService) MarkOnboardingComplete(userID string) error {
+	logData := fmt.Sprintf("user_id=%s", userID)
 	err := s.storage.MarkOnboardingComplete(userID)
 	if err != nil {
-		s.logger.Log(logger.Error, "Failed to mark onboarding as complete", userID)
+		s.logger.Log(logger.Error, fmt.Sprintf("user service: MarkOnboardingComplete: %v", err), logData)
 		return err
 	}
 
-	s.logger.Log(logger.Info, "Onboarding marked as complete", userID)
+	s.logger.Log(logger.Info, "user service: MarkOnboardingComplete ok", logData)
 	return nil
 }

--- a/api/internal/features/user/service/settings.go
+++ b/api/internal/features/user/service/settings.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/nixopus/nixopus/api/internal/features/logger"
@@ -8,12 +9,14 @@ import (
 )
 
 func (s *UserService) GetSettings(userID string) (*types.UserSettings, error) {
-	s.logger.Log(logger.Info, "getting user settings", "")
+	ctx := fmt.Sprintf("user_id=%s", userID)
+	s.logger.Log(logger.Info, "user service: GetSettings", ctx)
 	return s.storage.GetUserSettings(userID)
 }
 
 func (s *UserService) UpdateFont(userID string, fontFamily string, fontSize int) (*types.UserSettings, error) {
-	s.logger.Log(logger.Info, "updating user font settings", "")
+	ctx := fmt.Sprintf("user_id=%s font_family=%s font_size=%d", userID, fontFamily, fontSize)
+	s.logger.Log(logger.Info, "user service: UpdateFont", ctx)
 	return s.storage.UpdateUserSettings(userID, map[string]interface{}{
 		"font_family": fontFamily,
 		"font_size":   fontSize,
@@ -22,7 +25,8 @@ func (s *UserService) UpdateFont(userID string, fontFamily string, fontSize int)
 }
 
 func (s *UserService) UpdateTheme(userID string, theme string) (*types.UserSettings, error) {
-	s.logger.Log(logger.Info, "updating user theme", "")
+	ctx := fmt.Sprintf("user_id=%s theme=%s", userID, theme)
+	s.logger.Log(logger.Info, "user service: UpdateTheme", ctx)
 	return s.storage.UpdateUserSettings(userID, map[string]interface{}{
 		"theme":      theme,
 		"updated_at": time.Now(),
@@ -30,7 +34,8 @@ func (s *UserService) UpdateTheme(userID string, theme string) (*types.UserSetti
 }
 
 func (s *UserService) UpdateLanguage(userID string, language string) (*types.UserSettings, error) {
-	s.logger.Log(logger.Info, "updating user language", "")
+	ctx := fmt.Sprintf("user_id=%s language=%s", userID, language)
+	s.logger.Log(logger.Info, "user service: UpdateLanguage", ctx)
 	return s.storage.UpdateUserSettings(userID, map[string]interface{}{
 		"language":   language,
 		"updated_at": time.Now(),
@@ -38,7 +43,8 @@ func (s *UserService) UpdateLanguage(userID string, language string) (*types.Use
 }
 
 func (s *UserService) UpdateAutoUpdate(userID string, autoUpdate bool) (*types.UserSettings, error) {
-	s.logger.Log(logger.Info, "updating user auto update setting", "")
+	ctx := fmt.Sprintf("user_id=%s auto_update=%v", userID, autoUpdate)
+	s.logger.Log(logger.Info, "user service: UpdateAutoUpdate", ctx)
 	return s.storage.UpdateUserSettings(userID, map[string]interface{}{
 		"auto_update": autoUpdate,
 		"updated_at":  time.Now(),
@@ -47,12 +53,14 @@ func (s *UserService) UpdateAutoUpdate(userID string, autoUpdate bool) (*types.U
 
 // GetUserPreferences retrieves user preferences
 func (s *UserService) GetUserPreferences(userID string) (*types.UserPreferences, error) {
-	s.logger.Log(logger.Info, "getting user preferences", "")
+	ctx := fmt.Sprintf("user_id=%s", userID)
+	s.logger.Log(logger.Info, "user service: GetUserPreferences", ctx)
 	return s.storage.GetUserPreferences(userID)
 }
 
 // UpdateUserPreferences updates user preferences with the provided data
 func (s *UserService) UpdateUserPreferences(userID string, preferences types.UserPreferencesData) (*types.UserPreferences, error) {
-	s.logger.Log(logger.Info, "updating user preferences", "")
+	ctx := fmt.Sprintf("user_id=%s", userID)
+	s.logger.Log(logger.Info, "user service: UpdateUserPreferences", ctx)
 	return s.storage.UpdateUserPreferences(userID, preferences)
 }

--- a/api/internal/features/user/service/update_username.go
+++ b/api/internal/features/user/service/update_username.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -8,27 +9,27 @@ import (
 	"github.com/nixopus/nixopus/api/internal/features/user/types"
 )
 
-// Existing function that needs to be updated
+// UpdateUsername updates the authenticated user's display name (stored as name on the user row).
 func (s *UserService) UpdateUsername(id string, req *types.UpdateUserNameRequest) error {
+	data := fmt.Sprintf("user_id=%s", id)
 	if req == nil {
-		s.logger.Log(logger.Error, "invalid request type", "request is nil")
+		s.logger.Log(logger.Error, "user service: UpdateUsername: nil request", data)
 		return types.ErrInvalidRequestType
 	}
 
-	s.logger.Log(logger.Info, "Updating req", req.Name)
 	existingUser, err := s.storage.GetUserById(id)
 	if err != nil {
-		s.logger.Log(logger.Error, "error fetching user", err.Error())
+		s.logger.Log(logger.Error, fmt.Sprintf("user service: UpdateUsername: get user: %v", err), data)
 		return err
 	}
 
 	if existingUser.ID == uuid.Nil {
-		s.logger.Log(logger.Error, types.ErrUserDoesNotExist.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("user service: UpdateUsername: %v", types.ErrUserDoesNotExist), data)
 		return types.ErrUserDoesNotExist
 	}
 
 	if err := s.storage.UpdateUserName(existingUser.ID.String(), req.Name, time.Now()); err != nil {
-		s.logger.Log(logger.Error, types.ErrFailedToUpdateUser.Error(), "")
+		s.logger.Log(logger.Error, fmt.Sprintf("user service: UpdateUsername: %v", types.ErrFailedToUpdateUser), data)
 		return types.ErrFailedToUpdateUser
 	}
 

--- a/api/internal/features/user/storage/init.go
+++ b/api/internal/features/user/storage/init.go
@@ -8,14 +8,16 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/user/types"
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 	"github.com/uptrace/bun"
 )
 
 type UserStorage struct {
-	DB  *bun.DB
-	Ctx context.Context
+	DB     *bun.DB
+	Ctx    context.Context
+	Logger *logger.Logger // optional; nil disables storage logs
 }
 
 type UserRepository interface {
@@ -31,10 +33,11 @@ type UserRepository interface {
 	MarkOnboardingComplete(userID string) error
 }
 
-func CreateNewUserStorage(db *bun.DB, ctx context.Context) *UserStorage {
+func CreateNewUserStorage(db *bun.DB, ctx context.Context, l *logger.Logger) *UserStorage {
 	return &UserStorage{
-		DB:  db,
-		Ctx: ctx,
+		DB:     db,
+		Ctx:    ctx,
+		Logger: l,
 	}
 }
 
@@ -46,9 +49,12 @@ func CreateNewUserStorage(db *bun.DB, ctx context.Context) *UserStorage {
 // an empty user and a nil error. If an error occurs during the query, it returns
 // the error.
 func (s *UserStorage) GetUserById(id string) (*shared_types.User, error) {
+	data := fmt.Sprintf("user_id=%s", id)
+	storageLog(s.Logger, logger.Debug, "user storage: GetUserById", data)
 	user := &shared_types.User{}
 	err := s.DB.NewSelect().Model(user).Where("id = ?", id).Scan(s.Ctx)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetUserById: %v", err), data)
 		return nil, err
 	}
 	return user, nil
@@ -66,13 +72,17 @@ func (s *UserStorage) GetUserById(id string) (*shared_types.User, error) {
 //
 //	error - an error if the update query fails, otherwise nil.
 func (s *UserStorage) UpdateUserName(userID string, userName string, updatedAt time.Time) error {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: UpdateUserName", data)
 	_, err := s.DB.NewUpdate().
 		Model((*shared_types.User)(nil)).
 		Set("name = ?", userName).
 		Set("updated_at = ?", updatedAt).
 		Where("id = ?", userID).
 		Exec(s.Ctx)
-
+	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserName: %v", err), data)
+	}
 	return err
 }
 
@@ -84,6 +94,9 @@ func (s *UserStorage) UpdateUserName(userID string, userName string, updatedAt t
 // If the retrieval is successful, it returns a slice of types.UserOrganizationsResponse
 // structs containing the organization and role information for each organization user.
 func (s *UserStorage) GetUserOrganizationsWithRolesAndPermissions(userID string) ([]types.UserOrganizationsResponse, error) {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: GetUserOrganizationsWithRolesAndPermissions", data)
+
 	var organizationUsers []shared_types.OrganizationUsers
 
 	query := s.DB.NewSelect().
@@ -94,6 +107,7 @@ func (s *UserStorage) GetUserOrganizationsWithRolesAndPermissions(userID string)
 
 	err := query.Scan(s.Ctx, &organizationUsers)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetUserOrganizations member scan: %v", err), data)
 		return nil, err
 	}
 
@@ -119,6 +133,9 @@ func (s *UserStorage) GetUserOrganizationsWithRolesAndPermissions(userID string)
 }
 
 func (s *UserStorage) GetUserSettings(userID string) (*shared_types.UserSettings, error) {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: GetUserSettings", data)
+
 	var settings shared_types.UserSettings
 	err := s.DB.NewSelect().
 		Model(&settings).
@@ -143,18 +160,24 @@ func (s *UserStorage) GetUserSettings(userID string) (*shared_types.UserSettings
 				Model(defaultSettings).
 				Exec(s.Ctx)
 			if err != nil {
+				storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetUserSettings insert defaults: %v", err), data)
 				return nil, err
 			}
 			return defaultSettings, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetUserSettings: %v", err), data)
 		return nil, err
 	}
 	return &settings, nil
 }
 
 func (s *UserStorage) UpdateUserSettings(userID string, updates map[string]interface{}) (*shared_types.UserSettings, error) {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: UpdateUserSettings", data)
+
 	// Ensure a settings row exists before updating.
 	if _, err := s.GetUserSettings(userID); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserSettings ensure row: %v", err), data)
 		return nil, err
 	}
 
@@ -167,6 +190,7 @@ func (s *UserStorage) UpdateUserSettings(userID string, updates map[string]inter
 	}
 
 	if _, err := query.Exec(s.Ctx); err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserSettings exec: %v", err), data)
 		return nil, err
 	}
 
@@ -174,6 +198,9 @@ func (s *UserStorage) UpdateUserSettings(userID string, updates map[string]inter
 }
 
 func (s *UserStorage) UpdateUserAvatar(ctx context.Context, userID string, avatarData string) error {
+	data := fmt.Sprintf("user_id=%s payload_len=%d", userID, len(avatarData))
+	storageLog(s.Logger, logger.Debug, "user storage: UpdateUserAvatar", data)
+
 	var image interface{}
 	if avatarData == "" {
 		image = nil
@@ -188,6 +215,7 @@ func (s *UserStorage) UpdateUserAvatar(ctx context.Context, userID string, avata
 		Exec(ctx)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserAvatar: %v", err), data)
 		return fmt.Errorf("failed to update user avatar: %w", err)
 	}
 
@@ -196,6 +224,9 @@ func (s *UserStorage) UpdateUserAvatar(ctx context.Context, userID string, avata
 
 // GetUserPreferences retrieves user preferences, creating defaults if none exist
 func (s *UserStorage) GetUserPreferences(userID string) (*shared_types.UserPreferences, error) {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: GetUserPreferences", data)
+
 	var prefs shared_types.UserPreferences
 	err := s.DB.NewSelect().
 		Model(&prefs).
@@ -221,10 +252,12 @@ func (s *UserStorage) GetUserPreferences(userID string) (*shared_types.UserPrefe
 				Model(defaultPrefs).
 				Exec(s.Ctx)
 			if err != nil {
+				storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetUserPreferences insert defaults: %v", err), data)
 				return nil, err
 			}
 			return defaultPrefs, nil
 		}
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetUserPreferences: %v", err), data)
 		return nil, err
 	}
 	return &prefs, nil
@@ -232,9 +265,13 @@ func (s *UserStorage) GetUserPreferences(userID string) (*shared_types.UserPrefe
 
 // UpdateUserPreferences updates user preferences with the provided data
 func (s *UserStorage) UpdateUserPreferences(userID string, preferences shared_types.UserPreferencesData) (*shared_types.UserPreferences, error) {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: UpdateUserPreferences", data)
+
 	// Ensure preferences exist before updating
 	existingPrefs, err := s.GetUserPreferences(userID)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserPreferences load: %v", err), data)
 		return nil, fmt.Errorf("failed to get user preferences: %w", err)
 	}
 	if existingPrefs == nil {
@@ -251,20 +288,24 @@ func (s *UserStorage) UpdateUserPreferences(userID string, preferences shared_ty
 		Exec(s.Ctx)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserPreferences exec: %v", err), data)
 		return nil, err
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserPreferences rows affected: %v", err), data)
 		return nil, fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rowsAffected == 0 {
+		storageLog(s.Logger, logger.Debug, "user storage: UpdateUserPreferences: no rows updated", data)
 		return nil, fmt.Errorf("no rows updated for user ID: %s", userID)
 	}
 
 	// Re-fetch to ensure we have the updated data
 	updatedPrefs, err := s.GetUserPreferences(userID)
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: UpdateUserPreferences refetch: %v", err), data)
 		return nil, fmt.Errorf("failed to refetch user preferences after update: %w", err)
 	}
 	return updatedPrefs, nil
@@ -272,6 +313,9 @@ func (s *UserStorage) UpdateUserPreferences(userID string, preferences shared_ty
 
 // GetIsOnboarded retrieves the is_onboarded status for a user from the database.
 func (s *UserStorage) GetIsOnboarded(userID string) (bool, error) {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: GetIsOnboarded", data)
+
 	var user shared_types.User
 	err := s.DB.NewSelect().
 		Model(&user).
@@ -280,6 +324,7 @@ func (s *UserStorage) GetIsOnboarded(userID string) (bool, error) {
 		Scan(s.Ctx)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: GetIsOnboarded: %v", err), data)
 		return false, fmt.Errorf("failed to get onboarding status: %w", err)
 	}
 
@@ -288,6 +333,9 @@ func (s *UserStorage) GetIsOnboarded(userID string) (bool, error) {
 
 // MarkOnboardingComplete sets the is_onboarded field to true for a user.
 func (s *UserStorage) MarkOnboardingComplete(userID string) error {
+	data := fmt.Sprintf("user_id=%s", userID)
+	storageLog(s.Logger, logger.Debug, "user storage: MarkOnboardingComplete", data)
+
 	_, err := s.DB.NewUpdate().
 		Model((*shared_types.User)(nil)).
 		Set("is_onboarded = ?", true).
@@ -296,6 +344,7 @@ func (s *UserStorage) MarkOnboardingComplete(userID string) error {
 		Exec(s.Ctx)
 
 	if err != nil {
+		storageLog(s.Logger, logger.Error, fmt.Sprintf("user storage: MarkOnboardingComplete: %v", err), data)
 		return fmt.Errorf("failed to mark onboarding as complete: %w", err)
 	}
 

--- a/api/internal/features/user/storage/init_test.go
+++ b/api/internal/features/user/storage/init_test.go
@@ -108,7 +108,7 @@ func insertTestUser(t *testing.T, db *bun.DB, ctx context.Context) shared_types.
 func TestCreateNewUserStorage(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 	require.NotNil(t, s)
 	assert.Equal(t, db, s.DB)
 	assert.Equal(t, ctx, s.Ctx)
@@ -119,7 +119,7 @@ func TestCreateNewUserStorage(t *testing.T) {
 func TestGetUserById_found(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 	user := insertTestUser(t, db, ctx)
 
 	result, err := s.GetUserById(user.ID.String())
@@ -131,7 +131,7 @@ func TestGetUserById_found(t *testing.T) {
 func TestGetUserById_notFound(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetUserById(uuid.New().String())
 	require.Error(t, err)
@@ -141,7 +141,7 @@ func TestGetUserById_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetUserById(uuid.New().String())
 	require.Error(t, err)
@@ -152,7 +152,7 @@ func TestGetUserById_dbError(t *testing.T) {
 func TestUpdateUserName_success(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	id := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -174,7 +174,7 @@ func TestUpdateUserName_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	err := s.UpdateUserName(uuid.New().String(), "name", time.Now())
 	require.Error(t, err)
@@ -185,7 +185,7 @@ func TestUpdateUserName_dbError(t *testing.T) {
 func TestGetUserOrgs_empty(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	orgs, err := s.GetUserOrganizationsWithRolesAndPermissions(uuid.New().String())
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestGetUserOrgs_empty(t *testing.T) {
 func TestGetUserOrgs_orgNotFound_continue(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 	user := insertTestUser(t, db, ctx)
 
 	// Member row points to a non-existent organization → hits the "continue" branch
@@ -213,7 +213,7 @@ func TestGetUserOrgs_orgNotFound_continue(t *testing.T) {
 func TestGetUserOrgs_withOrgs(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 	user := insertTestUser(t, db, ctx)
 
 	orgID := uuid.New()
@@ -239,7 +239,7 @@ func TestGetUserOrgs_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetUserOrganizationsWithRolesAndPermissions(uuid.New().String())
 	require.Error(t, err)
@@ -250,7 +250,7 @@ func TestGetUserOrgs_dbError(t *testing.T) {
 func TestGetUserSettings_found(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -269,7 +269,7 @@ func TestGetUserSettings_found(t *testing.T) {
 func TestGetUserSettings_noRows_createsDefault(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	settings, err := s.GetUserSettings(userID.String())
@@ -283,7 +283,7 @@ func TestGetUserSettings_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetUserSettings(uuid.New().String())
 	require.Error(t, err)
@@ -294,7 +294,7 @@ func TestGetUserSettings_dbError(t *testing.T) {
 func TestUpdateUserSettings_success(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -318,7 +318,7 @@ func TestUpdateUserSettings_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.UpdateUserSettings(uuid.New().String(), map[string]interface{}{"theme": "dark"})
 	require.Error(t, err)
@@ -330,7 +330,7 @@ func TestUpdateUserAvatar_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	err := s.UpdateUserAvatar(ctx, uuid.New().String(), "data:image/png;base64,abc")
 	require.Error(t, err)
@@ -341,7 +341,7 @@ func TestUpdateUserAvatar_dbError(t *testing.T) {
 func TestGetUserPreferences_found(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -359,7 +359,7 @@ func TestGetUserPreferences_found(t *testing.T) {
 func TestGetUserPreferences_noRows_createsDefault(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	prefs, err := s.GetUserPreferences(userID.String())
@@ -371,7 +371,7 @@ func TestGetUserPreferences_noRows_createsDefault(t *testing.T) {
 func TestGetUserPreferences_invalidUserID_noRows(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetUserPreferences("not-a-valid-uuid")
 	require.Error(t, err)
@@ -382,7 +382,7 @@ func TestGetUserPreferences_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetUserPreferences(uuid.New().String())
 	require.Error(t, err)
@@ -393,7 +393,7 @@ func TestGetUserPreferences_dbError(t *testing.T) {
 func TestUpdateUserPreferences_success(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -413,7 +413,7 @@ func TestUpdateUserPreferences_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.UpdateUserPreferences(uuid.New().String(), shared_types.UserPreferencesData{})
 	require.Error(t, err)
@@ -424,7 +424,7 @@ func TestUpdateUserPreferences_dbError(t *testing.T) {
 func TestGetIsOnboarded_true(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -441,7 +441,7 @@ func TestGetIsOnboarded_true(t *testing.T) {
 func TestGetIsOnboarded_false(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -459,7 +459,7 @@ func TestGetIsOnboarded_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	_, err := s.GetIsOnboarded(uuid.New().String())
 	require.Error(t, err)
@@ -470,7 +470,7 @@ func TestGetIsOnboarded_dbError(t *testing.T) {
 func TestMarkOnboardingComplete_success(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	userID := uuid.New()
 	_, err := db.ExecContext(ctx,
@@ -492,7 +492,7 @@ func TestMarkOnboardingComplete_dbError(t *testing.T) {
 	t.Parallel()
 	db, ctx := newTestUserDB(t)
 	require.NoError(t, db.Close())
-	s := user_storage.CreateNewUserStorage(db, ctx)
+	s := user_storage.CreateNewUserStorage(db, ctx, nil)
 
 	err := s.MarkOnboardingComplete(uuid.New().String())
 	require.Error(t, err)

--- a/api/internal/features/user/storage/log.go
+++ b/api/internal/features/user/storage/log.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"github.com/nixopus/nixopus/api/internal/features/logger"
+)
+
+func storageLog(l *logger.Logger, sev logger.Severity, msg, data string) {
+	if l == nil {
+		return
+	}
+	l.Log(sev, msg, data)
+}

--- a/api/internal/features/user/validation/validator.go
+++ b/api/internal/features/user/validation/validator.go
@@ -2,18 +2,26 @@ package validation
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/features/user/types"
 
 	shared_types "github.com/nixopus/nixopus/api/internal/types"
 )
 
-type Validator struct{}
+type Validator struct {
+	Logger *logger.Logger // optional; nil skips validation debug logs
+}
 
 func NewValidator() *Validator {
 	return &Validator{}
+}
+
+func NewValidatorWithLogger(l *logger.Logger) *Validator {
+	return &Validator{Logger: l}
 }
 
 func (v *Validator) ParseRequestBody(req interface{}, body io.ReadCloser, decoded interface{}) error {
@@ -28,6 +36,9 @@ func (v *Validator) ValidateRequest(req interface{}, user shared_types.User) err
 	case *types.UpdateAvatarRequest:
 		return v.ValidateUpdateAvatarRequest(*r)
 	default:
+		if v.Logger != nil {
+			v.Logger.Log(logger.Debug, fmt.Sprintf("user validation: invalid request type %T", req), "")
+		}
 		return types.ErrInvalidRequestType
 	}
 }

--- a/api/internal/middleware/audit.go
+++ b/api/internal/middleware/audit.go
@@ -23,21 +23,21 @@ func AuditMiddleware(next http.Handler, app *storage.App, l logger.Logger, resou
 
 		user, ok := r.Context().Value(types.UserContextKey).(*types.User)
 		if !ok {
-			l.Log(logger.Debug, "Audit middleware skipped", fmt.Sprintf("No user in context, path: %s", r.URL.Path))
+			l.Log(logger.Debug, "middleware audit: skipped: no user in context", fmt.Sprintf("path=%s", r.URL.Path))
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		orgIDStr, ok := r.Context().Value(types.OrganizationIDKey).(string)
 		if !ok {
-			l.Log(logger.Debug, "Audit middleware skipped", fmt.Sprintf("No organization ID in context, path: %s, user_id: %s", r.URL.Path, user.ID))
+			l.Log(logger.Debug, "middleware audit: skipped: no organization in context", fmt.Sprintf("path=%s user_id=%s", r.URL.Path, user.ID))
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		orgID, err := uuid.Parse(orgIDStr)
 		if err != nil {
-			l.Log(logger.Warning, "Audit middleware skipped", fmt.Sprintf("Invalid organization ID, path: %s, user_id: %s, org_id: %s, error: %s", r.URL.Path, user.ID, orgIDStr, err.Error()))
+			l.Log(logger.Warning, "middleware audit: skipped: invalid organization id", fmt.Sprintf("path=%s user_id=%s org_id=%s error=%v", r.URL.Path, user.ID, orgIDStr, err))
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -94,10 +94,10 @@ func AuditMiddleware(next http.Handler, app *storage.App, l logger.Logger, resou
 			// Fire audit logging asynchronously to not affect API response time
 			go func() {
 				if err := auditService.LogAction(auditReq); err != nil {
-					l.Log(logger.Warning, "Failed to create audit log", fmt.Sprintf("path: %s, method: %s, user_id: %s, org_id: %s, error: %s",
-						r.URL.Path, r.Method, user.ID, orgID, err.Error()))
+					l.Log(logger.Warning, "middleware audit: failed to persist log", fmt.Sprintf("path=%s method=%s user_id=%s org_id=%s error=%v",
+						r.URL.Path, r.Method, user.ID, orgID, err))
 				} else {
-					l.Log(logger.Debug, "Audit log created", fmt.Sprintf("path: %s, method: %s, user_id: %s, org_id: %s",
+					l.Log(logger.Debug, "middleware audit: log created", fmt.Sprintf("path=%s method=%s user_id=%s org_id=%s",
 						r.URL.Path, r.Method, user.ID, orgID))
 				}
 			}()

--- a/api/internal/middleware/auth.go
+++ b/api/internal/middleware/auth.go
@@ -7,13 +7,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/cache"
 	betterauth "github.com/nixopus/nixopus/api/internal/features/auth"
+	applogger "github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/storage"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -110,11 +110,11 @@ func verifySessionWithFallback(r *http.Request) (*betterauth.SessionResponse, er
 // AuthMiddleware is a middleware that checks if the request has a valid
 // Better Auth session. If the session is valid, it adds both the user and
 // the authenticated client to the request context.
-func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache) http.Handler {
+func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache, l applogger.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		if handled := tryM2MJWTAuth(ctx, w, r, next, app); handled {
+		if handled := tryM2MJWTAuth(ctx, w, r, next, app, l); handled {
 			return
 		}
 
@@ -126,7 +126,7 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache) http.Ha
 
 		sessionResp, err := verifySessionCached(r, sessionCache)
 		if err != nil {
-			log.Printf("ERROR AuthMiddleware: Auth failed for path %s: %v", r.URL.Path, err)
+			l.Log(applogger.Error, fmt.Sprintf("middleware auth: verify session failed: %v", err), fmt.Sprintf("path=%s", r.URL.Path))
 			utils.SendErrorResponse(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
 			return
 		}
@@ -135,7 +135,7 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache) http.Ha
 
 		userIDUUID, err := uuid.Parse(betterAuthUserID)
 		if err != nil {
-			log.Printf("ERROR AuthMiddleware: Invalid Better Auth user ID format: %s", betterAuthUserID)
+			l.Log(applogger.Error, "middleware auth: invalid Better Auth user id format", fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
 			utils.SendErrorResponse(w, "Invalid user ID", http.StatusUnauthorized)
 			return
 		}
@@ -156,11 +156,11 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache) http.Ha
 
 			if err != nil {
 				if err == sql.ErrNoRows {
-					log.Printf("ERROR AuthMiddleware: User not found in Better Auth user table with ID %s", betterAuthUserID)
+					l.Log(applogger.Error, "middleware auth: user not found in database", fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
 					utils.SendErrorResponse(w, "User not found", http.StatusUnauthorized)
 					return
 				}
-				log.Printf("ERROR AuthMiddleware: Failed to query Better Auth user table: %v", err)
+				l.Log(applogger.Error, fmt.Sprintf("middleware auth: user lookup failed: %v", err), fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
 				utils.SendErrorResponse(w, "Failed to fetch user", http.StatusInternalServerError)
 				return
 			}
@@ -176,9 +176,9 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache) http.Ha
 		ctx = context.WithValue(ctx, types.UserContextKey, user)
 
 		if !isAuthEndpoint(r.URL.Path) {
-			organizationID, err := resolveAndVerifyOrganization(ctx, r, c, app, betterAuthUserID, sessionResp)
+			organizationID, err := resolveAndVerifyOrganization(ctx, r, c, app, betterAuthUserID, sessionResp, l)
 			if err != nil {
-				log.Printf("ERROR AuthMiddleware: Failed to resolve organization: %v", err)
+				l.Log(applogger.Error, fmt.Sprintf("middleware auth: resolve organization failed: %v", err), fmt.Sprintf("path=%s user_id=%s", r.URL.Path, betterAuthUserID))
 				statusCode := http.StatusBadRequest
 				if strings.Contains(err.Error(), "does not belong") {
 					statusCode = http.StatusForbidden
@@ -195,7 +195,7 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache) http.Ha
 	})
 }
 
-func tryM2MJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, next http.Handler, app *storage.App) bool {
+func tryM2MJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, next http.Handler, app *storage.App, l applogger.Logger) bool {
 	authHeader := r.Header.Get("Authorization")
 	if !strings.HasPrefix(authHeader, "Bearer ") {
 		return false
@@ -208,20 +208,20 @@ func tryM2MJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, 
 
 	orgID, err := validateM2MJWT(ctx, token, r.Header.Get("X-Organization-Id"))
 	if err != nil {
-		log.Printf("INFO AuthMiddleware: M2M JWT validation failed for path %s, falling through to session auth: %v", r.URL.Path, err)
+		l.Log(applogger.Info, "middleware auth: M2M JWT validation failed, using session auth", fmt.Sprintf("path=%s error=%v", r.URL.Path, err))
 		return false
 	}
 
 	userIDStr := r.Header.Get("X-User-Id")
 	if userIDStr == "" {
-		log.Printf("ERROR AuthMiddleware: M2M request missing X-User-Id header for path %s", r.URL.Path)
+		l.Log(applogger.Error, "middleware auth: M2M request missing X-User-Id", fmt.Sprintf("path=%s", r.URL.Path))
 		utils.SendErrorResponse(w, "M2M requests require X-User-Id header", http.StatusUnauthorized)
 		return true
 	}
 
 	userUUID, err := uuid.Parse(userIDStr)
 	if err != nil {
-		log.Printf("ERROR AuthMiddleware: Invalid X-User-Id format %q for path %s", userIDStr, r.URL.Path)
+		l.Log(applogger.Error, "middleware auth: invalid X-User-Id", fmt.Sprintf("user_id=%q path=%s", userIDStr, r.URL.Path))
 		utils.SendErrorResponse(w, "Invalid X-User-Id format", http.StatusUnauthorized)
 		return true
 	}
@@ -229,7 +229,7 @@ func tryM2MJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, 
 	var user types.User
 	err = app.Store.DB.NewSelect().Model(&user).Where("id = ?", userUUID).Scan(ctx)
 	if err != nil {
-		log.Printf("ERROR AuthMiddleware: M2M user lookup failed for ID %s: %v", userIDStr, err)
+		l.Log(applogger.Error, fmt.Sprintf("middleware auth: M2M user lookup failed: %v", err), fmt.Sprintf("user_id=%s path=%s", userIDStr, r.URL.Path))
 		utils.SendErrorResponse(w, "User not found", http.StatusUnauthorized)
 		return true
 	}
@@ -289,6 +289,7 @@ func resolveAndVerifyOrganization(
 	app *storage.App,
 	betterAuthUserID string,
 	sessionResp *betterauth.SessionResponse,
+	l applogger.Logger,
 ) (string, error) {
 	// Extract organization ID from session (already verified, no duplicate API call)
 	organizationID := extractOrgIDFromSession(sessionResp, r)
@@ -309,7 +310,7 @@ func resolveAndVerifyOrganization(
 				Limit(1).
 				Scan(ctx)
 			if dbErr == nil && member.OrganizationID != uuid.Nil {
-				log.Printf("INFO AuthMiddleware: activeOrganizationId missing from session for user %s, resolved from DB member table: %s", betterAuthUserID, member.OrganizationID)
+				l.Log(applogger.Info, "middleware auth: resolved org from DB (session missing activeOrganizationId)", fmt.Sprintf("user_id=%s organization_id=%s", betterAuthUserID, member.OrganizationID))
 				return member.OrganizationID.String(), nil
 			}
 		}
@@ -317,7 +318,7 @@ func resolveAndVerifyOrganization(
 	}
 
 	// Check organization membership via Better Auth API (with caching)
-	_, err := verifyOrganizationMembership(ctx, r, cache, betterAuthUserID, organizationID)
+	_, err := verifyOrganizationMembership(ctx, r, cache, betterAuthUserID, organizationID, l)
 	if err != nil {
 		return "", fmt.Errorf("user %s does not belong to organization %s: %w", betterAuthUserID, organizationID, err)
 	}
@@ -334,6 +335,7 @@ func verifyOrganizationMembership(
 	cache *cache.Cache,
 	betterAuthUserID string,
 	organizationID string,
+	l applogger.Logger,
 ) (bool, error) {
 	// Check cache first
 	if cache != nil {
@@ -343,7 +345,7 @@ func verifyOrganizationMembership(
 	}
 
 	// Verify membership via Better Auth API
-	member, err := getBetterAuthOrganizationMember(ctx, r, betterAuthUserID, organizationID)
+	member, err := getBetterAuthOrganizationMember(ctx, r, betterAuthUserID, organizationID, l)
 	if err != nil || member == nil {
 		// Cache negative result to avoid repeated API calls
 		if cache != nil {

--- a/api/internal/middleware/middleware_auth_rbac_feature_audit_test.go
+++ b/api/internal/middleware/middleware_auth_rbac_feature_audit_test.go
@@ -187,7 +187,7 @@ func Test_resolveAndVerifyOrganization_DB_fallback(t *testing.T) {
 	insertUser(t, db, ctx, uid, "m@x")
 	insertMember(t, db, ctx, uid, oid)
 
-	got, err := resolveAndVerifyOrganization(ctx, httptest.NewRequest(http.MethodGet, "/", nil), nil, app, uid.String(), sessionResp(uid.String(), ""))
+	got, err := resolveAndVerifyOrganization(ctx, httptest.NewRequest(http.MethodGet, "/", nil), nil, app, uid.String(), sessionResp(uid.String(), ""), logger.NewLogger())
 	require.NoError(t, err)
 	require.Equal(t, oid.String(), got)
 }
@@ -197,7 +197,7 @@ func Test_resolveAndVerifyOrganization_errors(t *testing.T) {
 	ctx := app.Ctx
 	t.Setenv("AUTH_SERVICE_URL", "http://127.0.0.1:9")
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
-	_, err := resolveAndVerifyOrganization(ctx, httptest.NewRequest(http.MethodGet, "/", nil), nil, app, uuid.New().String(), sessionResp(uuid.New().String(), "00000000-0000-0000-0000-000000000001"))
+	_, err := resolveAndVerifyOrganization(ctx, httptest.NewRequest(http.MethodGet, "/", nil), nil, app, uuid.New().String(), sessionResp(uuid.New().String(), "00000000-0000-0000-0000-000000000001"), logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not belong")
 }
@@ -209,7 +209,7 @@ func Test_verifyOrganizationMembership_cacheAndAPI(t *testing.T) {
 	oid := uuid.New().String()
 
 	require.NoError(t, c.SetOrgMembership(ctx, uid, oid, true))
-	ok, err := verifyOrganizationMembership(ctx, httptest.NewRequest(http.MethodGet, "/", nil), c, uid, oid)
+	ok, err := verifyOrganizationMembership(ctx, httptest.NewRequest(http.MethodGet, "/", nil), c, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -221,7 +221,7 @@ func Test_verifyOrganizationMembership_cacheAndAPI(t *testing.T) {
 	}
 	t.Cleanup(func() { betterauth.HTTPClient = orig })
 
-	ok, err = verifyOrganizationMembership(ctx, httptest.NewRequest(http.MethodGet, "/", nil), c, uid, "00000000-0000-0000-0000-000000000002")
+	ok, err = verifyOrganizationMembership(ctx, httptest.NewRequest(http.MethodGet, "/", nil), c, uid, "00000000-0000-0000-0000-000000000002", logger.NewLogger())
 	require.Error(t, err)
 	require.False(t, ok)
 }
@@ -246,7 +246,7 @@ func Test_AuthMiddleware_branches(t *testing.T) {
 		verifySessionFn = func(*http.Request) (*betterauth.SessionResponse, error) {
 			return nil, errors.New("nope")
 		}
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, authReq(t, "/api/v1/machines"))
 		require.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -256,7 +256,7 @@ func Test_AuthMiddleware_branches(t *testing.T) {
 		verifySessionFn = func(*http.Request) (*betterauth.SessionResponse, error) {
 			return sessionResp("not-a-uuid", oid.String()), nil
 		}
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, authReq(t, "/api/v1/machines"))
 		require.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -266,7 +266,7 @@ func Test_AuthMiddleware_branches(t *testing.T) {
 		verifySessionFn = func(*http.Request) (*betterauth.SessionResponse, error) {
 			return sessionResp(uuid.New().String(), oid.String()), nil
 		}
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, authReq(t, "/api/v1/machines"))
 		require.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -281,7 +281,7 @@ func Test_AuthMiddleware_branches(t *testing.T) {
 		h := AuthMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			v, _ := r.Context().Value(types.OrganizationIDKey).(string)
 			saw = v == oid.String()
-		}), app, c)
+		}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, authReq(t, "/api/v1/machines"))
 		require.True(t, saw, "body=%s code=%d", rec.Body.String(), rec.Code)
@@ -294,7 +294,7 @@ func Test_AuthMiddleware_branches(t *testing.T) {
 		var org any
 		h := AuthMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			org = r.Context().Value(types.OrganizationIDKey)
-		}), app, c)
+		}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, authReq(t, "/api/v1/auth/login"))
 		require.Nil(t, org)
@@ -350,7 +350,7 @@ func Test_tryM2MJWTAuth(t *testing.T) {
 		var gotOrg any
 		h := AuthMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			gotOrg = r.Context().Value(types.OrganizationIDKey)
-		}), app, nil)
+		}), app, nil, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
 		req.Header.Set("Authorization", "Bearer "+tok)
@@ -361,7 +361,7 @@ func Test_tryM2MJWTAuth(t *testing.T) {
 	})
 
 	t.Run("missing X-User-Id", func(t *testing.T) {
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, nil)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, nil, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
 		req.Header.Set("Authorization", "Bearer "+tok)
@@ -371,7 +371,7 @@ func Test_tryM2MJWTAuth(t *testing.T) {
 	})
 
 	t.Run("invalid X-User-Id", func(t *testing.T) {
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, nil)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, nil, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
 		req.Header.Set("Authorization", "Bearer "+tok)
@@ -392,7 +392,7 @@ func Test_tryM2MJWTAuth(t *testing.T) {
 		var ok bool
 		h := AuthMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			ok = r.Context().Value(types.OrganizationIDKey) == oid.String()
-		}), app, rc)
+		}), app, rc, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/machines", nil)
 		req.Header.Set("Authorization", "Bearer opaque-not-jwt")
@@ -416,7 +416,7 @@ func Test_RBACMiddleware(t *testing.T) {
 	}))
 
 	t.Run("missing org header uses context", func(t *testing.T) {
-		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine")
+		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine", logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/machines", nil)
 		ctx := context.WithValue(context.Background(), types.UserContextKey, u)
@@ -426,7 +426,7 @@ func Test_RBACMiddleware(t *testing.T) {
 	})
 
 	t.Run("missing user", func(t *testing.T) {
-		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine")
+		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine", logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("X-Organization-Id", oid.String())
@@ -435,7 +435,7 @@ func Test_RBACMiddleware(t *testing.T) {
 	})
 
 	t.Run("invalid user type", func(t *testing.T) {
-		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine")
+		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine", logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("X-Organization-Id", oid.String())
@@ -449,7 +449,7 @@ func Test_RBACMiddleware(t *testing.T) {
 			Roles:       []string{"viewer"},
 			Permissions: []string{"user:read"},
 		}))
-		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine")
+		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine", logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
 		req.Header.Set("X-Organization-Id", oid.String())
@@ -459,7 +459,7 @@ func Test_RBACMiddleware(t *testing.T) {
 	})
 
 	t.Run("missing org in header and context", func(t *testing.T) {
-		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine")
+		h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "machine", logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		ctx := context.WithValue(context.Background(), types.UserContextKey, u)
@@ -507,7 +507,7 @@ func Test_validateCachedPermissions_and_validateAndCachePermissions(t *testing.T
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	ok := validateAndCachePermissions(ctx, ctxUser, oid, "user:read", app)
+	ok := validateAndCachePermissions(ctx, ctxUser, oid, "user:read", app, logger.NewLogger())
 	require.True(t, ok)
 
 	cacheRBACPermissionsFromMember(uid, oid, &BetterAuthMember{UserID: uid, Role: []interface{}{"viewer"}})
@@ -516,24 +516,24 @@ func Test_validateCachedPermissions_and_validateAndCachePermissions(t *testing.T
 func Test_extractOrganizationID(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	require.Empty(t, extractOrganizationID(rec, req))
+	require.Empty(t, extractOrganizationID(rec, req, logger.NewLogger()))
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 
 	rec2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
 	req2.Header.Set("X-Organization-Id", "not-uuid")
-	require.Empty(t, extractOrganizationID(rec2, req2))
+	require.Empty(t, extractOrganizationID(rec2, req2, logger.NewLogger()))
 
 	oid := uuid.New().String()
 	rec3 := httptest.NewRecorder()
 	req3 := httptest.NewRequest(http.MethodGet, "/", nil)
 	req3.Header.Set("X-Organization-Id", oid)
-	require.Equal(t, oid, extractOrganizationID(rec3, req3))
+	require.Equal(t, oid, extractOrganizationID(rec3, req3, logger.NewLogger()))
 
 	rec4 := httptest.NewRecorder()
 	req4 := httptest.NewRequest(http.MethodGet, "/", nil)
 	cctx := context.WithValue(context.Background(), types.OrganizationIDKey, oid)
-	require.Equal(t, oid, extractOrganizationID(rec4, req4.WithContext(cctx)))
+	require.Equal(t, oid, extractOrganizationID(rec4, req4.WithContext(cctx), logger.NewLogger()))
 }
 
 func Test_FeatureFlagMiddleware(t *testing.T) {

--- a/api/internal/middleware/middleware_coverage_gaps_test.go
+++ b/api/internal/middleware/middleware_coverage_gaps_test.go
@@ -62,7 +62,7 @@ func Test_AuthMiddleware_moreBranches(t *testing.T) {
 		h := AuthMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			u2 := r.Context().Value(types.UserContextKey).(*types.User)
 			hit = u2.Email == "gaps@x"
-		}), app, c)
+		}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := authReq(t, "/api/v1/machines")
 		h.ServeHTTP(rec, req)
@@ -74,7 +74,7 @@ func Test_AuthMiddleware_moreBranches(t *testing.T) {
 			return sessionResp(uid.String(), oid.String()), nil
 		}
 		require.NoError(t, c.SetOrgMembership(ctx, uid.String(), oid.String(), true))
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := authReq(t, "/api/v1/machines")
 		req.Header.Set("X-Disable-Cache", "true")
@@ -89,7 +89,7 @@ func Test_AuthMiddleware_moreBranches(t *testing.T) {
 		t.Setenv("AUTH_SERVICE_URL", "http://127.0.0.1:9")
 		t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 		_ = c.InvalidateOrgMembership(ctx, uid.String(), oid.String())
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := authReq(t, "/api/v1/machines")
 		h.ServeHTTP(rec, req)
@@ -103,7 +103,7 @@ func Test_AuthMiddleware_moreBranches(t *testing.T) {
 		}
 		_ = c.InvalidateUserByID(ctx, uid.String())
 		require.NoError(t, db.Close())
-		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c)
+		h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, c, logger.NewLogger())
 		rec := httptest.NewRecorder()
 		req := authReq(t, "/api/v1/machines")
 		h.ServeHTTP(rec, req)
@@ -113,7 +113,7 @@ func Test_AuthMiddleware_moreBranches(t *testing.T) {
 
 func Test_resolveAndVerifyOrganization_noOrg_badUserID(t *testing.T) {
 	app := testApp(t)
-	_, err := resolveAndVerifyOrganization(context.Background(), httptest.NewRequest(http.MethodGet, "/", nil), nil, app, "not-uuid", sessionResp("not-uuid", ""))
+	_, err := resolveAndVerifyOrganization(context.Background(), httptest.NewRequest(http.MethodGet, "/", nil), nil, app, "not-uuid", sessionResp("not-uuid", ""), logger.NewLogger())
 	require.ErrorContains(t, err, "no organization ID")
 }
 
@@ -122,7 +122,7 @@ func Test_verifyOrganizationMembership_cacheReadError(t *testing.T) {
 	c, err := cache.NewCache("redis://" + mr.Addr())
 	require.NoError(t, err)
 	mr.Close()
-	_, err = verifyOrganizationMembership(context.Background(), nil, c, "u", "00000000-0000-0000-0000-000000000001")
+	_, err = verifyOrganizationMembership(context.Background(), nil, c, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 }
 
@@ -147,7 +147,7 @@ func Test_validateAndCachePermissions_variants(t *testing.T) {
 	t.Run("member fetch fails", func(t *testing.T) {
 		t.Setenv("AUTH_SERVICE_URL", "http://127.0.0.1:9")
 		t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
-		require.False(t, validateAndCachePermissions(ctx, u, oid, "user:read", app))
+		require.False(t, validateAndCachePermissions(ctx, u, oid, "user:read", app, logger.NewLogger()))
 	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -157,7 +157,7 @@ func Test_validateAndCachePermissions_variants(t *testing.T) {
 	t.Cleanup(srv.Close)
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
-	require.False(t, validateAndCachePermissions(ctx, u, oid, "user:read", app))
+	require.False(t, validateAndCachePermissions(ctx, u, oid, "user:read", app, logger.NewLogger()))
 
 	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		body := `[{"userId":"` + uid.String() + `","organizationId":"` + oid + `","role":123,"user":{"id":"` + uid.String() + `"}}]`
@@ -166,7 +166,7 @@ func Test_validateAndCachePermissions_variants(t *testing.T) {
 	}))
 	t.Cleanup(srv2.Close)
 	t.Setenv("AUTH_SERVICE_URL", srv2.URL)
-	ok := validateAndCachePermissions(ctx, u, oid, "user:read", app)
+	ok := validateAndCachePermissions(ctx, u, oid, "user:read", app, logger.NewLogger())
 	require.True(t, ok)
 
 	srv3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -176,7 +176,7 @@ func Test_validateAndCachePermissions_variants(t *testing.T) {
 	}))
 	t.Cleanup(srv3.Close)
 	t.Setenv("AUTH_SERVICE_URL", srv3.URL)
-	require.True(t, validateAndCachePermissions(ctx, u, oid, "user:read", app))
+	require.True(t, validateAndCachePermissions(ctx, u, oid, "user:read", app, logger.NewLogger()))
 }
 
 func Test_cacheRBACPermissionsFromMember_variants(t *testing.T) {
@@ -301,7 +301,7 @@ func Test_tryM2MJWTAuth_validateFailsFallsThrough(t *testing.T) {
 	rc := testRedisCache(t)
 	require.NoError(t, rc.SetOrgMembership(context.Background(), uid.String(), oid.String(), true))
 
-	h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, rc)
+	h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, rc, logger.NewLogger())
 	rec := httptest.NewRecorder()
 	req := authReq(t, "/api/v1/machines")
 	req.Header.Set("Authorization", "Bearer not-a-jwt-shape")
@@ -423,7 +423,7 @@ func Test_validateAndCachePermissions_roleJSONString(t *testing.T) {
 	t.Cleanup(srv.Close)
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
-	require.True(t, validateAndCachePermissions(ctx, u, oid, "user:read", app))
+	require.True(t, validateAndCachePermissions(ctx, u, oid, "user:read", app, logger.NewLogger()))
 }
 
 func Test_validateAndCachePermissions_noHTTPRequestInContext(t *testing.T) {
@@ -439,7 +439,7 @@ func Test_validateAndCachePermissions_noHTTPRequestInContext(t *testing.T) {
 	t.Cleanup(srv.Close)
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
-	require.True(t, validateAndCachePermissions(context.Background(), u, oid, "user:read", app))
+	require.True(t, validateAndCachePermissions(context.Background(), u, oid, "user:read", app, logger.NewLogger()))
 }
 
 func Test_validateAndCachePermissions_httpRequestWrongTypeInContext(t *testing.T) {
@@ -456,7 +456,7 @@ func Test_validateAndCachePermissions_httpRequestWrongTypeInContext(t *testing.T
 	t.Cleanup(srv.Close)
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
-	require.True(t, validateAndCachePermissions(ctx, u, oid, "user:read", app))
+	require.True(t, validateAndCachePermissions(ctx, u, oid, "user:read", app, logger.NewLogger()))
 }
 
 func Test_RBACMiddleware_cacheMissFetchesFromBetterAuth(t *testing.T) {
@@ -477,7 +477,7 @@ func Test_RBACMiddleware_cacheMissFetchesFromBetterAuth(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "user")
+	h := RBACMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), &storage.App{}, "user", logger.NewLogger())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
 	req.Header.Set("X-Organization-Id", oid.String())
@@ -505,7 +505,7 @@ func Test_verifyOrganizationMembership_successSetsOrgCacheAndRBAC(t *testing.T) 
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	ok, err := verifyOrganizationMembership(ctx, httptest.NewRequest(http.MethodGet, "/", nil), c, uid, oid)
+	ok, err := verifyOrganizationMembership(ctx, httptest.NewRequest(http.MethodGet, "/", nil), c, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	require.True(t, ok)
 	cached, err := c.GetOrgMembership(ctx, uid, oid)
@@ -568,7 +568,7 @@ func Test_tryM2MJWTAuth_invalidSignedJWTFallsThrough(t *testing.T) {
 	rc := testRedisCache(t)
 	require.NoError(t, rc.SetOrgMembership(ctx, uid.String(), oid.String(), true))
 
-	h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, rc)
+	h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, rc, logger.NewLogger())
 	rec := httptest.NewRecorder()
 	req := authReq(t, "/api/v1/machines")
 	req.Header.Set("Authorization", "Bearer "+badTok)
@@ -620,7 +620,7 @@ func Test_tryM2MJWTAuth_userMissingInDatabase(t *testing.T) {
 	require.NoError(t, err)
 
 	missingUser := uuid.New()
-	h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, nil)
+	h := AuthMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), app, nil, logger.NewLogger())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
 	req.Header.Set("Authorization", "Bearer "+string(raw))

--- a/api/internal/middleware/middleware_misc_test.go
+++ b/api/internal/middleware/middleware_misc_test.go
@@ -10,12 +10,13 @@ import (
 	"time"
 
 	"github.com/nixopus/nixopus/api/internal/config"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRecoveryMiddleware_panicAndOK(t *testing.T) {
-	h := RecoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := RecoveryMiddleware(logger.NewLogger())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/panic" {
 			panic("boom")
 		}

--- a/api/internal/middleware/rbac.go
+++ b/api/internal/middleware/rbac.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nixopus/nixopus/api/internal/cache"
 	betterauth "github.com/nixopus/nixopus/api/internal/features/auth"
+	applogger "github.com/nixopus/nixopus/api/internal/features/logger"
 	appStorage "github.com/nixopus/nixopus/api/internal/storage"
 	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/nixopus/nixopus/api/internal/utils"
@@ -35,28 +35,28 @@ func InitRBACCache(c *cache.Cache) {
 // RBACMiddleware validates permissions for the given resource based on HTTP method.
 // It extracts organization ID from header and validates permissions from the database.
 // Uses Redis cache to reduce database calls.
-func RBACMiddleware(next http.Handler, app *appStorage.App, resource string) http.Handler {
+func RBACMiddleware(next http.Handler, app *appStorage.App, resource string, l applogger.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requiredPermission := buildRequiredPermission(resource, r.Method)
-		log.Printf("DEBUG RBAC: %s %s -> required permission=%s", r.Method, r.URL.Path, requiredPermission)
+		l.Log(applogger.Debug, "middleware rbac: required permission", fmt.Sprintf("method=%s path=%s permission=%s", r.Method, r.URL.Path, requiredPermission))
 
-		organizationID := extractOrganizationID(w, r)
+		organizationID := extractOrganizationID(w, r, l)
 		if organizationID == "" {
-			log.Printf("DEBUG RBAC: %s %s -> blocked: missing or invalid X-Organization-Id header", r.Method, r.URL.Path)
+			l.Log(applogger.Debug, "middleware rbac: blocked: missing org", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			return
 		}
 
 		// Get user from context (set by AuthMiddleware)
 		userAny := r.Context().Value(types.UserContextKey)
 		if userAny == nil {
-			log.Printf("DEBUG RBAC: %s %s -> blocked: user not in context", r.Method, r.URL.Path)
+			l.Log(applogger.Debug, "middleware rbac: blocked: no user in context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			utils.SendErrorResponse(w, "User not found in context", http.StatusUnauthorized)
 			return
 		}
 
 		user, ok := userAny.(*types.User)
 		if !ok {
-			log.Printf("DEBUG RBAC: %s %s -> blocked: invalid user type in context", r.Method, r.URL.Path)
+			l.Log(applogger.Debug, "middleware rbac: blocked: invalid user in context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			utils.SendErrorResponse(w, "Invalid user type in context", http.StatusUnauthorized)
 			return
 		}
@@ -65,28 +65,28 @@ func RBACMiddleware(next http.Handler, app *appStorage.App, resource string) htt
 		ctx := context.WithValue(r.Context(), "http_request", r)
 
 		// Validate permission
-		if !validateUserPermission(ctx, user, organizationID, requiredPermission, app) {
-			log.Printf("DEBUG RBAC: %s %s -> blocked: user %s lacks %s for org %s", r.Method, r.URL.Path, user.ID, requiredPermission, organizationID)
+		if !validateUserPermission(ctx, user, organizationID, requiredPermission, app, l) {
+			l.Log(applogger.Debug, "middleware rbac: blocked: insufficient permission", fmt.Sprintf("method=%s path=%s user_id=%s permission=%s org_id=%s", r.Method, r.URL.Path, user.ID, requiredPermission, organizationID))
 			utils.SendErrorResponse(w, fmt.Sprintf("User lacks permission %s for organization %s", requiredPermission, organizationID), http.StatusForbidden)
 			return
 		}
 
-		log.Printf("DEBUG RBAC: %s %s -> allowed (user=%s, org=%s)", r.Method, r.URL.Path, user.ID, organizationID)
+		l.Log(applogger.Debug, "middleware rbac: allowed", fmt.Sprintf("method=%s path=%s user_id=%s org_id=%s", r.Method, r.URL.Path, user.ID, organizationID))
 		next.ServeHTTP(w, r)
 	})
 }
 
 // validateUserPermission validates user permissions using database
-func validateUserPermission(ctx context.Context, user *types.User, organizationID, requiredPermission string, app *appStorage.App) bool {
+func validateUserPermission(ctx context.Context, user *types.User, organizationID, requiredPermission string, app *appStorage.App, l applogger.Logger) bool {
 	// Try cache first
 	if result := validateCachedPermissions(user.ID.String(), organizationID, requiredPermission); result != nil {
-		log.Printf("DEBUG RBAC: cache hit for user=%s org=%s -> hasPerm=%v", user.ID, organizationID, *result)
+		l.Log(applogger.Debug, "middleware rbac: cache hit", fmt.Sprintf("user_id=%s org_id=%s has_perm=%v", user.ID, organizationID, *result))
 		return *result
 	}
 
-	log.Printf("DEBUG RBAC: cache miss for user=%s org=%s -> fetching from Better Auth", user.ID, organizationID)
+	l.Log(applogger.Debug, "middleware rbac: cache miss", fmt.Sprintf("user_id=%s org_id=%s", user.ID, organizationID))
 	// Cache miss: fetch from database
-	return validateAndCachePermissions(ctx, user, organizationID, requiredPermission, app)
+	return validateAndCachePermissions(ctx, user, organizationID, requiredPermission, app, l)
 }
 
 // validateCachedPermissions validates permissions using cached data
@@ -111,7 +111,7 @@ func validateCachedPermissions(userID, organizationID, requiredPermission string
 }
 
 // validateAndCachePermissions fetches permissions from Better Auth, caches them, and validates
-func validateAndCachePermissions(ctx context.Context, user *types.User, organizationID, requiredPermission string, app *appStorage.App) bool {
+func validateAndCachePermissions(ctx context.Context, user *types.User, organizationID, requiredPermission string, app *appStorage.App, l applogger.Logger) bool {
 	// Get the HTTP request from context to forward cookies to Better Auth
 	req := ctx.Value("http_request")
 	var httpReq *http.Request
@@ -120,14 +120,14 @@ func validateAndCachePermissions(ctx context.Context, user *types.User, organiza
 	}
 
 	// Get user's role from Better Auth organization membership
-	member, err := getBetterAuthOrganizationMember(ctx, httpReq, user.ID.String(), organizationID)
+	member, err := getBetterAuthOrganizationMember(ctx, httpReq, user.ID.String(), organizationID, l)
 	if err != nil || member == nil {
-		log.Printf("DEBUG RBAC: getBetterAuthOrganizationMember failed for user=%s org=%s: err=%v", user.ID, organizationID, err)
+		l.Log(applogger.Debug, "middleware rbac: list-members failed", fmt.Sprintf("user_id=%s org_id=%s error=%v", user.ID, organizationID, err))
 		// If we can't verify membership, deny access
 		return false
 	}
 
-	log.Printf("DEBUG RBAC: Better Auth member found for user=%s org=%s, role=%v", user.ID, organizationID, member.Role)
+	l.Log(applogger.Debug, "middleware rbac: member resolved", fmt.Sprintf("user_id=%s org_id=%s role=%v", user.ID, organizationID, member.Role))
 
 	// Extract role from Better Auth member data
 	// Better Auth can return role as string or array
@@ -150,7 +150,7 @@ func validateAndCachePermissions(ctx context.Context, user *types.User, organiza
 	roles := []string{role}
 	permissions := getPermissionsForRole(role)
 
-	log.Printf("DEBUG RBAC: resolved role=%s -> %d permissions, hasRequired=%v", role, len(permissions), hasPermission(permissions, requiredPermission))
+	l.Log(applogger.Debug, "middleware rbac: role resolved", fmt.Sprintf("role=%s permission_count=%d has_required=%v", role, len(permissions), hasPermission(permissions, requiredPermission)))
 
 	// Cache permissions
 	cachePermissions(user.ID.String(), organizationID, roles, permissions)
@@ -175,7 +175,7 @@ type BetterAuthMember struct {
 }
 
 // getBetterAuthOrganizationMember fetches organization membership from Better Auth API
-func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Request, userID, organizationID string) (*BetterAuthMember, error) {
+func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Request, userID, organizationID string, l applogger.Logger) (*BetterAuthMember, error) {
 	betterAuthURL := os.Getenv("AUTH_SERVICE_URL")
 	if betterAuthURL == "" {
 		betterAuthURL = "http://localhost:9090"
@@ -228,7 +228,7 @@ func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Requ
 		// If that fails, try as object with data/members field
 		var responseObj map[string]interface{}
 		if err2 := json.Unmarshal(body, &responseObj); err2 != nil {
-			log.Printf("DEBUG getBetterAuthOrganizationMember: Failed to parse response as array or object. Response body: %s", string(body))
+			l.Log(applogger.Debug, "middleware rbac: list-members parse failed", fmt.Sprintf("expected_array_or_object body=%s", string(body)))
 			return nil, fmt.Errorf("failed to parse response: %w (also tried object format: %v)", err, err2)
 		}
 
@@ -237,13 +237,13 @@ func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Requ
 			// Convert to []BetterAuthMember
 			dataBytes, _ := json.Marshal(data)
 			if err := json.Unmarshal(dataBytes, &members); err != nil {
-				log.Printf("DEBUG getBetterAuthOrganizationMember: Failed to parse data field. Data: %s", string(dataBytes))
+				l.Log(applogger.Debug, "middleware rbac: list-members data field parse failed", fmt.Sprintf("data=%s", string(dataBytes)))
 				return nil, fmt.Errorf("failed to parse data array: %w", err)
 			}
 		} else if membersData, ok := responseObj["members"]; ok {
 			membersBytes, _ := json.Marshal(membersData)
 			if err := json.Unmarshal(membersBytes, &members); err != nil {
-				log.Printf("DEBUG getBetterAuthOrganizationMember: Failed to parse members field. Members: %s", string(membersBytes))
+				l.Log(applogger.Debug, "middleware rbac: list-members members field parse failed", fmt.Sprintf("members=%s", string(membersBytes)))
 				return nil, fmt.Errorf("failed to parse members array: %w", err)
 			}
 		} else {
@@ -252,7 +252,7 @@ func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Requ
 			if err := json.Unmarshal(body, &singleMember); err == nil && singleMember.UserID != "" {
 				members = []BetterAuthMember{singleMember}
 			} else {
-				log.Printf("DEBUG getBetterAuthOrganizationMember: Response is not array or single member. Response: %s", string(body))
+				l.Log(applogger.Debug, "middleware rbac: list-members unexpected shape", fmt.Sprintf("body=%s", string(body)))
 				return nil, fmt.Errorf("response does not contain array or single member: %s", string(body))
 			}
 		}
@@ -397,26 +397,26 @@ func buildRequiredPermission(resource, method string) string {
 
 // extractOrganizationID extracts and validates organization ID from request header or auth context.
 // Falls back to OrganizationIDKey from AuthMiddleware (Better Auth session) when header is missing.
-func extractOrganizationID(w http.ResponseWriter, r *http.Request) string {
+func extractOrganizationID(w http.ResponseWriter, r *http.Request, l applogger.Logger) string {
 	organizationID := r.Header.Get("X-Organization-Id")
 	if organizationID == "" {
 		// Fallback: use org from auth context (set by AuthMiddleware from Better Auth session)
 		if orgAny := r.Context().Value(types.OrganizationIDKey); orgAny != nil {
 			if orgStr, ok := orgAny.(string); ok && orgStr != "" {
 				organizationID = orgStr
-				log.Printf("DEBUG RBAC: using org from context for %s %s (header missing)", r.Method, r.URL.Path)
+				l.Log(applogger.Debug, "middleware rbac: using org from context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			}
 		}
 	}
 	if organizationID == "" {
-		log.Printf("DEBUG RBAC: X-Organization-Id header missing and no org in context for %s %s", r.Method, r.URL.Path)
+		l.Log(applogger.Debug, "middleware rbac: missing X-Organization-Id and context org", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 		utils.SendErrorResponse(w, "Organization ID is required", http.StatusBadRequest)
 		return ""
 	}
 
 	// Validate UUID format
 	if _, err := uuid.Parse(organizationID); err != nil {
-		log.Printf("DEBUG RBAC: X-Organization-Id invalid format '%s' for %s %s", organizationID, r.Method, r.URL.Path)
+		l.Log(applogger.Debug, "middleware rbac: invalid X-Organization-Id", fmt.Sprintf("org_id=%s method=%s path=%s", organizationID, r.Method, r.URL.Path))
 		utils.SendErrorResponse(w, "Invalid organization ID format", http.StatusBadRequest)
 		return ""
 	}

--- a/api/internal/middleware/rbac_getmember_test.go
+++ b/api/internal/middleware/rbac_getmember_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	betterauth "github.com/nixopus/nixopus/api/internal/features/auth"
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +26,7 @@ func Test_getBetterAuthOrganizationMember_newRequestError(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", "http://example.invalid")
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "o")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "o", logger.NewLogger())
 	require.ErrorContains(t, err, "failed to create request")
 }
 
@@ -43,7 +44,7 @@ func Test_getBetterAuthOrganizationMember_httpDoError(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch organization members")
 }
@@ -57,7 +58,7 @@ func Test_getBetterAuthOrganizationMember_nonOK(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Better Auth API returned status 403")
 }
@@ -76,7 +77,7 @@ func Test_getBetterAuthOrganizationMember_readBodyError(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.ErrorContains(t, err, "failed to read response")
 }
 
@@ -93,7 +94,7 @@ func Test_getBetterAuthOrganizationMember_directArray(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid)
+	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	require.Equal(t, uid, m.UserID)
@@ -113,7 +114,7 @@ func Test_getBetterAuthOrganizationMember_dataWrapper(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid)
+	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	rs, ok := m.Role.(string)
 	require.True(t, ok)
@@ -134,7 +135,7 @@ func Test_getBetterAuthOrganizationMember_membersWrapper(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid)
+	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	require.NotNil(t, m)
 }
@@ -150,7 +151,7 @@ func Test_getBetterAuthOrganizationMember_dataUnmarshalError(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to parse data array")
 }
@@ -166,7 +167,7 @@ func Test_getBetterAuthOrganizationMember_membersUnmarshalError(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to parse members array")
 }
@@ -184,7 +185,7 @@ func Test_getBetterAuthOrganizationMember_singleMemberObject(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid)
+	m, err := getBetterAuthOrganizationMember(context.Background(), nil, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	require.NotNil(t, m)
 }
@@ -200,7 +201,7 @@ func Test_getBetterAuthOrganizationMember_singleMemberUnmarshalNoUserID(t *testi
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "response does not contain array or single member")
 }
@@ -216,7 +217,7 @@ func Test_getBetterAuthOrganizationMember_parseBodyNeitherArrayNorObject(t *test
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "u", "00000000-0000-0000-0000-000000000001", logger.NewLogger())
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "failed to parse response") || strings.Contains(err.Error(), "failed to parse"))
 }
@@ -232,7 +233,7 @@ func Test_getBetterAuthOrganizationMember_userNotInList(t *testing.T) {
 	t.Setenv("AUTH_SERVICE_URL", srv.URL)
 	t.Cleanup(func() { _ = os.Unsetenv("AUTH_SERVICE_URL") })
 
-	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "me", "o")
+	_, err := getBetterAuthOrganizationMember(context.Background(), nil, "me", "o", logger.NewLogger())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is not a member")
 }
@@ -258,7 +259,7 @@ func Test_getBetterAuthOrganizationMember_forwardsHeaders(t *testing.T) {
 	origReq.Header.Set("x-api-key", "k")
 	origReq.AddCookie(&http.Cookie{Name: "a", Value: "b"})
 
-	m, err := getBetterAuthOrganizationMember(context.Background(), origReq, uid, oid)
+	m, err := getBetterAuthOrganizationMember(context.Background(), origReq, uid, oid, logger.NewLogger())
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	require.True(t, sawAuth)

--- a/api/internal/middleware/recovery.go
+++ b/api/internal/middleware/recovery.go
@@ -1,21 +1,30 @@
 package middleware
 
 import (
-	"log"
+	"fmt"
 	"net/http"
+
+	"github.com/nixopus/nixopus/api/internal/features/logger"
 )
 
-func RecoveryMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			if err := recover(); err != nil {
-				log.Printf("Panic recovered: %v", err)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(`{"code":"internal_error","message":"Internal server error"}`))
-			}
-		}()
+// RecoveryMiddleware returns middleware that recovers panics and logs with the app logger.
+func RecoveryMiddleware(l logger.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if err := recover(); err != nil {
+					data := ""
+					if r != nil && r.URL != nil {
+						data = fmt.Sprintf("path=%s", r.URL.Path)
+					}
+					l.Log(logger.Error, fmt.Sprintf("middleware: panic recovered: %v", err), data)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(`{"code":"internal_error","message":"Internal server error"}`))
+				}
+			}()
 
-		next.ServeHTTP(w, r)
-	})
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nixopus/nixopus/api/internal/cache"
 	"github.com/nixopus/nixopus/api/internal/config"
 	audit "github.com/nixopus/nixopus/api/internal/features/audit/controller"
+	authsession "github.com/nixopus/nixopus/api/internal/features/auth"
 	auth "github.com/nixopus/nixopus/api/internal/features/auth/controller"
 	auth_service "github.com/nixopus/nixopus/api/internal/features/auth/service"
 	user_storage "github.com/nixopus/nixopus/api/internal/features/auth/storage"
@@ -73,11 +74,13 @@ func NewRouter(app *storage.App) *Router {
 	// Initialize RBAC cache for middleware
 	middleware.InitRBACCache(cache)
 
-	return &Router{
+	router := &Router{
 		app:    app,
 		cache:  cache,
 		logger: logger.NewLogger(),
 	}
+	authsession.VerifySessionLogger = &router.logger
+	return router
 }
 
 // applyMiddleware applies middleware chain to a route group based on configuration
@@ -419,7 +422,7 @@ func (router *Router) registerProtectedRoutes(server *fuego.Server, apiV1 api.Ve
 }
 
 func (router *Router) createAuthController() *auth.AuthController {
-	userStorage := &user_storage.UserStorage{DB: router.app.Store.DB, Ctx: router.app.Ctx}
+	userStorage := &user_storage.UserStorage{DB: router.app.Store.DB, Ctx: router.app.Ctx, Logger: &router.logger}
 	authService := auth_service.NewAuthService(userStorage, userStorage.DB, router.logger, router.app.Ctx, config.AppConfig.Redis.URL)
 	return auth.NewAuthController(router.app.Ctx, router.logger, authService)
 }

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -428,7 +428,7 @@ func (router *Router) createAuthController() *auth.AuthController {
 }
 
 func (router *Router) createFeatureFlagController() *feature_flags_controller.FeatureFlagController {
-	featureFlagStorage := &feature_flags_storage.FeatureFlagStorage{DB: router.app.Store.DB, Ctx: router.app.Ctx}
+	featureFlagStorage := &feature_flags_storage.FeatureFlagStorage{DB: router.app.Store.DB, Ctx: router.app.Ctx, Logger: &router.logger}
 	featureFlagService := feature_flags_service.NewFeatureFlagService(featureFlagStorage, router.logger, router.app.Ctx)
 	return feature_flags_controller.NewFeatureFlagController(featureFlagService, router.logger, router.app.Ctx, router.cache)
 }

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -87,7 +87,7 @@ func NewRouter(app *storage.App) *Router {
 func (router *Router) applyMiddleware(group *fuego.Server, cfg MiddlewareConfig) {
 	if cfg.RBAC {
 		fuego.Use(group, func(next http.Handler) http.Handler {
-			return middleware.RBACMiddleware(next, router.app, cfg.ResourceName)
+			return middleware.RBACMiddleware(next, router.app, cfg.ResourceName, router.logger)
 		})
 	}
 	if cfg.FeatureFlag != "" {
@@ -116,7 +116,7 @@ func (router *Router) createServer(port string) *fuego.Server {
 		),
 		fuego.WithoutAutoGroupTags(),
 		fuego.WithGlobalMiddlewares(
-			middleware.RecoveryMiddleware,
+			middleware.RecoveryMiddleware(router.logger),
 			middleware.RequestIDMiddleware,
 			middleware.CorsMiddleware,
 			middleware.LoggingMiddleware,
@@ -149,7 +149,7 @@ func (router *Router) setupAuthentication(server *fuego.Server) {
 				next.ServeHTTP(w, r)
 				return
 			}
-			middleware.AuthMiddleware(next, router.app, router.cache).ServeHTTP(w, r)
+			middleware.AuthMiddleware(next, router.app, router.cache, router.logger).ServeHTTP(w, r)
 		})
 	})
 }

--- a/api/internal/scheduler/init.go
+++ b/api/internal/scheduler/init.go
@@ -36,7 +36,7 @@ func InitSchedulers(store *shared_storage.Store, ctx context.Context) *Scheduler
 	sched.RegisterJob(container.NewPruneImagesJob(l))
 	sched.RegisterJob(container.NewPruneBuildCacheJob(l))
 
-	healthCheckStorage := healthcheck_storage.HealthCheckStorage{DB: store.DB, Ctx: ctx}
+	healthCheckStorage := healthcheck_storage.HealthCheckStorage{DB: store.DB, Ctx: ctx, Logger: &l}
 	healthCheckService := healthcheck_service.NewHealthCheckService(store, ctx, l, &healthCheckStorage)
 	healthCheckScheduler := NewHealthCheckScheduler(healthCheckService, l, ctx, nil)
 

--- a/api/internal/tests/extension/get_extension_test.go
+++ b/api/internal/tests/extension/get_extension_test.go
@@ -115,26 +115,26 @@ func seedTestExtension(t *testing.T, setup *testutils.TestSetup) (id uuid.UUID, 
 
 func TestIntegration_NewTemplateLoader(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	require.NotNil(t, l)
 }
 
 func TestIntegration_TemplateLoader_LoadExtensionsFromDirectory_empty(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	require.NoError(t, l.LoadExtensionsFromDirectory(setup.Ctx, t.TempDir()))
 }
 
 func TestIntegration_TemplateLoader_LoadExtensionsFromDirectory_nonexistent(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	err := l.LoadExtensionsFromDirectory(setup.Ctx, "/nonexistent-template-dir-xyz")
 	require.Error(t, err)
 }
 
 func TestIntegration_TemplateLoader_insert_skip_update_orphan_restore(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 
 	extID := "svc-tpl-" + strings.ReplaceAll(uuid.New().String(), "-", "")
 	orphanID := "svc-tpl-" + strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -190,7 +190,7 @@ func TestIntegration_TemplateLoader_insert_skip_update_orphan_restore(t *testing
 
 func TestIntegration_TemplateLoader_insert_noVariables(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	extID := "svc-tpl-novar-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:20]
 	root := t.TempDir()
 	sub := filepath.Join(root, "nv")
@@ -205,14 +205,14 @@ func TestIntegration_TemplateLoader_insert_noVariables(t *testing.T) {
 
 func TestIntegration_TemplateLoader_GetExtensionByID_notFound(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	_, err := l.GetExtensionByID(setup.Ctx, "no-such-extension-id-zzzzz")
 	require.Error(t, err)
 }
 
 func TestIntegration_TemplateLoader_LoadExtensionsFromTemplates(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(wd) })
@@ -231,7 +231,7 @@ func TestIntegration_TemplateLoader_LoadExtensionsFromTemplates(t *testing.T) {
 
 func TestIntegration_TemplateLoader_secondLoad(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	root := t.TempDir()
 	extID := "svc-tpl-rmnoop-" + strings.ReplaceAll(uuid.New().String(), "-", "")
 	tplWriteTree(t, root, "one", extID, "1.0.0")
@@ -241,7 +241,7 @@ func TestIntegration_TemplateLoader_secondLoad(t *testing.T) {
 
 func TestIntegration_TemplateLoader_LoadExtensions_cancelledContext(t *testing.T) {
 	setup := testutils.NewTestSetup()
-	l := extservice.NewTemplateLoader(setup.DB)
+	l := extservice.NewTemplateLoader(setup.DB, nil)
 	extID := "svc-tpl-cancel-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
 	root := t.TempDir()
 	tplWriteTree(t, root, "x", extID, "1.0.0")


### PR DESCRIPTION
## Summary

Introduces consistent structured logging: fixed message prefixes, contextual `data` strings (key=value), and wiring the shared app `logger` through middleware. Deploy and related subsystems (caddy, docker, tasks, storage) use aligned `deploy:*` / `deploy service:*` / `deploy tasks:*` / `deploy caddy:*` / `deploy docker:*` patterns.

## Scope

- **Features:** domain, auth, container, extension, feature-flags, github-connector, healthcheck, machine, mcp, notification, telemetry, user, deploy (controller/service/tasks/storage/validation), and related fixes.
- **Middleware:** audit, auth, RBAC, recovery use `middleware *` prefixes; routes pass `router.logger`.
- **Misc:** `GetApplications` `deployRequestData` call fix.

## Notes

- HTTP access middleware (`logger.go`) still uses colored console output; unchanged in this pass.
