### PR TITLE
feat(installer): install transcript and nixopus report

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -367,6 +367,18 @@ docker exec -i nixopus-db psql -U nixopus nixopus < /opt/nixopus/backups/<timest
 
 ## Troubleshooting
 
+### Reporting install or runtime issues
+
+The installer writes a full transcript to `/opt/nixopus/install.log` (and shows the path on failure). Attach that file when asking for help, or generate a single paste-friendly bundle **with secrets redacted in `.env`**:
+
+```bash
+sudo nixopus report
+# or save to a file:
+sudo nixopus report > /tmp/nixopus-report.txt
+```
+
+Installer logs may still contain API keys or passwords echoed during the run — review before sharing.
+
 ### Services fail to start after reinstall
 
 **Symptom:** `nixopus-auth` or `nixopus-api` crash-loop with database authentication errors.

--- a/installer/README.md
+++ b/installer/README.md
@@ -369,7 +369,7 @@ docker exec -i nixopus-db psql -U nixopus nixopus < /opt/nixopus/backups/<timest
 
 ### Reporting install or runtime issues
 
-The installer writes a full transcript to `/opt/nixopus/install.log` (and shows the path on failure). Attach that file when asking for help, or generate a single paste-friendly bundle **with secrets redacted in `.env`**:
+The installer writes a full transcript to `/opt/nixopus/install.log` (and shows the path on failure). Attach that file when asking for help, or generate a paste-friendly bundle with **`sudo nixopus report`** (redacts the installer log tail and `.env`; compose logs may still contain secrets — review before sharing):
 
 ```bash
 sudo nixopus report

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -13,6 +13,8 @@ INSTALL_LOG=""
 
 start_install_session_log() {
     INSTALL_LOG="/tmp/nixopus-install-$(date +%Y%m%dT%H%M%S)-$$.log"
+    : >"$INSTALL_LOG"
+    chmod 600 "$INSTALL_LOG" || true
     # Duplicate stdout/stderr to a file for copy-paste debugging.
     exec > >(tee "$INSTALL_LOG") 2>&1
 }
@@ -144,9 +146,11 @@ fail() {
     if [ -n "${INSTALL_LOG:-}" ] && [ -f "$INSTALL_LOG" ]; then
         local log_path="$INSTALL_LOG"
         if [ -d "${NIXOPUS_HOME:-}" ]; then
-            cp -f "$INSTALL_LOG" "$NIXOPUS_HOME/install.log" 2>/dev/null || true
-            chmod 600 "$NIXOPUS_HOME/install.log" 2>/dev/null || true
-            [ -f "$NIXOPUS_HOME/install.log" ] && log_path="$NIXOPUS_HOME/install.log"
+            if cp -f "$INSTALL_LOG" "$NIXOPUS_HOME/install.log" 2>/dev/null; then
+                chmod 600 "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+                log_path="$NIXOPUS_HOME/install.log"
+                rm -f "$INSTALL_LOG" 2>/dev/null || true
+            fi
         fi
         log_error "Installer log: $log_path"
         log_error "Attach when asking for help (may include secrets — redact before sharing)."
@@ -1004,8 +1008,10 @@ show_banner() {
 finalize_install_session_log() {
     [ -n "${INSTALL_LOG:-}" ] && [ -f "$INSTALL_LOG" ] || return 0
     [ -d "${NIXOPUS_HOME:-}" ] || return 0
-    cp -f "$INSTALL_LOG" "$NIXOPUS_HOME/install.log" 2>/dev/null || true
-    chmod 600 "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+    if cp -f "$INSTALL_LOG" "$NIXOPUS_HOME/install.log" 2>/dev/null; then
+        chmod 600 "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+        rm -f "$INSTALL_LOG" 2>/dev/null || true
+    fi
 }
 
 show_complete() {

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -8,6 +8,14 @@ NIXOPUS_REPO="${NIXOPUS_REPO:-nixopus/nixopus}"
 NIXOPUS_BRANCH="${NIXOPUS_BRANCH:-master}"
 REPO_RAW="${NIXOPUS_REPO_RAW:-https://raw.githubusercontent.com/${NIXOPUS_REPO}/${NIXOPUS_BRANCH}/installer}"
 INSTALL_START=$(date +%s)
+# Set in main(); full installer transcript for support (tee). On failure, path is under /tmp.
+INSTALL_LOG=""
+
+start_install_session_log() {
+    INSTALL_LOG="/tmp/nixopus-install-$(date +%Y%m%dT%H%M%S)-$$.log"
+    # Duplicate stdout/stderr to a file for copy-paste debugging.
+    exec > >(tee "$INSTALL_LOG") 2>&1
+}
 
 PREVIEW_PR=""
 PREVIEW_FORK=""
@@ -133,6 +141,16 @@ TOTAL_STEPS=6
 
 fail() {
     log_error "$1"
+    if [ -n "${INSTALL_LOG:-}" ] && [ -f "$INSTALL_LOG" ]; then
+        local log_path="$INSTALL_LOG"
+        if [ -d "${NIXOPUS_HOME:-}" ]; then
+            cp -f "$INSTALL_LOG" "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+            chmod 600 "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+            [ -f "$NIXOPUS_HOME/install.log" ] && log_path="$NIXOPUS_HOME/install.log"
+        fi
+        log_error "Installer log: $log_path"
+        log_error "Attach when asking for help (may include secrets — redact before sharing)."
+    fi
     send_telemetry "install_failure" "$1" || true
     exit 1
 }
@@ -983,6 +1001,13 @@ show_banner() {
     echo ""
 }
 
+finalize_install_session_log() {
+    [ -n "${INSTALL_LOG:-}" ] && [ -f "$INSTALL_LOG" ] || return 0
+    [ -d "${NIXOPUS_HOME:-}" ] || return 0
+    cp -f "$INSTALL_LOG" "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+    chmod 600 "$NIXOPUS_HOME/install.log" 2>/dev/null || true
+}
+
 show_complete() {
     local duration=$(( $(date +%s) - INSTALL_START ))
     echo ""
@@ -1035,10 +1060,13 @@ show_complete() {
     if [ "${NIXOPUS_TELEMETRY:-on}" != "off" ] && [ "${DO_NOT_TRACK:-0}" != "1" ]; then
         echo -e "  ${DIM}Anonymous telemetry enabled. Disable: NIXOPUS_TELEMETRY=off or DO_NOT_TRACK=1${NC}"
     fi
+    echo -e "  ${DIM}Problems? Attach $NIXOPUS_HOME/install.log or run: sudo nixopus report${NC}"
     echo ""
+    finalize_install_session_log
 }
 
 main() {
+    start_install_session_log
     show_banner
     send_telemetry "install_started" || true
 

--- a/installer/nixopus.sh
+++ b/installer/nixopus.sh
@@ -413,7 +413,16 @@ cmd_admin_bootstrap() {
     return 1
 }
 
-# cmd_report prints a single paste-friendly bundle for support (secrets redacted in .env).
+# Strip ANSI and redact secrets from an installer transcript (used by cmd_report).
+redact_install_log_lines() {
+    sed $'s/\e\[[0-9;]*m//g' \
+    | sed -E \
+        's/^(ADMIN_PASSWORD|DB_PASSWORD|REDIS_PASSWORD|AUTH_SERVICE_SECRET|JWT_SECRET|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GOOGLE_GENERATIVE_AI_API_KEY|DEEPSEEK_API_KEY|GROQ_API_KEY)=.*/\1=<redacted>/' \
+    | sed -E 's/^(DATABASE_URL|REDIS_URL)=.*/\1=<redacted>/' \
+    | sed -E '/Password:/s/^(.*Password:[[:space:]]+).*/\1<redacted>/'
+}
+
+# cmd_report prints a single paste-friendly bundle (installer log + .env redacted for pasting).
 cmd_report() {
     load_env
     echo "=== Nixopus support report $(date -u +"%Y-%m-%dT%H:%M:%SZ") ==="
@@ -421,8 +430,8 @@ cmd_report() {
     echo "Home:    $NIXOPUS_HOME"
     echo ""
     if [ -f "$NIXOPUS_HOME/install.log" ]; then
-        echo "=== Installer log (last 400 lines) ==="
-        tail -n 400 "$NIXOPUS_HOME/install.log" 2>/dev/null || echo "(unreadable)"
+        echo "=== Installer log (last 400 lines, secrets redacted) ==="
+        tail -n 400 "$NIXOPUS_HOME/install.log" 2>/dev/null | redact_install_log_lines || echo "(unreadable)"
         echo ""
     fi
     echo "=== uname -a ==="
@@ -452,7 +461,7 @@ cmd_report() {
     fi
     echo ""
     echo "=== End of report ==="
-    echo "Tip: sudo nixopus report > /tmp/nixopus-report.txt && cat /tmp/nixopus-report.txt"
+    echo "Tip: sudo nixopus report > /tmp/nixopus-report.txt — safe to share; review compose logs for app secrets."
 }
 
 cmd_help() {
@@ -475,7 +484,7 @@ cmd_help() {
     echo "  backup              Backup database and config"
     echo "  info                Show install info and status"
     echo "  admin-bootstrap     Create admin account via auth API (uses ADMIN_EMAIL/ADMIN_PASSWORD)"
-    echo "  report              Print paste-friendly support bundle (redacted .env)"
+    echo "  report              Print support bundle (installer log + .env redacted)"
     echo "  help                Show this help"
 }
 

--- a/installer/nixopus.sh
+++ b/installer/nixopus.sh
@@ -413,6 +413,48 @@ cmd_admin_bootstrap() {
     return 1
 }
 
+# cmd_report prints a single paste-friendly bundle for support (secrets redacted in .env).
+cmd_report() {
+    load_env
+    echo "=== Nixopus support report $(date -u +"%Y-%m-%dT%H:%M:%SZ") ==="
+    echo "Version: ${NIXOPUS_VERSION:-unknown}"
+    echo "Home:    $NIXOPUS_HOME"
+    echo ""
+    if [ -f "$NIXOPUS_HOME/install.log" ]; then
+        echo "=== Installer log (last 400 lines) ==="
+        tail -n 400 "$NIXOPUS_HOME/install.log" 2>/dev/null || echo "(unreadable)"
+        echo ""
+    fi
+    echo "=== uname -a ==="
+    uname -a 2>/dev/null || true
+    if [ -f /etc/os-release ]; then
+        echo ""
+        echo "=== /etc/os-release ==="
+        cat /etc/os-release
+    fi
+    echo ""
+    echo "=== docker version (summary) ==="
+    docker version 2>/dev/null | head -40 || echo "docker not available"
+    echo ""
+    echo "=== docker compose ps -a ==="
+    dc ps -a 2>&1 || true
+    echo ""
+    echo "=== compose logs (last 120 lines, all services) ==="
+    dc logs --tail 120 --no-color 2>&1 || dc logs --tail 120 2>&1 || true
+    echo ""
+    echo "=== Redacted .env ==="
+    if [ -f "$NIXOPUS_HOME/.env" ]; then
+        sed -E \
+            's/^(ADMIN_PASSWORD|DB_PASSWORD|REDIS_PASSWORD|AUTH_SERVICE_SECRET|JWT_SECRET|OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GOOGLE_GENERATIVE_AI_API_KEY|DEEPSEEK_API_KEY|GROQ_API_KEY)=.*/\1=<redacted>/' \
+            "$NIXOPUS_HOME/.env" | sed -E 's/^(DATABASE_URL|REDIS_URL)=.*/\1=<redacted>/'
+    else
+        echo "(no .env)"
+    fi
+    echo ""
+    echo "=== End of report ==="
+    echo "Tip: sudo nixopus report > /tmp/nixopus-report.txt && cat /tmp/nixopus-report.txt"
+}
+
 cmd_help() {
     echo "Usage: nixopus <command> [args]"
     echo ""
@@ -433,6 +475,7 @@ cmd_help() {
     echo "  backup              Backup database and config"
     echo "  info                Show install info and status"
     echo "  admin-bootstrap     Create admin account via auth API (uses ADMIN_EMAIL/ADMIN_PASSWORD)"
+    echo "  report              Print paste-friendly support bundle (redacted .env)"
     echo "  help                Show this help"
 }
 
@@ -450,6 +493,7 @@ case "${1:-help}" in
     backup)    cmd_backup ;;
     info)      cmd_info ;;
     admin-bootstrap) shift; cmd_admin_bootstrap "$@" ;;
+    report) cmd_report ;;
     help|--help|-h) cmd_help ;;
     *)         echo "Unknown command: $1"; cmd_help; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

- Tee full installer output to `/tmp/nixopus-install-*.log` and copy to `/opt/nixopus/install.log` on success; `fail()` prints log path (and copies to `$NIXOPUS_HOME/install.log` when that directory already exists).
- **`nixopus report`:** paste-friendly bundle — redacted `.env`, `docker compose ps -a`, last 120 lines of service logs, tail of `install.log`, OS/docker summary.
- **README:** troubleshooting section for attaching logs / using `report`.

Completion banner points users at `install.log` and `sudo nixopus report`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "report" command to create a paste-friendly diagnostic bundle (system info, logs, compose state, redacted sensitive entries).
  * Installer now records a full install stdout/stderr transcript and persists it for troubleshooting.

* **Documentation**
  * Added troubleshooting guidance showing how to generate and attach transcripts with the report command, plus a reminder to review/redact sensitive data before sharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->