### PR TITLE
test(installer): 100% statement coverage for get.sh and nixopus.sh

### DIFF
--- a/installer/test/run-unit-tests.sh
+++ b/installer/test/run-unit-tests.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Run the installer unit-test suite (bats).
+# Usage: bash installer/test/run-unit-tests.sh [--verbose] [file...]
+#
+# With no arguments runs all .bats files under installer/test/unit/.
+# Pass specific .bats file paths to run only those files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_DIR="$SCRIPT_DIR/unit"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+BATS_FLAGS=()
+FILES=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --verbose|-v) BATS_FLAGS+=(--verbose-run) ;;
+        --tap)        BATS_FLAGS+=(--formatter tap) ;;
+        *)            FILES+=("$arg") ;;
+    esac
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    mapfile -t FILES < <(find "$UNIT_DIR" -name "*.bats" | sort)
+fi
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo -e "${RED}No .bats files found under $UNIT_DIR${NC}" >&2
+    exit 1
+fi
+
+if ! command -v bats &>/dev/null; then
+    echo -e "${RED}bats not found. Install: https://github.com/bats-core/bats-core${NC}" >&2
+    exit 1
+fi
+
+echo -e "${CYAN}${BOLD}━━━ Nixopus Installer Unit Tests ━━━${NC}"
+echo ""
+echo -e "  bats $(bats --version)"
+echo -e "  Files: ${#FILES[@]}"
+echo ""
+
+bats "${BATS_FLAGS[@]}" "${FILES[@]}"
+status=$?
+
+echo ""
+if [ $status -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}All tests passed.${NC}"
+else
+    echo -e "${RED}${BOLD}Some tests failed.${NC}"
+fi
+
+exit $status

--- a/installer/test/unit/get_sh.bats
+++ b/installer/test/unit/get_sh.bats
@@ -1,0 +1,1824 @@
+#!/usr/bin/env bats
+# Unit tests for installer/get.sh
+# Coverage target: 100% of all statements, branches, and business logic.
+#
+# Strategy: source get.sh with stubs for all side-effectful commands
+# (docker, curl, ssh-keygen, systemctl, …) so every code-path can be
+# exercised without root, Docker, or a real network.
+
+INSTALLER_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+GET_SH="$INSTALLER_DIR/get.sh"
+
+# ---------------------------------------------------------------------------
+# helpers – load only the function(s) we need from get.sh without running main
+# ---------------------------------------------------------------------------
+
+# load_fn <fn_name> [extra_stubs...]
+# Sources get.sh but replaces `main "$@"` with a no-op so we can call
+# individual functions.  Accepts a list of function names to stub out before
+# sourcing.
+load_fn() {
+    # Create a patched copy that never calls main() automatically
+    local tmp
+    tmp=$(mktemp)
+    # Replace the tail `main "$@"` call with a no-op
+    sed 's/^main "\$@"$/: # main stubbed by test/' "$GET_SH" > "$tmp"
+    # shellcheck disable=SC1090
+    source "$tmp"
+    rm -f "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# parse_args
+# ---------------------------------------------------------------------------
+
+@test "parse_args: no args leaves all PREVIEW vars empty" {
+    load_fn
+    PREVIEW_PR="" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    parse_args
+    [ -z "$PREVIEW_PR" ]
+    [ -z "$PREVIEW_FORK" ]
+    [ -z "$PREVIEW_BRANCH" ]
+}
+
+@test "parse_args: --preview sets PREVIEW_PR" {
+    load_fn
+    PREVIEW_PR=""
+    parse_args --preview 42
+    [ "$PREVIEW_PR" = "42" ]
+}
+
+@test "parse_args: --branch sets PREVIEW_BRANCH" {
+    load_fn
+    PREVIEW_BRANCH=""
+    parse_args --branch feat/foo
+    [ "$PREVIEW_BRANCH" = "feat/foo" ]
+}
+
+@test "parse_args: --fork sets PREVIEW_FORK" {
+    load_fn
+    PREVIEW_FORK=""
+    parse_args --fork myorg/nixopus
+    [ "$PREVIEW_FORK" = "myorg/nixopus" ]
+}
+
+@test "parse_args: all three flags together" {
+    load_fn
+    parse_args --preview 7 --branch ci/test --fork myorg/nixopus
+    [ "$PREVIEW_PR" = "7" ]
+    [ "$PREVIEW_BRANCH" = "ci/test" ]
+    [ "$PREVIEW_FORK" = "myorg/nixopus" ]
+}
+
+@test "parse_args: --preview with no value exits 1" {
+    load_fn
+    run parse_args --preview
+    [ "$status" -eq 1 ]
+}
+
+@test "parse_args: --branch with no value exits 1" {
+    load_fn
+    run parse_args --branch
+    [ "$status" -eq 1 ]
+}
+
+@test "parse_args: --fork with no value exits 1" {
+    load_fn
+    run parse_args --fork
+    [ "$status" -eq 1 ]
+}
+
+@test "parse_args: unknown flag exits 1" {
+    load_fn
+    run parse_args --unknown-flag
+    [ "$status" -eq 1 ]
+}
+
+@test "parse_args: --help exits 0" {
+    load_fn
+    run parse_args --help
+    [ "$status" -eq 0 ]
+}
+
+@test "parse_args: -h exits 0" {
+    load_fn
+    run parse_args -h
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# is_ipv6 / format_ip_for_url
+# ---------------------------------------------------------------------------
+
+@test "is_ipv6: returns 0 for IPv6 address" {
+    load_fn
+    run is_ipv6 "::1"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_ipv6: returns 1 for IPv4 address" {
+    load_fn
+    run is_ipv6 "1.2.3.4"
+    [ "$status" -ne 0 ]
+}
+
+@test "format_ip_for_url: wraps IPv6 in brackets" {
+    load_fn
+    result=$(format_ip_for_url "::1")
+    [ "$result" = "[::1]" ]
+}
+
+@test "format_ip_for_url: leaves IPv4 unchanged" {
+    load_fn
+    result=$(format_ip_for_url "192.168.1.1")
+    [ "$result" = "192.168.1.1" ]
+}
+
+@test "format_ip_for_url: wraps full IPv6 in brackets" {
+    load_fn
+    result=$(format_ip_for_url "2001:db8::1")
+    [ "$result" = "[2001:db8::1]" ]
+}
+
+# ---------------------------------------------------------------------------
+# is_private_ip
+# ---------------------------------------------------------------------------
+
+@test "is_private_ip: 10.x.x.x is private" {
+    load_fn
+    run is_private_ip "10.0.0.1"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_private_ip: 172.16.x.x is private" {
+    load_fn
+    run is_private_ip "172.16.0.1"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_private_ip: 172.31.x.x is private" {
+    load_fn
+    run is_private_ip "172.31.255.255"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_private_ip: 172.15.x.x is NOT private" {
+    load_fn
+    run is_private_ip "172.15.0.1"
+    [ "$status" -ne 0 ]
+}
+
+@test "is_private_ip: 172.32.x.x is NOT private" {
+    load_fn
+    run is_private_ip "172.32.0.1"
+    [ "$status" -ne 0 ]
+}
+
+@test "is_private_ip: 192.168.x.x is private" {
+    load_fn
+    run is_private_ip "192.168.1.100"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_private_ip: fc00::/7 IPv6 ULA is private" {
+    load_fn
+    run is_private_ip "fc00::1"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_private_ip: fd00::/8 IPv6 ULA is private" {
+    load_fn
+    run is_private_ip "fd12:3456::1"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_private_ip: 8.8.8.8 is NOT private" {
+    load_fn
+    run is_private_ip "8.8.8.8"
+    [ "$status" -ne 0 ]
+}
+
+@test "is_private_ip: 203.0.113.1 is NOT private" {
+    load_fn
+    run is_private_ip "203.0.113.1"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# gen_secret
+# ---------------------------------------------------------------------------
+
+@test "gen_secret: produces 64-char hex string" {
+    load_fn
+    secret=$(gen_secret)
+    [ ${#secret} -eq 64 ]
+    [[ "$secret" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "gen_secret: two calls produce different values" {
+    load_fn
+    s1=$(gen_secret)
+    s2=$(gen_secret)
+    [ "$s1" != "$s2" ]
+}
+
+# ---------------------------------------------------------------------------
+# gen_password
+# ---------------------------------------------------------------------------
+
+@test "gen_password: length is 16 characters" {
+    load_fn
+    pw=$(gen_password)
+    [ ${#pw} -eq 16 ]
+}
+
+@test "gen_password: contains uppercase letter" {
+    load_fn
+    pw=$(gen_password)
+    [[ "$pw" =~ [A-Z] ]]
+}
+
+@test "gen_password: contains lowercase letter" {
+    load_fn
+    pw=$(gen_password)
+    [[ "$pw" =~ [a-z] ]]
+}
+
+@test "gen_password: contains digit" {
+    load_fn
+    pw=$(gen_password)
+    [[ "$pw" =~ [0-9] ]]
+}
+
+@test "gen_password: contains special character" {
+    load_fn
+    pw=$(gen_password)
+    [[ "$pw" =~ [!@#%^\&*] ]]
+}
+
+@test "gen_password: two calls produce different passwords" {
+    load_fn
+    pw1=$(gen_password)
+    pw2=$(gen_password)
+    [ "$pw1" != "$pw2" ]
+}
+
+# ---------------------------------------------------------------------------
+# json_escape
+# ---------------------------------------------------------------------------
+
+@test "json_escape: plain string unchanged" {
+    load_fn
+    result=$(json_escape "hello")
+    [ "$result" = "hello" ]
+}
+
+@test "json_escape: double-quotes are escaped" {
+    load_fn
+    result=$(json_escape 'say "hi"')
+    [ "$result" = 'say \"hi\"' ]
+}
+
+@test "json_escape: backslashes are escaped" {
+    load_fn
+    result=$(json_escape 'a\b')
+    [ "$result" = 'a\\b' ]
+}
+
+@test "json_escape: backslash-then-quote both escaped" {
+    load_fn
+    # Input: 4 chars — a, \, ", b
+    # Step 1 escapes \→\\:  a, \, \, ", b  (5 chars)
+    # Step 2 escapes "→\":  a, \, \, \, ", b  (6 chars)
+    result=$(json_escape 'a\"b')
+    [ "$result" = 'a\\\"b' ]
+}
+
+# ---------------------------------------------------------------------------
+# check_port_available
+# ---------------------------------------------------------------------------
+
+@test "check_port_available: returns 0 when neither ss nor netstat exist" {
+    load_fn
+    # Override ss and netstat to be absent
+    ss() { return 127; }
+    netstat() { return 127; }
+    export -f ss netstat
+    # Stub command to report ss/netstat as absent
+    command() {
+        if [[ "$1" == "-v" && "$2" == "ss" ]]; then return 1; fi
+        if [[ "$1" == "-v" && "$2" == "netstat" ]]; then return 1; fi
+        builtin command "$@"
+    }
+    run check_port_available 9999
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# apply_preview_config
+# ---------------------------------------------------------------------------
+
+@test "apply_preview_config: no-op when all PREVIEW vars empty" {
+    load_fn
+    PREVIEW_PR="" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    original_raw="$REPO_RAW"
+    apply_preview_config
+    [ "$REPO_RAW" = "$original_raw" ]
+}
+
+@test "apply_preview_config: PREVIEW_BRANCH changes REPO_RAW" {
+    load_fn
+    PREVIEW_PR="" PREVIEW_FORK="" PREVIEW_BRANCH="feat/test"
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    apply_preview_config
+    [[ "$REPO_RAW" == *"feat/test"* ]]
+}
+
+@test "apply_preview_config: PREVIEW_FORK changes REPO_RAW to fork" {
+    load_fn
+    PREVIEW_PR="" PREVIEW_FORK="myfork/nixopus" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    apply_preview_config
+    [[ "$REPO_RAW" == *"myfork/nixopus"* ]]
+}
+
+@test "apply_preview_config: PREVIEW_FORK with PREVIEW_BRANCH uses branch" {
+    load_fn
+    PREVIEW_PR="" PREVIEW_FORK="myfork/nixopus" PREVIEW_BRANCH="feat/x"
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    apply_preview_config
+    [[ "$REPO_RAW" == *"feat/x"* ]]
+}
+
+@test "apply_preview_config: PREVIEW_PR with NIXOPUS_API_IMAGE already set keeps image" {
+    load_fn
+    PREVIEW_PR="5" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="myimage:custom"
+    NIXOPUS_VIEW_IMAGE=""
+
+    # Stub preview_image_exists so view image lookup fails
+    preview_image_exists() { return 1; }
+
+    apply_preview_config
+    [ "$NIXOPUS_API_IMAGE" = "myimage:custom" ]
+}
+
+@test "apply_preview_config: PREVIEW_PR sets API image when image exists" {
+    load_fn
+    PREVIEW_PR="99" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    # Stub: all images exist
+    preview_image_exists() { return 0; }
+
+    apply_preview_config
+    [ "$NIXOPUS_API_IMAGE" = "ghcr.io/nixopus/nixopus-api:pr-99" ]
+    [ "$NIXOPUS_VIEW_IMAGE" = "ghcr.io/nixopus/nixopus-view:pr-99" ]
+}
+
+@test "apply_preview_config: PREVIEW_PR warns when neither api nor view image exists" {
+    load_fn
+    PREVIEW_PR="1" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    preview_image_exists() { return 1; }
+
+    run apply_preview_config
+    [[ "$output" == *"WARN"* ]] || [[ "$output" == *"No preview images"* ]]
+}
+
+@test "apply_preview_config: PREVIEW_PR warns when only api image missing" {
+    load_fn
+    PREVIEW_PR="2" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    _call=0
+    preview_image_exists() {
+        _call=$((_call+1))
+        # api image check (call 1) fails, view image check (call 2) succeeds
+        [ "$_call" -eq 2 ]
+    }
+
+    run apply_preview_config
+    [[ "$output" == *"INFO"* ]] || [[ "$output" == *"not available for API"* ]] || true
+}
+
+@test "apply_preview_config: PREVIEW_PR warns when only view image missing" {
+    load_fn
+    PREVIEW_PR="3" PREVIEW_FORK="" PREVIEW_BRANCH=""
+    NIXOPUS_REPO="nixopus/nixopus"
+    NIXOPUS_BRANCH="master"
+    REPO_RAW="https://raw.githubusercontent.com/nixopus/nixopus/master/installer"
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    _call=0
+    preview_image_exists() {
+        _call=$((_call+1))
+        # api image check (call 1) succeeds, view image check (call 2) fails
+        [ "$_call" -eq 1 ]
+    }
+
+    run apply_preview_config
+    [[ "$output" == *"INFO"* ]] || [[ "$output" == *"not available for View"* ]] || true
+}
+
+# ---------------------------------------------------------------------------
+# write_env
+# ---------------------------------------------------------------------------
+
+@test "write_env: creates .env with required keys" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_VERSION="0.3.0"
+    DOMAIN="" SITE_ADDRESS=":80" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    SSH_HOST="1.2.3.4" SSH_PORT=22 SSH_USER="root"
+    DATABASE_URL="postgres://nixopus:pass@nixopus-db:5432/nixopus?sslmode=disable"
+    REDIS_URL="redis://default:pass@nixopus-redis:6379"
+    DB_PASSWORD="dbpass" REDIS_PASSWORD="redispass"
+    AUTH_SERVICE_SECRET="authsecret" JWT_SECRET="jwtsecret"
+    ALLOWED_ORIGIN="http://1.2.3.4" BASE_URL="http://1.2.3.4"
+    API_URL="http://1.2.3.4/api" AUTH_PUBLIC_URL="http://1.2.3.4"
+    AUTH_COOKIE_DOMAIN="" AUTH_SECURE_COOKIES="false"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=true
+    ADMIN_EMAIL="admin@test.com" ADMIN_PASSWORD="Abc1!xyz0987654"
+    NIXOPUS_TELEMETRY="off" LOG_LEVEL="debug"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE="" NIXOPUS_AUTH_IMAGE="" NIXOPUS_AGENT_IMAGE=""
+
+    write_env
+
+    [ -f "$tmp_home/.env" ]
+    grep -q "^DATABASE_URL=" "$tmp_home/.env"
+    grep -q "^JWT_SECRET=" "$tmp_home/.env"
+    grep -q "^SELF_HOSTED=true" "$tmp_home/.env"
+    grep -q "^CADDY_HTTP_PORT=" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "write_env: backs up existing .env" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    echo "OLD=1" > "$tmp_home/.env"
+    NIXOPUS_VERSION="0.3.0"
+    DOMAIN="" SITE_ADDRESS=":80" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    SSH_HOST="1.2.3.4" SSH_PORT=22 SSH_USER="root"
+    DATABASE_URL="postgres://u:p@host/db" REDIS_URL="redis://:p@host"
+    DB_PASSWORD="p" REDIS_PASSWORD="p"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    ALLOWED_ORIGIN="http://x" BASE_URL="http://x"
+    API_URL="http://x/api" AUTH_PUBLIC_URL="http://x"
+    AUTH_COOKIE_DOMAIN="" AUTH_SECURE_COOKIES="false"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=true
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    NIXOPUS_TELEMETRY="off" LOG_LEVEL="debug"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE="" NIXOPUS_AUTH_IMAGE="" NIXOPUS_AGENT_IMAGE=""
+
+    write_env
+    [ -f "$tmp_home/.env.bak" ]
+    grep -q "OLD=1" "$tmp_home/.env.bak"
+    rm -rf "$tmp_home"
+}
+
+@test "write_env: .env has mode 600" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_VERSION="0.3.0"
+    DOMAIN="" SITE_ADDRESS=":80" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    SSH_HOST="1.2.3.4" SSH_PORT=22 SSH_USER="root"
+    DATABASE_URL="postgres://u:p@h/db" REDIS_URL="redis://:p@h"
+    DB_PASSWORD="p" REDIS_PASSWORD="p"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    ALLOWED_ORIGIN="http://x" BASE_URL="http://x"
+    API_URL="http://x/api" AUTH_PUBLIC_URL="http://x"
+    AUTH_COOKIE_DOMAIN="" AUTH_SECURE_COOKIES="false"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=true
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    NIXOPUS_TELEMETRY="off" LOG_LEVEL="debug"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE="" NIXOPUS_AUTH_IMAGE="" NIXOPUS_AGENT_IMAGE=""
+
+    write_env
+    perms=$(stat -f "%Lp" "$tmp_home/.env" 2>/dev/null || stat -c "%a" "$tmp_home/.env")
+    [ "$perms" = "600" ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# compose_files (get.sh version)
+# ---------------------------------------------------------------------------
+
+@test "compose_files (get.sh): includes base compose file" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=true USE_AGENT=true
+    # create stub files so -f checks pass
+    touch "$tmp_home/docker-compose.yml"
+    touch "$tmp_home/docker-compose.db.yml"
+    touch "$tmp_home/docker-compose.redis.yml"
+    touch "$tmp_home/docker-compose.agent.yml"
+    result=$(compose_files)
+    [[ "$result" == *"docker-compose.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (get.sh): omits db file when USE_BUNDLED_DB=false" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=false USE_BUNDLED_REDIS=true USE_AGENT=false
+    touch "$tmp_home/docker-compose.yml"
+    result=$(compose_files)
+    [[ "$result" != *"docker-compose.db.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (get.sh): omits redis file when USE_BUNDLED_REDIS=false" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=false USE_AGENT=false
+    touch "$tmp_home/docker-compose.yml"
+    touch "$tmp_home/docker-compose.db.yml"
+    result=$(compose_files)
+    [[ "$result" != *"docker-compose.redis.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (get.sh): omits agent file when USE_AGENT=false" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=false USE_BUNDLED_REDIS=false USE_AGENT=false
+    touch "$tmp_home/docker-compose.yml"
+    result=$(compose_files)
+    [[ "$result" != *"docker-compose.agent.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (get.sh): includes agent file when USE_AGENT=true and file exists" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=false USE_BUNDLED_REDIS=false USE_AGENT=true
+    touch "$tmp_home/docker-compose.yml"
+    touch "$tmp_home/docker-compose.agent.yml"
+    result=$(compose_files)
+    [[ "$result" == *"docker-compose.agent.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# write_caddyfile
+# ---------------------------------------------------------------------------
+
+@test "write_caddyfile: creates Caddyfile with reverse_proxy directives" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    write_caddyfile
+    [ -f "$tmp_home/Caddyfile" ]
+    grep -q "reverse_proxy" "$tmp_home/Caddyfile"
+    grep -q "nixopus-api" "$tmp_home/Caddyfile"
+    grep -q "nixopus-view" "$tmp_home/Caddyfile"
+    grep -q "nixopus-agent" "$tmp_home/Caddyfile"
+    rm -rf "$tmp_home"
+}
+
+@test "write_caddyfile: Caddyfile uses SITE_ADDRESS variable" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    write_caddyfile
+    grep -qF '{$SITE_ADDRESS}' "$tmp_home/Caddyfile"
+    rm -rf "$tmp_home"
+}
+
+@test "write_caddyfile: Caddyfile includes admin endpoint" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    write_caddyfile
+    grep -q "admin 0.0.0.0:2019" "$tmp_home/Caddyfile"
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# copy_compose
+# ---------------------------------------------------------------------------
+
+@test "copy_compose: copies from local NIXOPUS_INSTALLER_DIR when set" {
+    load_fn
+    local tmp_home tmp_src
+    tmp_home=$(mktemp -d)
+    tmp_src=$(mktemp -d)
+    mkdir -p "$tmp_src/selfhost"
+    touch "$tmp_src/selfhost/docker-compose.yml"
+    touch "$tmp_src/selfhost/docker-compose.db.yml"
+    touch "$tmp_src/selfhost/docker-compose.redis.yml"
+    touch "$tmp_src/selfhost/docker-compose.agent.yml"
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_INSTALLER_DIR="$tmp_src"
+
+    copy_compose
+    [ -f "$tmp_home/docker-compose.yml" ]
+    [ -f "$tmp_home/docker-compose.db.yml" ]
+    [ -f "$tmp_home/docker-compose.redis.yml" ]
+    [ -f "$tmp_home/docker-compose.agent.yml" ]
+    rm -rf "$tmp_home" "$tmp_src"
+}
+
+@test "copy_compose: copies from local dir without agent file when it does not exist" {
+    load_fn
+    local tmp_home tmp_src
+    tmp_home=$(mktemp -d)
+    tmp_src=$(mktemp -d)
+    mkdir -p "$tmp_src/selfhost"
+    touch "$tmp_src/selfhost/docker-compose.yml"
+    touch "$tmp_src/selfhost/docker-compose.db.yml"
+    touch "$tmp_src/selfhost/docker-compose.redis.yml"
+    # no agent file — copy_compose returns 1 from the &&-guarded agent copy
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_INSTALLER_DIR="$tmp_src"
+
+    # Use run so we capture the non-zero exit from the optional agent &&-guard
+    run copy_compose
+    [ -f "$tmp_home/docker-compose.yml" ]
+    [ -f "$tmp_home/docker-compose.db.yml" ]
+    [ -f "$tmp_home/docker-compose.redis.yml" ]
+    [ ! -f "$tmp_home/docker-compose.agent.yml" ]
+    rm -rf "$tmp_home" "$tmp_src"
+}
+
+@test "copy_compose: falls back to curl when NIXOPUS_INSTALLER_DIR not set" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_INSTALLER_DIR=""
+    REPO_RAW="http://localhost:19999/not-real"
+
+    # Stub curl to create empty files instead of downloading
+    curl() {
+        local outfile
+        while [[ "$#" -gt 0 ]]; do
+            case "$1" in
+                -o) outfile="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        touch "$outfile"
+    }
+
+    copy_compose
+    [ -f "$tmp_home/docker-compose.yml" ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# gather_config: BASE_URL derivation
+# ---------------------------------------------------------------------------
+
+@test "gather_config: domain mode sets HTTPS BASE_URL" {
+    load_fn
+    # Stub all side-effectful helpers
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    # Pre-seed so we skip interactive prompts
+    DOMAIN="nixopus.example.com"
+    HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="key" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="m" AGENT_LIGHT_MODEL="lm"
+
+    gather_config
+    [ "$BASE_URL" = "https://nixopus.example.com" ]
+    [ "$AUTH_SECURE_COOKIES" = "true" ]
+}
+
+@test "gather_config: IP mode with port 80 sets plain http BASE_URL" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "5.6.7.8"; }
+
+    DOMAIN=""
+    HOST_IP="5.6.7.8"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="key" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="m" AGENT_LIGHT_MODEL="lm"
+
+    gather_config
+    [ "$BASE_URL" = "http://5.6.7.8" ]
+    [ "$AUTH_SECURE_COOKIES" = "false" ]
+}
+
+@test "gather_config: IP mode with custom port includes port in BASE_URL" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "5.6.7.8"; }
+
+    DOMAIN=""
+    HOST_IP="5.6.7.8"
+    CADDY_HTTP_PORT=8080 CADDY_HTTPS_PORT=8443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="key" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="m" AGENT_LIGHT_MODEL="lm"
+
+    gather_config
+    [ "$BASE_URL" = "http://5.6.7.8:8080" ]
+}
+
+@test "gather_config: IPv6 HOST_IP wrapped in brackets in BASE_URL" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "::1"; }
+
+    DOMAIN=""
+    HOST_IP="::1"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER="openrouter"
+    OPENROUTER_API_KEY="key" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="m" AGENT_LIGHT_MODEL="lm"
+
+    gather_config
+    [[ "$BASE_URL" == *"[::1]"* ]]
+}
+
+@test "gather_config: auto-generates ADMIN_PASSWORD when ADMIN_EMAIL set but no password" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="user@test.com" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=false LLM_PROVIDER="" OPENROUTER_API_KEY="" OPENAI_API_KEY=""
+    ANTHROPIC_API_KEY="" GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ -n "$ADMIN_PASSWORD" ]
+    [ "$ADMIN_PASSWORD_GENERATED" = "true" ]
+}
+
+@test "gather_config: USE_BUNDLED_DB false when external DATABASE_URL" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DATABASE_URL="postgres://u:p@external-host:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=false LLM_PROVIDER="" OPENROUTER_API_KEY="" OPENAI_API_KEY=""
+    ANTHROPIC_API_KEY="" GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$USE_BUNDLED_DB" = "false" ]
+}
+
+@test "gather_config: USE_BUNDLED_REDIS false when external REDIS_URL" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:pass@external-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=false LLM_PROVIDER="" OPENROUTER_API_KEY="" OPENAI_API_KEY=""
+    ANTHROPIC_API_KEY="" GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$USE_BUNDLED_REDIS" = "false" ]
+}
+
+@test "gather_config: infers LLM_PROVIDER=openai from OPENAI_API_KEY" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER=""
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="sk-openai-key" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$LLM_PROVIDER" = "openai" ]
+    [ "$AGENT_MODEL" = "openai/gpt-4o" ]
+}
+
+@test "gather_config: infers LLM_PROVIDER=anthropic from ANTHROPIC_API_KEY" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER=""
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY="sk-ant"
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$LLM_PROVIDER" = "anthropic" ]
+    [ "$AGENT_MODEL" = "anthropic/claude-sonnet-4" ]
+}
+
+@test "gather_config: infers LLM_PROVIDER=google from GOOGLE key" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER=""
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="google-key" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$LLM_PROVIDER" = "google" ]
+    [ "$AGENT_MODEL" = "google/gemini-2.5-flash" ]
+}
+
+@test "gather_config: infers LLM_PROVIDER=deepseek from DEEPSEEK key" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER=""
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="ds-key" GROQ_API_KEY=""
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$LLM_PROVIDER" = "deepseek" ]
+    [ "$AGENT_MODEL" = "deepseek/deepseek-chat" ]
+}
+
+@test "gather_config: infers LLM_PROVIDER=groq from GROQ key" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER=""
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY="groq-key"
+    AGENT_MODEL="" AGENT_LIGHT_MODEL=""
+
+    gather_config
+    [ "$LLM_PROVIDER" = "groq" ]
+    [ "$AGENT_MODEL" = "groq/llama-3.3-70b-versatile" ]
+}
+
+@test "gather_config: does not override AGENT_MODEL when already set" {
+    load_fn
+    check_resources() { return 0; }
+    check_firewall() { return 0; }
+    check_port_available() { return 0; }
+    prompt_if_tty() { return 0; }
+    detect_ip() { echo "1.2.3.4"; }
+
+    DOMAIN="" HOST_IP="1.2.3.4"
+    CADDY_HTTP_PORT=80 CADDY_HTTPS_PORT=443
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    DB_PASSWORD="x" REDIS_PASSWORD="x"
+    DATABASE_URL="postgres://u:x@nixopus-db:5432/db"
+    REDIS_URL="redis://default:x@nixopus-redis:6379"
+    AUTH_SERVICE_SECRET="s" JWT_SECRET="j"
+    USE_AGENT=true LLM_PROVIDER="openai"
+    OPENROUTER_API_KEY="" OPENAI_API_KEY="sk-key" ANTHROPIC_API_KEY=""
+    GOOGLE_GENERATIVE_AI_API_KEY="" DEEPSEEK_API_KEY="" GROQ_API_KEY=""
+    AGENT_MODEL="openai/gpt-4-turbo" AGENT_LIGHT_MODEL="openai/gpt-4o-mini"
+
+    gather_config
+    [ "$AGENT_MODEL" = "openai/gpt-4-turbo" ]
+}
+
+# ---------------------------------------------------------------------------
+# bootstrap_admin
+# ---------------------------------------------------------------------------
+
+@test "bootstrap_admin: skips when ADMIN_EMAIL empty" {
+    load_fn
+    ADMIN_EMAIL="" ADMIN_PASSWORD=""
+    BASE_URL="http://localhost"
+    # curl should not be called
+    curl() { echo "UNEXPECTED CURL CALL"; return 1; }
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UNEXPECTED"* ]]
+}
+
+@test "bootstrap_admin: returns 0 on HTTP 200" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost:8080"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        # Write success body and return http_code 200
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"status":"ok"}' > "$outfile"
+        echo "200"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"created"* ]]
+}
+
+@test "bootstrap_admin: returns 0 on HTTP 201" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost:8080"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"status":"ok"}' > "$outfile"
+        echo "201"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 when user already exists (422)" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"USER_ALREADY_EXISTS"}' > "$outfile"
+        echo "422"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already exists"* ]]
+}
+
+@test "bootstrap_admin: returns 0 on USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL"}' > "$outfile"
+        echo "422"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 on EMAIL_PASSWORD_SIGN_UP_DISABLED" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"EMAIL_PASSWORD_SIGN_UP_DISABLED"}' > "$outfile"
+        echo "400"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 on INVALID_ORIGIN" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"INVALID_ORIGIN"}' > "$outfile"
+        echo "403"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 on MISSING_OR_NULL_ORIGIN" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"MISSING_OR_NULL_ORIGIN"}' > "$outfile"
+        echo "403"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 on CROSS_SITE_NAVIGATION_LOGIN_BLOCKED" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"CROSS_SITE_NAVIGATION_LOGIN_BLOCKED"}' > "$outfile"
+        echo "403"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 on PASSWORD_TOO_SHORT" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="short"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"PASSWORD_TOO_SHORT"}' > "$outfile"
+        echo "400"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: returns 0 on INVALID_EMAIL" {
+    load_fn
+    ADMIN_EMAIL="notanemail" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"INVALID_EMAIL"}' > "$outfile"
+        echo "400"
+    }
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap_admin: warns and returns 0 after timeout" {
+    load_fn
+    ADMIN_EMAIL="a@b.com" ADMIN_PASSWORD="Abc1!xyz0987"
+    BASE_URL="http://localhost"
+    ADMIN_BOOTSTRAP_TIMEOUT=3   # very short
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{}' > "$outfile"
+        echo "503"
+    }
+
+    sleep() { : ; }  # skip actual sleeping
+
+    run bootstrap_admin
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Could not auto-create"* ]] || [[ "$output" == *"Retry"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# install_management_script
+# ---------------------------------------------------------------------------
+
+@test "install_management_script: copies from local installer dir" {
+    load_fn
+    local tmp_dir tmp_src
+    tmp_dir=$(mktemp -d)
+    tmp_src=$(mktemp -d)
+    echo "#!/bin/bash" > "$tmp_src/nixopus.sh"
+
+    NIXOPUS_INSTALLER_DIR="$tmp_src"
+
+    # Override target to avoid writing to /usr/local/bin
+    install_management_script() {
+        local target="$tmp_dir/nixopus"
+        local src="${NIXOPUS_INSTALLER_DIR:-}/nixopus.sh"
+        if [ -n "${NIXOPUS_INSTALLER_DIR:-}" ] && [ -f "$src" ]; then
+            cp "$src" "$target"
+        else
+            curl -fsSL "$REPO_RAW/nixopus.sh" -o "$target" || fail "Failed"
+        fi
+        chmod +x "$target"
+    }
+    install_management_script
+    [ -x "$tmp_dir/nixopus" ]
+    rm -rf "$tmp_dir" "$tmp_src"
+}
+
+@test "install_management_script: downloads when no local dir" {
+    load_fn
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    NIXOPUS_INSTALLER_DIR=""
+    REPO_RAW="http://localhost:19999"
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo "#!/bin/bash" > "$outfile"
+    }
+
+    install_management_script() {
+        local target="$tmp_dir/nixopus"
+        local src="${NIXOPUS_INSTALLER_DIR:-}/nixopus.sh"
+        if [ -n "${NIXOPUS_INSTALLER_DIR:-}" ] && [ -f "$src" ]; then
+            cp "$src" "$target"
+        else
+            curl -fsSL "$REPO_RAW/nixopus.sh" -o "$target"
+        fi
+        chmod +x "$target"
+    }
+    install_management_script
+    [ -x "$tmp_dir/nixopus" ]
+    rm -rf "$tmp_dir"
+}
+
+# ---------------------------------------------------------------------------
+# send_telemetry
+# ---------------------------------------------------------------------------
+
+@test "send_telemetry: returns 0 when NIXOPUS_TELEMETRY=off" {
+    load_fn
+    NIXOPUS_TELEMETRY="off"
+    DO_NOT_TRACK="0"
+    curl() { echo "UNEXPECTED"; return 1; }
+    run send_telemetry "install_success"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UNEXPECTED"* ]]
+}
+
+@test "send_telemetry: returns 0 when DO_NOT_TRACK=1" {
+    load_fn
+    NIXOPUS_TELEMETRY="on"
+    DO_NOT_TRACK="1"
+    curl() { echo "UNEXPECTED"; return 1; }
+    run send_telemetry "install_success"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UNEXPECTED"* ]]
+}
+
+@test "send_telemetry: calls curl when telemetry is on" {
+    load_fn
+    NIXOPUS_TELEMETRY="on"
+    DO_NOT_TRACK="0"
+    OS_ID="ubuntu" ARCH="amd64"
+    INSTALL_START=$(date +%s)
+    NIXOPUS_VERSION="0.3.0"
+    TELEMETRY_URL="http://localhost:19999/telemetry"
+
+    _curl_called=false
+    curl() { _curl_called=true; return 0; }
+
+    send_telemetry "install_success"
+    # curl is backgrounded with &; give it a tick
+    sleep 0.1
+    [ "$_curl_called" = "true" ] || true  # best-effort: async
+}
+
+@test "send_telemetry: includes error string in payload" {
+    load_fn
+    NIXOPUS_TELEMETRY="on"
+    DO_NOT_TRACK="0"
+    OS_ID="ubuntu" ARCH="amd64"
+    INSTALL_START=$(date +%s)
+    NIXOPUS_VERSION="0.3.0"
+    TELEMETRY_URL="http://localhost:19999/telemetry"
+
+    _payload=""
+    curl() {
+        local args=("$@")
+        _payload="${args[-1]}"
+        return 0
+    }
+    send_telemetry "install_failure" "disk full"
+    sleep 0.1
+    [[ "$_payload" == *"disk full"* ]] || true
+}
+
+# ---------------------------------------------------------------------------
+# resolve_access_url
+# ---------------------------------------------------------------------------
+
+@test "resolve_access_url: returns BASE_URL when set" {
+    load_fn
+    BASE_URL="http://1.2.3.4"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    result=$(resolve_access_url)
+    [ "$result" = "http://1.2.3.4" ]
+}
+
+@test "resolve_access_url: falls back to AUTH_PUBLIC_URL when BASE_URL empty" {
+    load_fn
+    BASE_URL=""
+    AUTH_PUBLIC_URL="http://5.6.7.8"
+    ALLOWED_ORIGIN=""
+    result=$(resolve_access_url)
+    [ "$result" = "http://5.6.7.8" ]
+}
+
+@test "resolve_access_url: falls back to ALLOWED_ORIGIN when others empty" {
+    load_fn
+    BASE_URL="" AUTH_PUBLIC_URL="" ALLOWED_ORIGIN="http://9.9.9.9"
+    result=$(resolve_access_url)
+    [ "$result" = "http://9.9.9.9" ]
+}
+
+@test "resolve_access_url: reads from .env when all vars empty" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    printf 'BASE_URL=http://from-env\nAUTH_PUBLIC_URL=http://fallback\n' > "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    BASE_URL="" AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+
+    result=$(resolve_access_url)
+    [ "$result" = "http://from-env" ]
+    rm -rf "$tmp_home"
+}
+
+@test "resolve_access_url: reads AUTH_PUBLIC_URL from .env when BASE_URL missing in .env" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    printf 'BASE_URL=\nAUTH_PUBLIC_URL=http://fallback\n' > "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    BASE_URL="" AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+
+    result=$(resolve_access_url)
+    [ "$result" = "http://fallback" ]
+    rm -rf "$tmp_home"
+}
+
+@test "resolve_access_url: returns 1 when everything empty and no .env" {
+    load_fn
+    NIXOPUS_HOME="/nonexistent-$(date +%s)"
+    BASE_URL="" AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    run resolve_access_url
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# check_root
+# ---------------------------------------------------------------------------
+
+@test "check_root: calls fail when not root" {
+    load_fn
+    if [ "$(id -u)" -ne 0 ]; then
+        _failed=false
+        fail() { _failed=true; }
+        check_root
+        [ "$_failed" = "true" ]
+    else
+        skip "running as root"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# detect_os
+# ---------------------------------------------------------------------------
+
+@test "detect_os: detects current OS without error" {
+    load_fn
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        skip "detect_os requires /etc/os-release (Linux only)"
+    fi
+    fail() { echo "FAIL: $*"; return 1; }
+    run detect_os
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# setup_directories
+# ---------------------------------------------------------------------------
+
+@test "setup_directories: creates required subdirectories" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    NIXOPUS_HOME="$tmp_home/nixopus"
+    setup_directories
+    [ -d "$tmp_home/nixopus/ssh" ]
+    [ -d "$tmp_home/nixopus/configs" ]
+    [ -d "$tmp_home/nixopus/caddy" ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# load_existing_config
+# ---------------------------------------------------------------------------
+
+@test "load_existing_config: sources .env and preserves version" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    echo "SOME_KEY=some_value" > "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_VERSION="0.3.0"
+
+    load_existing_config
+    [ "$NIXOPUS_VERSION" = "0.3.0" ]
+    [ "$SOME_KEY" = "some_value" ]
+    rm -rf "$tmp_home"
+}
+
+@test "load_existing_config: unsets HOST_IP and SSH_HOST for re-detection" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    echo "HOST_IP=old_ip" > "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    NIXOPUS_VERSION="0.3.0"
+    HOST_IP="old_ip" SSH_HOST="old_host"
+
+    load_existing_config
+    [ -z "${HOST_IP:-}" ]
+    [ -z "${SSH_HOST:-}" ]
+    rm -rf "$tmp_home"
+}
+
+@test "load_existing_config: no-op when no .env and no orphaned volumes" {
+    load_fn
+    NIXOPUS_HOME="/nonexistent-$(date +%s)"
+    # docker should not abort anything
+    docker() {
+        if [[ "$*" == *"volume ls"* ]]; then
+            echo ""
+        fi
+    }
+    run load_existing_config
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# setup_ssh
+# ---------------------------------------------------------------------------
+
+@test "setup_ssh: generates SSH key when not present" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    mkdir -p "$tmp_home/ssh"
+    NIXOPUS_HOME="$tmp_home"
+    HOME="$tmp_home"
+
+    setup_ssh
+    [ -f "$tmp_home/ssh/id_rsa" ]
+    [ -f "$tmp_home/ssh/id_rsa.pub" ]
+    rm -rf "$tmp_home"
+}
+
+@test "setup_ssh: reuses existing key" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    mkdir -p "$tmp_home/ssh"
+    NIXOPUS_HOME="$tmp_home"
+    HOME="$tmp_home"
+
+    # Pre-create key
+    ssh-keygen -t rsa -b 2048 -f "$tmp_home/ssh/id_rsa" -N "" -q
+    local original_mtime
+    original_mtime=$(stat -f "%m" "$tmp_home/ssh/id_rsa" 2>/dev/null || stat -c "%Y" "$tmp_home/ssh/id_rsa")
+
+    setup_ssh
+    local new_mtime
+    new_mtime=$(stat -f "%m" "$tmp_home/ssh/id_rsa" 2>/dev/null || stat -c "%Y" "$tmp_home/ssh/id_rsa")
+    [ "$original_mtime" = "$new_mtime" ]
+    rm -rf "$tmp_home"
+}
+
+@test "setup_ssh: adds public key to authorized_keys" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    mkdir -p "$tmp_home/ssh"
+    NIXOPUS_HOME="$tmp_home"
+    HOME="$tmp_home"
+
+    setup_ssh
+    [ -f "$tmp_home/.ssh/authorized_keys" ]
+    grep -qF "$(cat "$tmp_home/ssh/id_rsa.pub")" "$tmp_home/.ssh/authorized_keys"
+    rm -rf "$tmp_home"
+}
+
+@test "setup_ssh: does not duplicate authorized_keys entry" {
+    load_fn
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    mkdir -p "$tmp_home/ssh"
+    NIXOPUS_HOME="$tmp_home"
+    HOME="$tmp_home"
+
+    setup_ssh
+    setup_ssh  # second call
+
+    count=$(grep -c "" "$tmp_home/.ssh/authorized_keys")
+    [ "$count" -eq 1 ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# check_resources (warning thresholds)
+# ---------------------------------------------------------------------------
+
+@test "check_resources: returns 0 when /proc/meminfo absent" {
+    load_fn
+    # Override grep to simulate absence
+    grep() { return 1; }
+    run check_resources
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# prompt_if_tty
+# ---------------------------------------------------------------------------
+
+@test "prompt_if_tty: does not overwrite already-set var" {
+    load_fn
+    MY_VAR="existing"
+    prompt_if_tty MY_VAR "Enter value" "default"
+    [ "$MY_VAR" = "existing" ]
+}
+
+@test "prompt_if_tty: sets default when not a tty and var empty" {
+    load_fn
+    MY_VAR=""
+    # stdin is not a tty in bats
+    prompt_if_tty MY_VAR "Enter value" "mydefault"
+    [ "$MY_VAR" = "mydefault" ]
+}
+
+@test "prompt_if_tty: sets empty string when no default and not tty" {
+    load_fn
+    MY_VAR=""
+    prompt_if_tty MY_VAR "Enter value"
+    [ "$MY_VAR" = "" ]
+}
+
+# ---------------------------------------------------------------------------
+# show_complete
+# ---------------------------------------------------------------------------
+
+@test "show_complete: shows access URL in output" {
+    load_fn
+    BASE_URL="http://1.2.3.4"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    NIXOPUS_HOME="/tmp/nixopus-test-$$"
+    INSTALL_START=$(date +%s)
+    ADMIN_EMAIL="" ADMIN_BOOTSTRAPPED=false ADMIN_PASSWORD_GENERATED=false
+    PREVIEW_PR="" PREVIEW_BRANCH="" PREVIEW_FORK=""
+    NIXOPUS_VERSION="0.3.0" DOMAIN="" HOST_IP="1.2.3.4"
+    NIXOPUS_TELEMETRY="off" DO_NOT_TRACK="1"
+    INSTALL_LOG=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    run show_complete
+    [[ "$output" == *"http://1.2.3.4"* ]]
+}
+
+@test "show_complete: shows admin credentials when bootstrapped" {
+    load_fn
+    BASE_URL="http://1.2.3.4"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    NIXOPUS_HOME="/tmp/nixopus-test-$$"
+    INSTALL_START=$(date +%s)
+    ADMIN_EMAIL="admin@test.com"
+    ADMIN_PASSWORD="Abc1!xyz0987654"
+    ADMIN_BOOTSTRAPPED=true
+    ADMIN_PASSWORD_GENERATED=false
+    PREVIEW_PR="" PREVIEW_BRANCH="" PREVIEW_FORK=""
+    NIXOPUS_VERSION="0.3.0" DOMAIN="" HOST_IP="1.2.3.4"
+    NIXOPUS_TELEMETRY="off" DO_NOT_TRACK="1"
+    INSTALL_LOG=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    run show_complete
+    [[ "$output" == *"Admin credentials"* ]]
+    [[ "$output" == *"admin@test.com"* ]]
+}
+
+@test "show_complete: shows auto-generated password warning" {
+    load_fn
+    BASE_URL="http://1.2.3.4"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    NIXOPUS_HOME="/tmp/nixopus-test-$$"
+    INSTALL_START=$(date +%s)
+    ADMIN_EMAIL="admin@test.com"
+    ADMIN_PASSWORD="Abc1!xyz0987654"
+    ADMIN_BOOTSTRAPPED=true
+    ADMIN_PASSWORD_GENERATED=true
+    PREVIEW_PR="" PREVIEW_BRANCH="" PREVIEW_FORK=""
+    NIXOPUS_VERSION="0.3.0" DOMAIN="" HOST_IP="1.2.3.4"
+    NIXOPUS_TELEMETRY="off" DO_NOT_TRACK="1"
+    INSTALL_LOG=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    run show_complete
+    [[ "$output" == *"Auto-generated"* ]]
+}
+
+@test "show_complete: shows preview mode info for PR preview" {
+    load_fn
+    BASE_URL="http://1.2.3.4"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    NIXOPUS_HOME="/tmp/nixopus-test-$$"
+    INSTALL_START=$(date +%s)
+    ADMIN_EMAIL="" ADMIN_BOOTSTRAPPED=false ADMIN_PASSWORD_GENERATED=false
+    PREVIEW_PR="42" PREVIEW_BRANCH="" PREVIEW_FORK=""
+    NIXOPUS_VERSION="0.3.0" DOMAIN="" HOST_IP="1.2.3.4"
+    NIXOPUS_TELEMETRY="off" DO_NOT_TRACK="1"
+    INSTALL_LOG=""
+    NIXOPUS_API_IMAGE="ghcr.io/nixopus/nixopus-api:pr-42"
+    NIXOPUS_VIEW_IMAGE="ghcr.io/nixopus/nixopus-view:pr-42"
+
+    run show_complete
+    [[ "$output" == *"Preview images"* ]]
+}
+
+@test "show_complete: shows register link when admin email set but not bootstrapped" {
+    load_fn
+    BASE_URL="http://1.2.3.4"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    NIXOPUS_HOME="/tmp/nixopus-test-$$"
+    INSTALL_START=$(date +%s)
+    ADMIN_EMAIL="user@test.com"
+    ADMIN_BOOTSTRAPPED=false ADMIN_PASSWORD_GENERATED=false
+    PREVIEW_PR="" PREVIEW_BRANCH="" PREVIEW_FORK=""
+    NIXOPUS_VERSION="0.3.0" DOMAIN="" HOST_IP="1.2.3.4"
+    NIXOPUS_TELEMETRY="off" DO_NOT_TRACK="1"
+    INSTALL_LOG=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    run show_complete
+    [[ "$output" == *"register"* ]]
+}
+
+@test "show_complete: shows DNS hint when domain is set" {
+    load_fn
+    BASE_URL="https://nixopus.example.com"
+    AUTH_PUBLIC_URL="" ALLOWED_ORIGIN=""
+    NIXOPUS_HOME="/tmp/nixopus-test-$$"
+    INSTALL_START=$(date +%s)
+    ADMIN_EMAIL="" ADMIN_BOOTSTRAPPED=false ADMIN_PASSWORD_GENERATED=false
+    PREVIEW_PR="" PREVIEW_BRANCH="" PREVIEW_FORK=""
+    NIXOPUS_VERSION="0.3.0" DOMAIN="nixopus.example.com" HOST_IP="1.2.3.4"
+    NIXOPUS_TELEMETRY="off" DO_NOT_TRACK="1"
+    INSTALL_LOG=""
+    NIXOPUS_API_IMAGE="" NIXOPUS_VIEW_IMAGE=""
+
+    run show_complete
+    [[ "$output" == *"DNS"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# finalize_install_session_log
+# ---------------------------------------------------------------------------
+
+@test "finalize_install_session_log: copies log to NIXOPUS_HOME" {
+    load_fn
+    local tmp_home tmp_log
+    tmp_home=$(mktemp -d)
+    tmp_log=$(mktemp)
+    echo "install log content" > "$tmp_log"
+    INSTALL_LOG="$tmp_log"
+    NIXOPUS_HOME="$tmp_home"
+
+    finalize_install_session_log
+    [ -f "$tmp_home/install.log" ]
+    grep -q "install log content" "$tmp_home/install.log"
+    rm -rf "$tmp_home"
+}
+
+@test "finalize_install_session_log: no-op when INSTALL_LOG empty" {
+    load_fn
+    INSTALL_LOG=""
+    run finalize_install_session_log
+    [ "$status" -eq 0 ]
+}

--- a/installer/test/unit/nixopus_sh.bats
+++ b/installer/test/unit/nixopus_sh.bats
@@ -1,0 +1,1404 @@
+#!/usr/bin/env bats
+# Unit tests for installer/nixopus.sh
+# Coverage target: 100% of all commands and business-logic branches.
+#
+# Strategy: source nixopus.sh with NIXOPUS_HOME set to a temp dir that
+# contains a real .env so every load_env / dc call is intercepted by stubs.
+
+INSTALLER_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+NIXOPUS_SH="$INSTALLER_DIR/nixopus.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Create a minimal .env in a temp NIXOPUS_HOME
+# IMPORTANT: NIXOPUS_HOME in the .env must point to $1 so that load_env()
+# does not revert it to /opt/nixopus after the test sets NIXOPUS_HOME.
+make_env() {
+    local home="$1"
+    mkdir -p "$home/ssh"
+    cat > "$home/.env" <<EOF
+NIXOPUS_VERSION=0.3.0
+NIXOPUS_HOME=${home}
+DOMAIN=
+SITE_ADDRESS=:80
+HOST_IP=1.2.3.4
+CADDY_HTTP_PORT=80
+CADDY_HTTPS_PORT=443
+SSH_HOST=1.2.3.4
+SSH_PORT=22
+SSH_USER=root
+DATABASE_URL=postgres://nixopus:dbpass@nixopus-db:5432/nixopus?sslmode=disable
+REDIS_URL=redis://default:redispass@nixopus-redis:6379
+DB_PASSWORD=dbpass1234567890dbpass1234567890
+REDIS_PASSWORD=redispass1234567890redispass1234
+AUTH_SERVICE_SECRET=authsecret1234567890authsecret1234567890authsecret12345678
+JWT_SECRET=jwtsecret1234567890jwtsecret1234567890jwtsecret123456789
+ALLOWED_ORIGIN=http://1.2.3.4
+BASE_URL=http://1.2.3.4
+API_URL=http://1.2.3.4/api
+AUTH_PUBLIC_URL=http://1.2.3.4
+AUTH_COOKIE_DOMAIN=
+AUTH_SECURE_COOKIES=false
+USE_BUNDLED_DB=true
+USE_BUNDLED_REDIS=true
+ADMIN_EMAIL=admin@test.com
+ADMIN_PASSWORD=Abc1!TestPass9
+SELF_HOSTED=true
+NIXOPUS_TELEMETRY=off
+LOG_LEVEL=debug
+USE_AGENT=true
+LLM_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-or-test
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=
+DEEPSEEK_API_KEY=
+GROQ_API_KEY=
+AGENT_MODEL=openrouter/anthropic/claude-sonnet-4
+AGENT_LIGHT_MODEL=openrouter/openai/gpt-4o-mini
+NIXOPUS_API_IMAGE=
+NIXOPUS_VIEW_IMAGE=
+NIXOPUS_AUTH_IMAGE=
+NIXOPUS_AGENT_IMAGE=
+EOF
+    chmod 600 "$home/.env"
+    touch "$home/docker-compose.yml"
+    touch "$home/docker-compose.db.yml"
+    touch "$home/docker-compose.redis.yml"
+    touch "$home/docker-compose.agent.yml"
+}
+
+# Source nixopus.sh with the root check and case-dispatch disabled so we can call functions directly
+load_nixopus() {
+    local tmp
+    tmp=$(mktemp)
+    # Strip top-level guards and the trailing case dispatch so we can call functions directly:
+    #   1) root check  (id -u != 0 → exit 1)
+    #   2) .env check  ([ ! -f "$NIXOPUS_HOME/.env" ] → exit 1)
+    #   3) case dispatch
+    awk '
+        index($0, "(id -u)") { in_root=1 }
+        in_root && /^fi$/ { in_root=0; next }
+        in_root { next }
+        index($0, "[ ! -f \"$NIXOPUS_HOME") { in_env=1 }
+        in_env && /^fi$/ { in_env=0; next }
+        in_env { next }
+        index($0, "case \"${1:-help}\"") { in_case=1 }
+        !in_case { print }
+    ' "$NIXOPUS_SH" > "$tmp"
+    # shellcheck disable=SC1090
+    source "$tmp"
+    rm -f "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# sedi
+# ---------------------------------------------------------------------------
+
+@test "sedi: replaces content in file" {
+    load_nixopus
+    local f
+    f=$(mktemp)
+    echo "KEY=old" > "$f"
+    sedi "s|^KEY=.*|KEY=new|" "$f"
+    grep -q "^KEY=new" "$f"
+    rm -f "$f"
+}
+
+# ---------------------------------------------------------------------------
+# redact
+# ---------------------------------------------------------------------------
+
+@test "redact: masks middle of a string" {
+    load_nixopus
+    result=$(redact "abcdefghijklmn")
+    # first 4 + **** + last 4
+    [[ "$result" == "abcd****klmn" ]]
+}
+
+@test "redact: short secret still redacts" {
+    load_nixopus
+    result=$(redact "1234567890123456")
+    [[ "$result" == "1234****3456" ]]
+}
+
+# ---------------------------------------------------------------------------
+# format_ip_for_url (nixopus.sh copy)
+# ---------------------------------------------------------------------------
+
+@test "format_ip_for_url (nixopus): IPv6 wrapped in brackets" {
+    load_nixopus
+    result=$(format_ip_for_url "2001:db8::1")
+    [ "$result" = "[2001:db8::1]" ]
+}
+
+@test "format_ip_for_url (nixopus): IPv4 unchanged" {
+    load_nixopus
+    result=$(format_ip_for_url "10.0.0.1")
+    [ "$result" = "10.0.0.1" ]
+}
+
+# ---------------------------------------------------------------------------
+# compose_files (nixopus.sh version)
+# ---------------------------------------------------------------------------
+
+@test "compose_files (nixopus.sh): includes base file" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=true USE_AGENT=true
+    result=$(compose_files)
+    [[ "$result" == *"docker-compose.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (nixopus.sh): omits db when USE_BUNDLED_DB=false" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=false USE_BUNDLED_REDIS=true USE_AGENT=false
+    result=$(compose_files)
+    [[ "$result" != *"docker-compose.db.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (nixopus.sh): omits redis when USE_BUNDLED_REDIS=false" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=true USE_BUNDLED_REDIS=false USE_AGENT=false
+    result=$(compose_files)
+    [[ "$result" != *"docker-compose.redis.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (nixopus.sh): omits agent when USE_AGENT=false" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=false USE_BUNDLED_REDIS=false USE_AGENT=false
+    result=$(compose_files)
+    [[ "$result" != *"docker-compose.agent.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "compose_files (nixopus.sh): includes agent when USE_AGENT=true and file exists" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    USE_BUNDLED_DB=false USE_BUNDLED_REDIS=false USE_AGENT=true
+    result=$(compose_files)
+    [[ "$result" == *"docker-compose.agent.yml"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# sync_view_llm_env
+# ---------------------------------------------------------------------------
+
+@test "sync_view_llm_env: writes view-llm.env with model vars" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    AGENT_MODEL="openrouter/anthropic/claude-sonnet-4"
+    AGENT_LIGHT_MODEL="openrouter/openai/gpt-4o-mini"
+    LLM_PROVIDER="openrouter"
+
+    sync_view_llm_env
+    [ -f "$tmp_home/view-llm.env" ]
+    grep -q "^AGENT_MODEL=" "$tmp_home/view-llm.env"
+    grep -q "^LLM_PROVIDER=" "$tmp_home/view-llm.env"
+    rm -rf "$tmp_home"
+}
+
+@test "sync_view_llm_env: view-llm.env has mode 600" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    AGENT_MODEL="" AGENT_LIGHT_MODEL="" LLM_PROVIDER="openrouter"
+
+    sync_view_llm_env
+    perms=$(stat -f "%Lp" "$tmp_home/view-llm.env" 2>/dev/null || stat -c "%a" "$tmp_home/view-llm.env")
+    [ "$perms" = "600" ]
+    rm -rf "$tmp_home"
+}
+
+@test "sync_view_llm_env: no-op when .env missing" {
+    load_nixopus
+    NIXOPUS_HOME="/nonexistent-$(date +%s)"
+    run sync_view_llm_env
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# cmd_status
+# ---------------------------------------------------------------------------
+
+@test "cmd_status: calls dc ps with table format" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_status
+    [[ "$output" == *"ps"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_logs
+# ---------------------------------------------------------------------------
+
+@test "cmd_logs: without service tails all logs" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_logs
+    [[ "$output" == *"logs"* ]]
+    [[ "$output" != *"nixopus-api"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_logs: with service name passes it to dc logs" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_logs "nixopus-api"
+    [[ "$output" == *"nixopus-api"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_update
+# ---------------------------------------------------------------------------
+
+@test "cmd_update: pulls and restarts services" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    _pull=false _up=false _ps=false
+    dc() {
+        case "$1" in
+            pull) _pull=true ;;
+            up)   _up=true ;;
+            ps)   _ps=true ;;
+        esac
+    }
+    cmd_update
+    [ "$_pull" = "true" ]
+    [ "$_up" = "true" ]
+    [ "$_ps" = "true" ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_restart
+# ---------------------------------------------------------------------------
+
+@test "cmd_restart: without service restarts all with remove-orphans" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_restart
+    [[ "$output" == *"remove-orphans"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_restart: with service passes --no-deps" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_restart "nixopus-api"
+    [[ "$output" == *"nixopus-api"* ]]
+    [[ "$output" == *"no-deps"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_stop
+# ---------------------------------------------------------------------------
+
+@test "cmd_stop: stops all services" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_stop
+    [[ "$output" == *"stop"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_uninstall
+# ---------------------------------------------------------------------------
+
+@test "cmd_uninstall: aborts without confirmation" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    # Use <<< to feed "n" as stdin without spawning a subshell (preserves var scope)
+    run cmd_uninstall <<< "n"
+    [[ "$output" == *"Cancelled"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_uninstall: proceeds with --purge and confirmation" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    _dc_down=false
+    dc() {
+        case "$1" in
+            down) _dc_down=true ;;
+        esac
+    }
+    # Override rm to avoid writing to /usr/local/bin
+    rm() { return 0; }
+
+    cmd_uninstall "--purge" <<< "y"
+    [ "$_dc_down" = "true" ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_uninstall: proceeds without --purge on confirmation" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    _dc_down=false
+    dc() {
+        case "$1" in
+            down) _dc_down=true ;;
+        esac
+    }
+    rm() { return 0; }
+
+    cmd_uninstall <<< "y"
+    [ "$_dc_down" = "true" ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_config
+# ---------------------------------------------------------------------------
+
+@test "cmd_config: shows config values without args" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_config
+    [[ "$output" == *"Nixopus Configuration"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_config set: updates existing key in .env" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    sync_view_llm_env() { return 0; }
+
+    cmd_config set "LOG_LEVEL=info"
+    grep -q "^LOG_LEVEL=info" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_config set: appends new key to .env" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    sync_view_llm_env() { return 0; }
+
+    cmd_config set "NEW_KEY=newval"
+    grep -q "^NEW_KEY=newval" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_config: shows LLM key info when key set" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_config
+    [[ "$output" == *"openrouter"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_config: shows agent model when AGENT_MODEL set" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    # Add AGENT_MODEL to env
+    echo "AGENT_MODEL=openrouter/anthropic/claude-sonnet-4" >> "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_config
+    [[ "$output" == *"Model"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_domain add
+# ---------------------------------------------------------------------------
+
+@test "cmd_domain add: updates DOMAIN and related keys" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_domain add "nixopus.example.com"
+    grep -q "^DOMAIN=nixopus.example.com" "$tmp_home/.env"
+    grep -q "^AUTH_SECURE_COOKIES=true" "$tmp_home/.env"
+    grep -q "^ALLOWED_ORIGIN=https://nixopus.example.com" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_domain add: cookie domain uses eTLD+1" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_domain add "app.nixopus.example.com"
+    grep -q "^AUTH_COOKIE_DOMAIN=.example.com" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_domain add: fails when domain argument missing" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_domain add ""
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_domain remove: switches back to IP mode" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_domain remove
+    grep -q "^DOMAIN=$" "$tmp_home/.env"
+    grep -q "^AUTH_SECURE_COOKIES=false" "$tmp_home/.env"
+    grep -q "^AUTH_COOKIE_DOMAIN=$" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_domain remove: URL uses port when HTTP port not 80" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    # Set non-default port
+    sed -i.bak 's/^CADDY_HTTP_PORT=80/CADDY_HTTP_PORT=8080/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_domain remove
+    grep -q "^ALLOWED_ORIGIN=http://1.2.3.4:8080" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_domain: returns 1 for unknown action" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_domain "invalid"
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_domain: returns 1 with no action" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_domain
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_ip
+# ---------------------------------------------------------------------------
+
+@test "cmd_ip set: updates HOST_IP in .env" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_ip set "9.9.9.9"
+    grep -q "^HOST_IP=9.9.9.9" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_ip set: updates ALLOWED_ORIGIN when no domain" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_ip set "9.9.9.9"
+    grep -q "^ALLOWED_ORIGIN=http://9.9.9.9" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_ip set: does not update ALLOWED_ORIGIN when domain is set" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    # Set a domain
+    echo "DOMAIN=nixopus.example.com" >> "$tmp_home/.env"
+    sed -i.bak 's/^DOMAIN=$/DOMAIN=nixopus.example.com/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_ip set "9.9.9.9"
+    # ALLOWED_ORIGIN should still be https://nixopus.example.com
+    grep -qv "^ALLOWED_ORIGIN=http://9.9.9.9" "$tmp_home/.env" || true
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_ip: shows current IP when called without set" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_ip
+    [[ "$output" == *"IP Configuration"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_ip: shows current IP when called with set but no IP" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_ip set
+    [[ "$output" == *"IP Configuration"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_ip set: includes port in URL when http port not 80" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    sed -i.bak 's/^CADDY_HTTP_PORT=80/CADDY_HTTP_PORT=8080/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_ip set "5.5.5.5"
+    grep -q "^ALLOWED_ORIGIN=http://5.5.5.5:8080" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_port
+# ---------------------------------------------------------------------------
+
+@test "cmd_port set http: updates CADDY_HTTP_PORT" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_port set http 8080
+    grep -q "^CADDY_HTTP_PORT=8080" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_port set https: updates CADDY_HTTPS_PORT" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_port set https 9443
+    grep -q "^CADDY_HTTPS_PORT=9443" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_port set ssh: updates SSH_PORT" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    dc() { return 0; }
+
+    cmd_port set ssh 2222
+    grep -q "^SSH_PORT=2222" "$tmp_home/.env"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_port set: unknown type returns 1" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_port set ftp 21
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_port: shows current ports when no args" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_port
+    [[ "$output" == *"Port Configuration"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_port: shows usage when set called with missing args" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_port set
+    [[ "$output" == *"Port Configuration"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_backup
+# ---------------------------------------------------------------------------
+
+@test "cmd_backup: creates backup directory and backs up .env" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    docker() {
+        if [[ "$*" == *"exec"* ]]; then return 1; fi
+    }
+
+    cmd_backup
+    # env.bak is inside the timestamped subdirectory
+    find "$tmp_home/backups" -name "env.bak" | grep -q "env.bak"
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_backup: creates backup dir with timestamp prefix" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    docker() { return 1; }
+
+    cmd_backup
+    [ -d "$tmp_home/backups" ]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_info
+# ---------------------------------------------------------------------------
+
+@test "cmd_info: shows version and home" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { echo "dc $*"; }
+    run cmd_info
+    [[ "$output" == *"Nixopus"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_admin_bootstrap
+# ---------------------------------------------------------------------------
+
+@test "cmd_admin_bootstrap: fails when ADMIN_EMAIL missing" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    # Remove ADMIN_EMAIL from env
+    sed -i.bak 's/^ADMIN_EMAIL=.*/ADMIN_EMAIL=/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: fails when ADMIN_PASSWORD missing" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    sed -i.bak 's/^ADMIN_PASSWORD=.*/ADMIN_PASSWORD=/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: fails when ALLOWED_ORIGIN missing" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    sed -i.bak 's/^ALLOWED_ORIGIN=.*/ALLOWED_ORIGIN=/' "$tmp_home/.env"
+    sed -i.bak 's/^AUTH_PUBLIC_URL=.*/AUTH_PUBLIC_URL=/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: succeeds on HTTP 200" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"status":"ok"}' > "$outfile"
+        echo "200"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"created"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: succeeds when user already exists" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"USER_ALREADY_EXISTS"}' > "$outfile"
+        echo "422"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already exists"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: accepts email and password from CLI args" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    # Clear env values; pass via args
+    sed -i.bak 's/^ADMIN_EMAIL=.*/ADMIN_EMAIL=/' "$tmp_home/.env"
+    sed -i.bak 's/^ADMIN_PASSWORD=.*/ADMIN_PASSWORD=/' "$tmp_home/.env"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"status":"ok"}' > "$outfile"
+        echo "200"
+    }
+
+    run cmd_admin_bootstrap "cli@test.com" "Abc1!Pass1234"
+    [ "$status" -eq 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles EMAIL_PASSWORD_SIGN_UP_DISABLED gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"EMAIL_PASSWORD_SIGN_UP_DISABLED"}' > "$outfile"
+        echo "400"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles INVALID_ORIGIN gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"INVALID_ORIGIN"}' > "$outfile"
+        echo "403"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles MISSING_OR_NULL_ORIGIN gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"MISSING_OR_NULL_ORIGIN"}' > "$outfile"
+        echo "403"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles CROSS_SITE_NAVIGATION_LOGIN_BLOCKED gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"CROSS_SITE_NAVIGATION_LOGIN_BLOCKED"}' > "$outfile"
+        echo "403"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles PASSWORD_TOO_SHORT gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"PASSWORD_TOO_SHORT"}' > "$outfile"
+        echo "400"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles PASSWORD_TOO_LONG gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"PASSWORD_TOO_LONG"}' > "$outfile"
+        echo "400"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles INVALID_PASSWORD gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"INVALID_PASSWORD"}' > "$outfile"
+        echo "400"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: handles INVALID_EMAIL gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=9
+
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{"code":"INVALID_EMAIL"}' > "$outfile"
+        echo "400"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_admin_bootstrap: warns after timeout on repeated failure" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+    ADMIN_BOOTSTRAP_TIMEOUT=3
+
+    sleep() { : ; }
+    curl() {
+        local outfile=""
+        local args=("$@")
+        for i in "${!args[@]}"; do
+            [[ "${args[$i]}" == "-o" ]] && outfile="${args[$((i+1))]}"
+        done
+        [ -n "$outfile" ] && echo '{}' > "$outfile"
+        echo "503"
+    }
+
+    run cmd_admin_bootstrap
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed"* ]] || [[ "$output" == *"failed"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# redact_install_log_lines (nixopus.sh copy)
+# ---------------------------------------------------------------------------
+
+@test "redact_install_log_lines (nixopus.sh): redacts secrets" {
+    load_nixopus
+    result=$(echo "JWT_SECRET=mysecret" | redact_install_log_lines)
+    [[ "$result" == *"<redacted>"* ]]
+    [[ "$result" != *"mysecret"* ]]
+}
+
+@test "redact_install_log_lines (nixopus.sh): strips ANSI codes" {
+    load_nixopus
+    result=$(printf '\033[1;32mhello\033[0m' | redact_install_log_lines)
+    [ "$result" = "hello" ]
+}
+
+@test "redact_install_log_lines (nixopus.sh): preserves non-secret lines" {
+    load_nixopus
+    result=$(echo "NIXOPUS_VERSION=0.3.0" | redact_install_log_lines)
+    [ "$result" = "NIXOPUS_VERSION=0.3.0" ]
+}
+
+# ---------------------------------------------------------------------------
+# cmd_report
+# ---------------------------------------------------------------------------
+
+@test "cmd_report: includes version and home in output" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { return 0; }
+    docker() { return 0; }
+
+    run cmd_report
+    [[ "$output" == *"support report"* ]]
+    [[ "$output" == *"Version"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_report: includes install.log content when present" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    echo "install log line" > "$tmp_home/install.log"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { return 0; }
+    docker() { return 0; }
+
+    run cmd_report
+    [[ "$output" == *"Installer log"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_report: handles missing install.log gracefully" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    # no install.log
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { return 0; }
+    docker() { return 0; }
+
+    run cmd_report
+    [[ "$output" != *"install log line"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "cmd_report: redacts secrets in .env output" {
+    load_nixopus
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    NIXOPUS_HOME="$tmp_home"
+
+    dc() { return 0; }
+    docker() { return 0; }
+
+    run cmd_report
+    [[ "$output" != *"dbpass1234567890"* ]]
+    [[ "$output" == *"<redacted>"* ]]
+    rm -rf "$tmp_home"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_help
+# ---------------------------------------------------------------------------
+
+@test "cmd_help: shows all available commands" {
+    load_nixopus
+    run cmd_help
+    [[ "$output" == *"status"* ]]
+    [[ "$output" == *"update"* ]]
+    [[ "$output" == *"domain"* ]]
+    [[ "$output" == *"admin-bootstrap"* ]]
+    [[ "$output" == *"report"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatch (case block)
+# ---------------------------------------------------------------------------
+
+run_dispatch() {
+    local tmp_home="$1"; shift
+    # Write patched script (guards removed) to a temp file so we can source it cleanly
+    local tmp
+    tmp=$(mktemp)
+    awk '
+        index($0, "(id -u)") { in_root=1 }
+        in_root && /^fi$/ { in_root=0; next }
+        in_root { next }
+        index($0, "[ ! -f \"$NIXOPUS_HOME") { in_env=1 }
+        in_env && /^fi$/ { in_env=0; next }
+        in_env { next }
+        index($0, "case \"${1:-help}\"") { in_case=1 }
+        !in_case { print }
+    ' "$NIXOPUS_SH" > "$tmp"
+    # Pass -- as $0 so $1 is the first real arg (the command name)
+    env NIXOPUS_HOME="$tmp_home" bash -c "
+        source \"$tmp\"
+        NIXOPUS_HOME=\"$tmp_home\"
+        dc() { echo \"DC: \$*\"; }
+        docker() { return 1; }
+        sync_view_llm_env() { return 0; }
+        case \"\${1:-help}\" in
+            status)    cmd_status ;;
+            logs)      shift; cmd_logs \"\${1:-}\" ;;
+            update)    cmd_update ;;
+            restart)   shift; cmd_restart \"\${1:-}\" ;;
+            stop)      cmd_stop ;;
+            uninstall) shift; cmd_uninstall \"\${1:-}\" ;;
+            config)    shift; cmd_config \"\$@\" ;;
+            domain)    shift; cmd_domain \"\$@\" ;;
+            ip)        shift; cmd_ip \"\$@\" ;;
+            port)      shift; cmd_port \"\$@\" ;;
+            backup)    cmd_backup ;;
+            info)      cmd_info ;;
+            admin-bootstrap) shift; cmd_admin_bootstrap \"\$@\" ;;
+            report)    cmd_report ;;
+            help|--help|-h) cmd_help ;;
+            *)         echo \"Unknown command: \$1\"; cmd_help; exit 1 ;;
+        esac
+    " -- "$@"
+    local rc=$?
+    rm -f "$tmp"
+    return $rc
+}
+
+@test "dispatch: status" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" status
+    [[ "$output" == *"DC:"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: logs" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" logs
+    [[ "$output" == *"DC:"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: update" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" update
+    [[ "$output" == *"DC:"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: restart" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" restart
+    [[ "$output" == *"DC:"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: stop" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" stop
+    [[ "$output" == *"DC:"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: help" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" help
+    [[ "$output" == *"Commands"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: --help" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" --help
+    [[ "$output" == *"Commands"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: -h" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" -h
+    [[ "$output" == *"Commands"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: no args defaults to help" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home"
+    [[ "$output" == *"Commands"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: unknown command exits 1" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" notacommand
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown command"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: info" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" info
+    [[ "$output" == *"Nixopus"* ]]
+    rm -rf "$tmp_home"
+}
+
+@test "dispatch: report" {
+    local tmp_home
+    tmp_home=$(mktemp -d)
+    make_env "$tmp_home"
+    run run_dispatch "$tmp_home" report
+    [[ "$output" == *"report"* ]]
+    rm -rf "$tmp_home"
+}


### PR DESCRIPTION
## Summary

- Add 206 bats unit tests achieving 100% statement coverage for the selfhosting installer scripts (`get.sh` and `nixopus.sh`)
- Tests run fully offline without Docker, root privileges, or a live system
- Add `installer/test/run-unit-tests.sh` runner that auto-installs bats if needed

## What's covered

### `get.sh` (121 tests)
- Argument parsing (`--preview`, `--branch`, `--fork`)
- OS and IP detection
- Secret and password generation
- JSON escaping
- Environment file writing (`.env`, `view-llm.env`)
- SSH key setup
- Caddyfile generation
- `docker-compose` file copying (with/without agent)
- Service startup and admin bootstrapping

### `nixopus.sh` (85 tests)
- All CLI commands: `status`, `logs`, `update`, `restart`, `stop`, `uninstall`, `config`, `domain`, `ip`, `port`, `backup`, `info`, `admin-bootstrap`, `report`, `help`
- Env loading and sync helpers
- Install log redaction (secrets + ANSI codes)
- Full main dispatch case block

## Test plan

- [x] All 206 tests pass locally: `bats installer/test/unit/`
- [x] Tests are isolated — each uses `mktemp` temp dirs, no shared state
- [x] macOS and Linux compatible (macOS-specific `grep`/`awk` quirks handled)