### PR TITLE
fix(installer): .env-safe ADMIN_PASSWORD + mock agent /agent/healthz

### DIFF
--- a/installer/get.sh
+++ b/installer/get.sh
@@ -336,14 +336,15 @@ gen_secret() { openssl rand -hex 32; }
 # validation rules (>=8 chars, 1 upper, 1 lower, 1 digit, 1 special).
 # Special set is restricted to characters that are JSON- and shell-safe so
 # the resulting value can be embedded in .env and curl payloads without
-# escaping headaches.
+# escaping headaches.  Exclude & ; | etc. — unquoted .env lines must remain
+# valid when sourced by nixopus.sh under set -u (see load_env).
 gen_password() {
     local upper lower digit special rest combined
     upper=$(LC_ALL=C tr -dc 'A-Z'             </dev/urandom 2>/dev/null | head -c 1)
     lower=$(LC_ALL=C tr -dc 'a-z'             </dev/urandom 2>/dev/null | head -c 1)
     digit=$(LC_ALL=C tr -dc '0-9'             </dev/urandom 2>/dev/null | head -c 1)
-    special=$(LC_ALL=C tr -dc '!@#%^&*'       </dev/urandom 2>/dev/null | head -c 1)
-    rest=$(LC_ALL=C tr -dc 'A-Za-z0-9!@#%^&*' </dev/urandom 2>/dev/null | head -c 12)
+    special=$(LC_ALL=C tr -dc '!@#%^*'       </dev/urandom 2>/dev/null | head -c 1)
+    rest=$(LC_ALL=C tr -dc 'A-Za-z0-9!@#%^*' </dev/urandom 2>/dev/null | head -c 12)
     combined="${upper}${lower}${digit}${special}${rest}"
     echo "$combined" | fold -w1 | shuf | tr -d '\n'
 }

--- a/installer/test/mocks/agent/Caddyfile
+++ b/installer/test/mocks/agent/Caddyfile
@@ -1,4 +1,6 @@
 :4090 {
+    # External Caddy proxies /agent/* preserving the path segment.
+    respond /agent/healthz `{"status":"ok"}` 200
     respond /healthz `{"status":"ok"}` 200
     respond /readyz `{"status":"ready","checks":{"database":{"ok":true}}}` 200
     respond * `{"mock":"nixopus-agent"}` 200

--- a/installer/test/unit/get_sh.bats
+++ b/installer/test/unit/get_sh.bats
@@ -253,7 +253,7 @@ load_fn() {
 @test "gen_password: contains special character" {
     load_fn
     pw=$(gen_password)
-    [[ "$pw" =~ [!@#%^\&*] ]]
+    [[ "$pw" =~ [@#%!^*] ]]
 }
 
 @test "gen_password: two calls produce different passwords" {


### PR DESCRIPTION
## CI (run 25415807422 after #1324)

- **Unit-test job**: green.
- **Docker matrix**: 29/33 verification checks pass; 4 fail:
  - **Agent health** — Caddy calls `/agent/healthz`; mock agent only had `/healthz`.
  - **nixopus status / info / config** — auto-generated `ADMIN_PASSWORD` contained **`&`**. Unquoted `.env` line `ADMIN_PASSWORD=ymt&wHlMk2eZWTnL` is parsed as background job when sourced, so `load_env`/`set -e` breaks the CLI.

## Fixes

1. **`gen_password`**: drop `&` from the allowed special/rest charset (still satisfies Better Auth “special character” requirement).
2. **Mock agent Caddyfile**: `respond /agent/healthz` (keep `/healthz` for direct checks).
3. **Bats**: special-character assertion uses `[@#%!^*]` — avoids `[!…]` regex-class ambiguity.

## Verification

206 bats tests pass locally.