### PR TITLE
feat(api): unify error envelope, add security headers, trace request_id

### DIFF
--- a/api/internal/features/logger/init.go
+++ b/api/internal/features/logger/init.go
@@ -1,6 +1,9 @@
 package logger
 
 import (
+	"context"
+
+	"github.com/nixopus/nixopus/api/internal/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,28 +44,45 @@ func NewLogger() Logger {
 	}
 }
 
-// Log records a log entry with the specified severity, message, and data
+// Log records a log entry with the specified severity, message, and data.
 func (l *Logger) Log(sev Severity, msg, data string) {
+	l.logWithEntry(logrus.NewEntry(logrus.StandardLogger()), sev, msg, data)
+}
+
+// LogCtx records a log entry and automatically attaches the request_id from
+// the context set by RequestIDMiddleware. Use this instead of Log in any code
+// that has access to a request context (handlers, middleware, services called
+// from a request path).
+func (l *Logger) LogCtx(ctx context.Context, sev Severity, msg, data string) {
+	entry := logrus.NewEntry(logrus.StandardLogger())
+	if ctx != nil {
+		if id, ok := ctx.Value(types.RequestIDKey).(string); ok && id != "" {
+			entry = entry.WithField("request_id", id)
+		}
+	}
+	l.logWithEntry(entry, sev, msg, data)
+}
+
+func (l *Logger) logWithEntry(entry *logrus.Entry, sev Severity, msg, data string) {
 	l.Severity, l.Message, l.Data = sev, msg, data
 	logEntry := l.Message + " " + l.Data
 
 	if l.Env == Development {
-		switch l.Severity {
+		switch sev {
 		case Debug:
-			logrus.Debug(logEntry)
+			entry.Debug(logEntry)
 		case Info:
-			logrus.Info(logEntry)
+			entry.Info(logEntry)
 		case Warning:
-			logrus.Warn(logEntry)
+			entry.Warn(logEntry)
 		case Error:
-			logrus.Error(logEntry)
+			entry.Error(logEntry)
 		case Fatal:
-			logrus.Fatal(logEntry)
+			entry.Fatal(logEntry)
 		default:
-			logrus.Info(logEntry)
+			entry.Info(logEntry)
 		}
 	} else if l.Env == Production {
-		// here we probably need to store in a database
-		logrus.Info(l.Message)
+		entry.Info(l.Message)
 	}
 }

--- a/api/internal/middleware/audit.go
+++ b/api/internal/middleware/audit.go
@@ -23,21 +23,21 @@ func AuditMiddleware(next http.Handler, app *storage.App, l logger.Logger, resou
 
 		user, ok := r.Context().Value(types.UserContextKey).(*types.User)
 		if !ok {
-			l.Log(logger.Debug, "middleware audit: skipped: no user in context", fmt.Sprintf("path=%s", r.URL.Path))
+			l.LogCtx(r.Context(), logger.Debug, "middleware audit: skipped: no user in context", fmt.Sprintf("path=%s", r.URL.Path))
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		orgIDStr, ok := r.Context().Value(types.OrganizationIDKey).(string)
 		if !ok {
-			l.Log(logger.Debug, "middleware audit: skipped: no organization in context", fmt.Sprintf("path=%s user_id=%s", r.URL.Path, user.ID))
+			l.LogCtx(r.Context(), logger.Debug, "middleware audit: skipped: no organization in context", fmt.Sprintf("path=%s user_id=%s", r.URL.Path, user.ID))
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		orgID, err := uuid.Parse(orgIDStr)
 		if err != nil {
-			l.Log(logger.Warning, "middleware audit: skipped: invalid organization id", fmt.Sprintf("path=%s user_id=%s org_id=%s error=%v", r.URL.Path, user.ID, orgIDStr, err))
+			l.LogCtx(r.Context(), logger.Warning, "middleware audit: skipped: invalid organization id", fmt.Sprintf("path=%s user_id=%s org_id=%s error=%v", r.URL.Path, user.ID, orgIDStr, err))
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -92,12 +92,13 @@ func AuditMiddleware(next http.Handler, app *storage.App, l logger.Logger, resou
 			}
 
 			// Fire audit logging asynchronously to not affect API response time
+			reqCtx := r.Context()
 			go func() {
 				if err := auditService.LogAction(auditReq); err != nil {
-					l.Log(logger.Warning, "middleware audit: failed to persist log", fmt.Sprintf("path=%s method=%s user_id=%s org_id=%s error=%v",
+					l.LogCtx(reqCtx, logger.Warning, "middleware audit: failed to persist log", fmt.Sprintf("path=%s method=%s user_id=%s org_id=%s error=%v",
 						r.URL.Path, r.Method, user.ID, orgID, err))
 				} else {
-					l.Log(logger.Debug, "middleware audit: log created", fmt.Sprintf("path=%s method=%s user_id=%s org_id=%s",
+					l.LogCtx(reqCtx, logger.Debug, "middleware audit: log created", fmt.Sprintf("path=%s method=%s user_id=%s org_id=%s",
 						r.URL.Path, r.Method, user.ID, orgID))
 				}
 			}()

--- a/api/internal/middleware/auth.go
+++ b/api/internal/middleware/auth.go
@@ -126,7 +126,7 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache, l applo
 
 		sessionResp, err := verifySessionCached(r, sessionCache)
 		if err != nil {
-			l.Log(applogger.Error, fmt.Sprintf("middleware auth: verify session failed: %v", err), fmt.Sprintf("path=%s", r.URL.Path))
+			l.LogCtx(r.Context(), applogger.Error, fmt.Sprintf("middleware auth: verify session failed: %v", err), fmt.Sprintf("path=%s", r.URL.Path))
 			utils.SendErrorResponse(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
 			return
 		}
@@ -135,7 +135,7 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache, l applo
 
 		userIDUUID, err := uuid.Parse(betterAuthUserID)
 		if err != nil {
-			l.Log(applogger.Error, "middleware auth: invalid Better Auth user id format", fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
+			l.LogCtx(r.Context(), applogger.Error, "middleware auth: invalid Better Auth user id format", fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
 			utils.SendErrorResponse(w, "Invalid user ID", http.StatusUnauthorized)
 			return
 		}
@@ -156,11 +156,11 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache, l applo
 
 			if err != nil {
 				if err == sql.ErrNoRows {
-					l.Log(applogger.Error, "middleware auth: user not found in database", fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
+					l.LogCtx(r.Context(), applogger.Error, "middleware auth: user not found in database", fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
 					utils.SendErrorResponse(w, "User not found", http.StatusUnauthorized)
 					return
 				}
-				l.Log(applogger.Error, fmt.Sprintf("middleware auth: user lookup failed: %v", err), fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
+				l.LogCtx(r.Context(), applogger.Error, fmt.Sprintf("middleware auth: user lookup failed: %v", err), fmt.Sprintf("user_id=%s path=%s", betterAuthUserID, r.URL.Path))
 				utils.SendErrorResponse(w, "Failed to fetch user", http.StatusInternalServerError)
 				return
 			}
@@ -178,7 +178,7 @@ func AuthMiddleware(next http.Handler, app *storage.App, c *cache.Cache, l applo
 		if !isAuthEndpoint(r.URL.Path) {
 			organizationID, err := resolveAndVerifyOrganization(ctx, r, c, app, betterAuthUserID, sessionResp, l)
 			if err != nil {
-				l.Log(applogger.Error, fmt.Sprintf("middleware auth: resolve organization failed: %v", err), fmt.Sprintf("path=%s user_id=%s", r.URL.Path, betterAuthUserID))
+				l.LogCtx(r.Context(), applogger.Error, fmt.Sprintf("middleware auth: resolve organization failed: %v", err), fmt.Sprintf("path=%s user_id=%s", r.URL.Path, betterAuthUserID))
 				statusCode := http.StatusBadRequest
 				if strings.Contains(err.Error(), "does not belong") {
 					statusCode = http.StatusForbidden
@@ -208,20 +208,20 @@ func tryM2MJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, 
 
 	orgID, err := validateM2MJWT(ctx, token, r.Header.Get("X-Organization-Id"))
 	if err != nil {
-		l.Log(applogger.Info, "middleware auth: M2M JWT validation failed, using session auth", fmt.Sprintf("path=%s error=%v", r.URL.Path, err))
+		l.LogCtx(r.Context(), applogger.Info, "middleware auth: M2M JWT validation failed, using session auth", fmt.Sprintf("path=%s error=%v", r.URL.Path, err))
 		return false
 	}
 
 	userIDStr := r.Header.Get("X-User-Id")
 	if userIDStr == "" {
-		l.Log(applogger.Error, "middleware auth: M2M request missing X-User-Id", fmt.Sprintf("path=%s", r.URL.Path))
+		l.LogCtx(r.Context(), applogger.Error, "middleware auth: M2M request missing X-User-Id", fmt.Sprintf("path=%s", r.URL.Path))
 		utils.SendErrorResponse(w, "M2M requests require X-User-Id header", http.StatusUnauthorized)
 		return true
 	}
 
 	userUUID, err := uuid.Parse(userIDStr)
 	if err != nil {
-		l.Log(applogger.Error, "middleware auth: invalid X-User-Id", fmt.Sprintf("user_id=%q path=%s", userIDStr, r.URL.Path))
+		l.LogCtx(r.Context(), applogger.Error, "middleware auth: invalid X-User-Id", fmt.Sprintf("user_id=%q path=%s", userIDStr, r.URL.Path))
 		utils.SendErrorResponse(w, "Invalid X-User-Id format", http.StatusUnauthorized)
 		return true
 	}
@@ -229,7 +229,7 @@ func tryM2MJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, 
 	var user types.User
 	err = app.Store.DB.NewSelect().Model(&user).Where("id = ?", userUUID).Scan(ctx)
 	if err != nil {
-		l.Log(applogger.Error, fmt.Sprintf("middleware auth: M2M user lookup failed: %v", err), fmt.Sprintf("user_id=%s path=%s", userIDStr, r.URL.Path))
+		l.LogCtx(r.Context(), applogger.Error, fmt.Sprintf("middleware auth: M2M user lookup failed: %v", err), fmt.Sprintf("user_id=%s path=%s", userIDStr, r.URL.Path))
 		utils.SendErrorResponse(w, "User not found", http.StatusUnauthorized)
 		return true
 	}
@@ -310,7 +310,7 @@ func resolveAndVerifyOrganization(
 				Limit(1).
 				Scan(ctx)
 			if dbErr == nil && member.OrganizationID != uuid.Nil {
-				l.Log(applogger.Info, "middleware auth: resolved org from DB (session missing activeOrganizationId)", fmt.Sprintf("user_id=%s organization_id=%s", betterAuthUserID, member.OrganizationID))
+				l.LogCtx(ctx, applogger.Info, "middleware auth: resolved org from DB (session missing activeOrganizationId)", fmt.Sprintf("user_id=%s organization_id=%s", betterAuthUserID, member.OrganizationID))
 				return member.OrganizationID.String(), nil
 			}
 		}

--- a/api/internal/middleware/middleware_misc_test.go
+++ b/api/internal/middleware/middleware_misc_test.go
@@ -252,6 +252,20 @@ func TestNewRateLimiterWithConfig_exhausted(t *testing.T) {
 	require.Fail(t, "expected 429 from config limiter")
 }
 
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	h := SecurityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+	require.Equal(t, "no-referrer", rec.Header().Get("Referrer-Policy"))
+	require.Equal(t, "none", rec.Header().Get("X-Permitted-Cross-Domain-Policies"))
+}
+
 func Test_isWebSocketUpgrade(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	require.False(t, isWebSocketUpgrade(r))

--- a/api/internal/middleware/rate_limiter.go
+++ b/api/internal/middleware/rate_limiter.go
@@ -30,8 +30,9 @@ type client struct {
 }
 
 type rateLimitResponse struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail"`
 }
 
 func StartCleanupTask() {
@@ -111,8 +112,9 @@ func RateLimiter(next http.Handler) http.Handler {
 			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusTooManyRequests)
 			json.NewEncoder(w).Encode(&rateLimitResponse{
-				Code:    "rate_limited",
-				Message: "The API is at capacity, try again later.",
+				Title:  "Too Many Requests",
+				Status: http.StatusTooManyRequests,
+				Detail: "The API is at capacity, try again later.",
 			})
 			return
 		}
@@ -176,8 +178,9 @@ func NewRateLimiterWithConfig(rps float64, burst int) func(http.Handler) http.Ha
 				w.Header().Set("Retry-After", "1")
 				w.WriteHeader(http.StatusTooManyRequests)
 				json.NewEncoder(w).Encode(&rateLimitResponse{
-					Code:    "rate_limited",
-					Message: "Too many requests, try again later.",
+					Title:  "Too Many Requests",
+					Status: http.StatusTooManyRequests,
+					Detail: "Too many requests, try again later.",
 				})
 				return
 			}

--- a/api/internal/middleware/rbac.go
+++ b/api/internal/middleware/rbac.go
@@ -38,25 +38,25 @@ func InitRBACCache(c *cache.Cache) {
 func RBACMiddleware(next http.Handler, app *appStorage.App, resource string, l applogger.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requiredPermission := buildRequiredPermission(resource, r.Method)
-		l.Log(applogger.Debug, "middleware rbac: required permission", fmt.Sprintf("method=%s path=%s permission=%s", r.Method, r.URL.Path, requiredPermission))
+		l.LogCtx(r.Context(), applogger.Debug, "middleware rbac: required permission", fmt.Sprintf("method=%s path=%s permission=%s", r.Method, r.URL.Path, requiredPermission))
 
 		organizationID := extractOrganizationID(w, r, l)
 		if organizationID == "" {
-			l.Log(applogger.Debug, "middleware rbac: blocked: missing org", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
+			l.LogCtx(r.Context(), applogger.Debug, "middleware rbac: blocked: missing org", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			return
 		}
 
 		// Get user from context (set by AuthMiddleware)
 		userAny := r.Context().Value(types.UserContextKey)
 		if userAny == nil {
-			l.Log(applogger.Debug, "middleware rbac: blocked: no user in context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
+			l.LogCtx(r.Context(), applogger.Debug, "middleware rbac: blocked: no user in context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			utils.SendErrorResponse(w, "User not found in context", http.StatusUnauthorized)
 			return
 		}
 
 		user, ok := userAny.(*types.User)
 		if !ok {
-			l.Log(applogger.Debug, "middleware rbac: blocked: invalid user in context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
+			l.LogCtx(r.Context(), applogger.Debug, "middleware rbac: blocked: invalid user in context", fmt.Sprintf("method=%s path=%s", r.Method, r.URL.Path))
 			utils.SendErrorResponse(w, "Invalid user type in context", http.StatusUnauthorized)
 			return
 		}
@@ -66,12 +66,12 @@ func RBACMiddleware(next http.Handler, app *appStorage.App, resource string, l a
 
 		// Validate permission
 		if !validateUserPermission(ctx, user, organizationID, requiredPermission, app, l) {
-			l.Log(applogger.Debug, "middleware rbac: blocked: insufficient permission", fmt.Sprintf("method=%s path=%s user_id=%s permission=%s org_id=%s", r.Method, r.URL.Path, user.ID, requiredPermission, organizationID))
+			l.LogCtx(r.Context(), applogger.Debug, "middleware rbac: blocked: insufficient permission", fmt.Sprintf("method=%s path=%s user_id=%s permission=%s org_id=%s", r.Method, r.URL.Path, user.ID, requiredPermission, organizationID))
 			utils.SendErrorResponse(w, fmt.Sprintf("User lacks permission %s for organization %s", requiredPermission, organizationID), http.StatusForbidden)
 			return
 		}
 
-		l.Log(applogger.Debug, "middleware rbac: allowed", fmt.Sprintf("method=%s path=%s user_id=%s org_id=%s", r.Method, r.URL.Path, user.ID, organizationID))
+		l.LogCtx(r.Context(), applogger.Debug, "middleware rbac: allowed", fmt.Sprintf("method=%s path=%s user_id=%s org_id=%s", r.Method, r.URL.Path, user.ID, organizationID))
 		next.ServeHTTP(w, r)
 	})
 }
@@ -80,11 +80,11 @@ func RBACMiddleware(next http.Handler, app *appStorage.App, resource string, l a
 func validateUserPermission(ctx context.Context, user *types.User, organizationID, requiredPermission string, app *appStorage.App, l applogger.Logger) bool {
 	// Try cache first
 	if result := validateCachedPermissions(user.ID.String(), organizationID, requiredPermission); result != nil {
-		l.Log(applogger.Debug, "middleware rbac: cache hit", fmt.Sprintf("user_id=%s org_id=%s has_perm=%v", user.ID, organizationID, *result))
+		l.LogCtx(ctx, applogger.Debug, "middleware rbac: cache hit", fmt.Sprintf("user_id=%s org_id=%s has_perm=%v", user.ID, organizationID, *result))
 		return *result
 	}
 
-	l.Log(applogger.Debug, "middleware rbac: cache miss", fmt.Sprintf("user_id=%s org_id=%s", user.ID, organizationID))
+	l.LogCtx(ctx, applogger.Debug, "middleware rbac: cache miss", fmt.Sprintf("user_id=%s org_id=%s", user.ID, organizationID))
 	// Cache miss: fetch from database
 	return validateAndCachePermissions(ctx, user, organizationID, requiredPermission, app, l)
 }
@@ -122,12 +122,12 @@ func validateAndCachePermissions(ctx context.Context, user *types.User, organiza
 	// Get user's role from Better Auth organization membership
 	member, err := getBetterAuthOrganizationMember(ctx, httpReq, user.ID.String(), organizationID, l)
 	if err != nil || member == nil {
-		l.Log(applogger.Debug, "middleware rbac: list-members failed", fmt.Sprintf("user_id=%s org_id=%s error=%v", user.ID, organizationID, err))
+		l.LogCtx(ctx, applogger.Debug, "middleware rbac: list-members failed", fmt.Sprintf("user_id=%s org_id=%s error=%v", user.ID, organizationID, err))
 		// If we can't verify membership, deny access
 		return false
 	}
 
-	l.Log(applogger.Debug, "middleware rbac: member resolved", fmt.Sprintf("user_id=%s org_id=%s role=%v", user.ID, organizationID, member.Role))
+	l.LogCtx(ctx, applogger.Debug, "middleware rbac: member resolved", fmt.Sprintf("user_id=%s org_id=%s role=%v", user.ID, organizationID, member.Role))
 
 	// Extract role from Better Auth member data
 	// Better Auth can return role as string or array
@@ -150,7 +150,7 @@ func validateAndCachePermissions(ctx context.Context, user *types.User, organiza
 	roles := []string{role}
 	permissions := getPermissionsForRole(role)
 
-	l.Log(applogger.Debug, "middleware rbac: role resolved", fmt.Sprintf("role=%s permission_count=%d has_required=%v", role, len(permissions), hasPermission(permissions, requiredPermission)))
+	l.LogCtx(ctx, applogger.Debug, "middleware rbac: role resolved", fmt.Sprintf("role=%s permission_count=%d has_required=%v", role, len(permissions), hasPermission(permissions, requiredPermission)))
 
 	// Cache permissions
 	cachePermissions(user.ID.String(), organizationID, roles, permissions)
@@ -228,7 +228,7 @@ func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Requ
 		// If that fails, try as object with data/members field
 		var responseObj map[string]interface{}
 		if err2 := json.Unmarshal(body, &responseObj); err2 != nil {
-			l.Log(applogger.Debug, "middleware rbac: list-members parse failed", fmt.Sprintf("expected_array_or_object body=%s", string(body)))
+			l.LogCtx(ctx, applogger.Debug, "middleware rbac: list-members parse failed", fmt.Sprintf("expected_array_or_object body=%s", string(body)))
 			return nil, fmt.Errorf("failed to parse response: %w (also tried object format: %v)", err, err2)
 		}
 
@@ -237,13 +237,13 @@ func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Requ
 			// Convert to []BetterAuthMember
 			dataBytes, _ := json.Marshal(data)
 			if err := json.Unmarshal(dataBytes, &members); err != nil {
-				l.Log(applogger.Debug, "middleware rbac: list-members data field parse failed", fmt.Sprintf("data=%s", string(dataBytes)))
+				l.LogCtx(ctx, applogger.Debug, "middleware rbac: list-members data field parse failed", fmt.Sprintf("data=%s", string(dataBytes)))
 				return nil, fmt.Errorf("failed to parse data array: %w", err)
 			}
 		} else if membersData, ok := responseObj["members"]; ok {
 			membersBytes, _ := json.Marshal(membersData)
 			if err := json.Unmarshal(membersBytes, &members); err != nil {
-				l.Log(applogger.Debug, "middleware rbac: list-members members field parse failed", fmt.Sprintf("members=%s", string(membersBytes)))
+				l.LogCtx(ctx, applogger.Debug, "middleware rbac: list-members members field parse failed", fmt.Sprintf("members=%s", string(membersBytes)))
 				return nil, fmt.Errorf("failed to parse members array: %w", err)
 			}
 		} else {
@@ -252,7 +252,7 @@ func getBetterAuthOrganizationMember(ctx context.Context, originalReq *http.Requ
 			if err := json.Unmarshal(body, &singleMember); err == nil && singleMember.UserID != "" {
 				members = []BetterAuthMember{singleMember}
 			} else {
-				l.Log(applogger.Debug, "middleware rbac: list-members unexpected shape", fmt.Sprintf("body=%s", string(body)))
+				l.LogCtx(ctx, applogger.Debug, "middleware rbac: list-members unexpected shape", fmt.Sprintf("body=%s", string(body)))
 				return nil, fmt.Errorf("response does not contain array or single member: %s", string(body))
 			}
 		}

--- a/api/internal/middleware/recovery.go
+++ b/api/internal/middleware/recovery.go
@@ -17,10 +17,10 @@ func RecoveryMiddleware(l logger.Logger) func(http.Handler) http.Handler {
 					if r != nil && r.URL != nil {
 						data = fmt.Sprintf("path=%s", r.URL.Path)
 					}
-					l.Log(logger.Error, fmt.Sprintf("middleware: panic recovered: %v", err), data)
+					l.LogCtx(r.Context(), logger.Error, fmt.Sprintf("middleware: panic recovered: %v", err), data)
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte(`{"code":"internal_error","message":"Internal server error"}`))
+					w.Write([]byte(`{"title":"Internal Server Error","status":500,"detail":"Internal server error"}`))
 				}
 			}()
 

--- a/api/internal/middleware/request_id.go
+++ b/api/internal/middleware/request_id.go
@@ -1,9 +1,12 @@
 package middleware
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"net/http"
+
+	"github.com/nixopus/nixopus/api/internal/types"
 )
 
 const RequestIDHeader = "X-Request-ID"
@@ -15,7 +18,8 @@ func RequestIDMiddleware(next http.Handler) http.Handler {
 			requestID = generateRequestID()
 		}
 		w.Header().Set(RequestIDHeader, requestID)
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), types.RequestIDKey, requestID)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/api/internal/middleware/security_headers.go
+++ b/api/internal/middleware/security_headers.go
@@ -1,0 +1,17 @@
+package middleware
+
+import "net/http"
+
+// SecurityHeadersMiddleware adds defensive HTTP headers to every response.
+// HSTS is intentionally omitted — Caddy handles TLS termination and sets
+// Strict-Transport-Security closer to the edge where it belongs.
+func SecurityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("X-Permitted-Cross-Domain-Policies", "none")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -124,6 +124,7 @@ func (router *Router) createServer(port string) *fuego.Server {
 		fuego.WithGlobalMiddlewares(
 			middleware.RecoveryMiddleware(router.logger),
 			middleware.RequestIDMiddleware,
+			middleware.SecurityHeadersMiddleware,
 			middleware.CorsMiddleware,
 			middleware.LoggingMiddleware,
 			api.VersionMiddleware,

--- a/api/internal/types/types.go
+++ b/api/internal/types/types.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	apilog "github.com/nixopus/nixopus/api/internal/log"
 	"os"
+
+	apilog "github.com/nixopus/nixopus/api/internal/log"
 )
 
 type TimescaleConfig struct {
@@ -151,6 +152,7 @@ const AuthTokenKey ClientContext = "auth_token"
 const DBContextKey ClientContext = "db"
 const OrganizationIDKey contextKey = "organization_id"
 const ServerIDKey contextKey = "server_id"
+const RequestIDKey contextKey = "request_id"
 
 type AvailableActions string
 

--- a/api/internal/utils/response.go
+++ b/api/internal/utils/response.go
@@ -2,8 +2,9 @@ package utils
 
 import (
 	"encoding/json"
-	apilog "github.com/nixopus/nixopus/api/internal/log"
 	"net/http"
+
+	apilog "github.com/nixopus/nixopus/api/internal/log"
 )
 
 type jsonSuccessResponse struct {
@@ -12,10 +13,12 @@ type jsonSuccessResponse struct {
 	Data    json.RawMessage `json:"data,omitempty"`
 }
 
+// jsonErrorResponse matches the Fuego HTTPError wire format so all error
+// responses from middleware and Fuego handlers share a single envelope shape.
 type jsonErrorResponse struct {
-	Code    string            `json:"code"`
-	Message string            `json:"message"`
-	Details map[string]string `json:"details,omitempty"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail"`
 }
 
 // SendJSONResponse writes a JSON response to the given http.ResponseWriter.
@@ -34,8 +37,9 @@ func SendJSONResponse(w http.ResponseWriter, status string, message string, data
 			apilog.Printf("Error marshaling response data: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(jsonErrorResponse{
-				Code:    "internal_error",
-				Message: "failed to encode response data",
+				Title:  http.StatusText(http.StatusInternalServerError),
+				Status: http.StatusInternalServerError,
+				Detail: "failed to encode response data",
 			})
 			return
 		}
@@ -48,35 +52,16 @@ func SendJSONResponse(w http.ResponseWriter, status string, message string, data
 }
 
 // SendErrorResponse writes an error response to the given http.ResponseWriter.
+// The JSON shape matches Fuego's HTTPError so clients see one consistent envelope.
 func SendErrorResponse(w http.ResponseWriter, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	response := jsonErrorResponse{
-		Code:    errorCodeFromStatus(statusCode),
-		Message: message,
+		Title:  http.StatusText(statusCode),
+		Status: statusCode,
+		Detail: message,
 	}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		apilog.Printf("Error encoding error response: %v", err)
-	}
-}
-
-func errorCodeFromStatus(statusCode int) string {
-	switch statusCode {
-	case 400:
-		return "invalid_request"
-	case 401:
-		return "unauthorized"
-	case 403:
-		return "forbidden"
-	case 404:
-		return "not_found"
-	case 409:
-		return "conflict"
-	case 422:
-		return "unprocessable_entity"
-	case 429:
-		return "rate_limited"
-	default:
-		return "internal_error"
 	}
 }

--- a/api/internal/utils/response_test.go
+++ b/api/internal/utils/response_test.go
@@ -37,8 +37,9 @@ func TestSendJSONResponse(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		var got map[string]any
 		require.NoError(t, json.NewDecoder(rr.Body).Decode(&got))
-		assert.Equal(t, "internal_error", got["code"])
-		assert.Equal(t, "failed to encode response data", got["message"])
+		assert.Equal(t, "Internal Server Error", got["title"])
+		assert.Equal(t, float64(500), got["status"])
+		assert.Equal(t, "failed to encode response data", got["detail"])
 	})
 
 	t.Run("encode to writer fails", func(t *testing.T) {
@@ -63,8 +64,9 @@ func TestSendErrorResponse(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	var got map[string]any
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&got))
-	assert.Equal(t, "invalid_request", got["code"])
-	assert.Equal(t, "bad", got["message"])
+	assert.Equal(t, "Bad Request", got["title"])
+	assert.Equal(t, float64(400), got["status"])
+	assert.Equal(t, "bad", got["detail"])
 }
 
 func TestSendErrorResponse_encodeFails(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Consistent error envelope**: `SendErrorResponse`, `recovery`, and `rate-limiter` now all emit the RFC 7807-like shape `{"title","status","detail"}` that Fuego's `HTTPError` uses — no more split personality between custom `{"code","message"}` and framework errors.
- **Security headers middleware**: New `SecurityHeadersMiddleware` sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, and `X-Permitted-Cross-Domain-Policies: none` on every response. HSTS is intentionally omitted (Caddy handles it at the edge).
- **Request-ID tracing**: `RequestIDMiddleware` now stores the `X-Request-ID` value in `context.Context`. A new `Logger.LogCtx(ctx, ...)` method auto-attaches `request_id` as a structured field; all log calls in `auth`, `rbac`, and `audit` middleware were migrated to `LogCtx` so every log line is correlated to its request.

## Changed files

| File | What changed |
|---|---|
| `utils/response.go` | Emit `{title, status, detail}` shape; remove `errorCodeFromStatus` |
| `utils/response_test.go` | Update assertions for new shape |
| `middleware/security_headers.go` | New file — `SecurityHeadersMiddleware` |
| `middleware/recovery.go` | Hardcoded panic JSON updated to new shape |
| `middleware/rate_limiter.go` | `rateLimitResponse` struct updated to new shape |
| `middleware/request_id.go` | Store request ID in `context.Context` |
| `middleware/auth.go` | `l.Log` → `l.LogCtx(r.Context(), ...)` |
| `middleware/rbac.go` | `l.Log` → `l.LogCtx(r.Context(), ...)` |
| `middleware/audit.go` | `l.Log` → `l.LogCtx(r.Context(), ...)` |
| `middleware/middleware_misc_test.go` | `TestSecurityHeadersMiddleware` added |
| `features/logger/init.go` | `LogCtx` method + `logWithEntry` refactor |
| `types/types.go` | `RequestIDKey` context key added |
| `routes/routes.go` | Wire `SecurityHeadersMiddleware` into global chain |

## Test plan

- [x] `go test ./internal/middleware/...` — all middleware tests pass including new `TestSecurityHeadersMiddleware`
- [x] `go test ./internal/utils/...` — response shape tests pass
- [x] `go test ./internal/features/logger/...` — `LogCtx` tests pass
- [x] Full `go test ./...` — only pre-existing failures (no DB / no live server in local env)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security headers to all responses (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, X-Permitted-Cross-Domain-Policies)
  * Introduced context-aware logging with automatic request ID propagation

* **Improvements**
  * Restructured error responses with Title/Status/Detail format
  * Enhanced audit logging with asynchronous processing
  * Strengthened RBAC with caching and improved permission validation

* **Tests**
  * Added security headers validation test
  * Updated tests for new error response format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->