### PR TITLE
feat(view): add route-level loading.tsx Suspense fallbacks

### DIFF
--- a/view/app/activities/loading.tsx
+++ b/view/app/activities/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/api-keys/loading.tsx
+++ b/view/app/api-keys/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/apps/loading.tsx
+++ b/view/app/apps/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/backups/loading.tsx
+++ b/view/app/backups/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/charts/loading.tsx
+++ b/view/app/charts/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/chats/loading.tsx
+++ b/view/app/chats/loading.tsx
@@ -1,0 +1,1 @@
+export { ChatSkeleton as default } from '@/components/ui/page-skeleton';

--- a/view/app/domains/loading.tsx
+++ b/view/app/domains/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/extensions/loading.tsx
+++ b/view/app/extensions/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/integrations/loading.tsx
+++ b/view/app/integrations/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/loading.tsx
+++ b/view/app/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/machines/[machineId]/apps/loading.tsx
+++ b/view/app/machines/[machineId]/apps/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/machines/[machineId]/backups/loading.tsx
+++ b/view/app/machines/[machineId]/backups/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/machines/[machineId]/charts/loading.tsx
+++ b/view/app/machines/[machineId]/charts/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/machines/loading.tsx
+++ b/view/app/machines/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/security/loading.tsx
+++ b/view/app/security/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/app/settings/loading.tsx
+++ b/view/app/settings/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/page-skeleton';

--- a/view/components/ui/page-skeleton.tsx
+++ b/view/components/ui/page-skeleton.tsx
@@ -1,0 +1,71 @@
+import { Skeleton } from '@nixopus/ui';
+
+export function ChatSkeleton() {
+  return (
+    <div className="flex h-full w-full overflow-hidden">
+      <div className="flex w-64 shrink-0 flex-col gap-3 border-r border-border p-4">
+        <Skeleton className="h-8 w-full rounded-md" />
+        <div className="flex flex-col gap-2 pt-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+              <Skeleton className="h-4 w-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col">
+        <div className="flex h-14 shrink-0 items-center gap-3 border-b border-border px-4">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex-1 space-y-4 overflow-auto p-6">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className={`flex gap-3 ${i % 2 === 0 ? '' : 'flex-row-reverse'}`}>
+              <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+              <Skeleton className={`h-16 rounded-2xl ${i % 2 === 0 ? 'w-2/3' : 'w-1/2'}`} />
+            </div>
+          ))}
+        </div>
+        <div className="flex h-16 shrink-0 items-center gap-2 border-t border-border px-4">
+          <Skeleton className="h-10 flex-1 rounded-md" />
+          <Skeleton className="h-10 w-10 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PageSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+      <div className="flex gap-2">
+        <Skeleton className="h-9 w-64 rounded-md" />
+        <Skeleton className="h-9 w-24 rounded-md" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-3 rounded-lg border border-border p-4">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-8 w-8 rounded-md" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <div className="flex gap-2 pt-1">
+              <Skeleton className="h-7 w-16 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/view/components/ui/page-skeleton.tsx
+++ b/view/components/ui/page-skeleton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Skeleton } from '@nixopus/ui';
 
 export function ChatSkeleton() {


### PR DESCRIPTION
## Summary

- Adds `components/ui/page-skeleton.tsx` — two reusable skeleton variants:
  - `PageSkeleton` (default): header + search bar + 8-card grid — matches all list/detail routes
  - `ChatSkeleton`: two-panel layout (thread list + message area) — matches `/chats`
- Adds `loading.tsx` to **16 routes** across `app/` and `app/machines/[machineId]/`
- Each `loading.tsx` is a single re-export line; updating the skeleton shape updates all routes at once

## Why

Without `loading.tsx`, Next.js shows a blank screen while route JS chunks download during first-visit navigation. These files are auto-wrapped in `<Suspense>` by the framework — no manual wiring needed.

## Routes covered

| Route | Skeleton |
|---|---|
| `/` (root fallback) | PageSkeleton |
| `/apps`, `/charts`, `/machines`, `/settings` | PageSkeleton |
| `/chats` | ChatSkeleton |
| `/extensions`, `/integrations`, `/activities` | PageSkeleton |
| `/backups`, `/domains`, `/api-keys`, `/security` | PageSkeleton |
| `/machines/[machineId]/apps` | PageSkeleton |
| `/machines/[machineId]/charts` | PageSkeleton |
| `/machines/[machineId]/backups` | PageSkeleton |

Auth routes (`/auth`, `/register`, `/verify-email`) intentionally skipped — public form pages with no async data loading.

## How to test

1. Open DevTools → Network → set throttling to **Slow 3G**
2. Hard-reload and navigate between routes — skeleton should flash briefly instead of a blank screen
3. On `/chats`, confirm the two-panel skeleton (thread list + message bubbles) appears
4. On all other routes, confirm the card-grid skeleton appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced skeleton loading animations throughout the application, providing visual feedback and improving perceived performance when users navigate between different sections and pages.

* **Refactor**
  * Consolidated loading state components across all application areas to maintain consistent visual design and enhance user experience during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->