### PR TITLE
feat(view): add HTTP security headers to next.config.ts

### DIFF
--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -4,9 +4,58 @@ import { fileURLToPath } from 'node:url';
 
 const nextConfigDir = path.dirname(fileURLToPath(import.meta.url));
 
+// Applied to every response served by Next.js (HTML pages, API routes, static assets).
+// Note: HSTS is intentionally omitted — Caddy handles TLS termination and sets
+// Strict-Transport-Security at the edge, matching the Go API middleware decision.
+const securityHeaders = [
+  // Prevents MIME-type sniffing; stops browsers from interpreting files as a
+  // different MIME type than declared by the server.
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  // Blocks the page from being embedded in <iframe>/<frame>/<object> on other
+  // origins, defending against clickjacking. CSP frame-ancestors also covers
+  // this for modern browsers; both co-exist for full browser compatibility.
+  { key: 'X-Frame-Options', value: 'DENY' },
+  // Controls how much referrer info is included with requests. Sends full URL
+  // to same-origin, only origin to cross-origin HTTPS — keeps analytics working
+  // while not leaking paths to third parties.
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  // Restricts browser feature APIs. Disabling camera/mic/geo/browsing-topics
+  // reduces attack surface; none of these are used by the Nixopus UI.
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()'
+  },
+  // Disable legacy XSS auditor. OWASP recommends '0' because '1; mode=block'
+  // can itself be exploited as an XSS vector in some browsers.
+  { key: 'X-XSS-Protection', value: '0' },
+  // Baseline CSP. unsafe-inline is required for Next.js hydration inline
+  // scripts; a nonce-based CSP to eliminate it is tracked separately.
+  // connect-src allows ws:/wss: for the terminal WebSocket and https: for
+  // the backend API + PostHog (hosts are runtime env vars, so wildcarded here).
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self'",
+      "connect-src 'self' ws: wss: https:",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'"
+    ].join('; ')
+  }
+];
+
 const nextConfig: NextConfig = {
   outputFileTracingRoot: nextConfigDir,
   output: 'standalone',
+  // Remove the X-Powered-By: Next.js response header to avoid fingerprinting.
+  poweredByHeader: false,
+  // Do not ship source maps to the browser in production. Source maps for error
+  // monitoring should be uploaded to a service like Sentry server-side instead.
+  productionBrowserSourceMaps: false,
   transpilePackages: [],
   basePath: process.env.BASE_PATH || '',
   assetPrefix: process.env.ASSET_PREFIX || undefined,
@@ -15,6 +64,15 @@ const nextConfig: NextConfig = {
   },
   images: {
     unoptimized: true
+  },
+  async headers() {
+    return [
+      {
+        // Apply to every route served by Next.js.
+        source: '/(.*)',
+        headers: securityHeaders
+      }
+    ];
   }
 };
 


### PR DESCRIPTION
## Summary

Single file change — `view/next.config.ts`. Adds two config flags and a `headers()` function that injects security headers on every Next.js response (HTML pages, API routes, static assets).

## Headers added

| Header | Value | Why |
|---|---|---|
| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing attacks |
| `X-Frame-Options` | `DENY` | Blocks clickjacking via iframes |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Sends origin only to cross-origin HTTPS; keeps analytics working without leaking full paths |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), browsing-topics=()` | Restricts unused browser feature APIs |
| `X-XSS-Protection` | `0` | Disables legacy XSS auditor (OWASP-recommended; `1; mode=block` can itself be an XSS vector) |
| `Content-Security-Policy` | See below | Baseline policy; `unsafe-inline` required for Next.js hydration scripts |
| `poweredByHeader: false` | — | Removes `X-Powered-By: Next.js` fingerprint header |
| `productionBrowserSourceMaps: false` | — | Prevents internal source code from being served to browsers |

## CSP policy

```
default-src 'self';
script-src 'self' 'unsafe-inline';
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob: https:;
font-src 'self';
connect-src 'self' ws: wss: https:;
frame-ancestors 'none';
base-uri 'self';
form-action 'self'
```

`unsafe-inline` on `script-src` is required because Next.js inlines hydration scripts into the HTML shell. Eliminating it requires a nonce-based CSP (generating a unique nonce per request in middleware and threading it through layout.tsx) — tracked as a follow-up.

`connect-src` uses `https:` and `ws:/wss:` rather than exact origins because `API_URL`, `WEBSOCKET_URL`, and `POSTHOG_HOST` are runtime environment variables and cannot be hardcoded at build time.

## What's intentionally omitted

- **HSTS** — Caddy handles TLS termination and sets `Strict-Transport-Security` at the edge. This matches the explicit comment in `api/internal/middleware/security_headers.go`.

## How to verify

```bash
curl -I http://localhost:3000 | grep -E "x-frame|x-content|referrer|permissions|content-security|x-powered"
```

All listed headers should appear; `X-Powered-By` should be absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application security by implementing comprehensive HTTP security headers across all routes, protecting against common web vulnerabilities and improving overall platform security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->