### PR TITLE
fix(csp): allow http: origins and Google Fonts

### DIFF
--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -37,10 +37,10 @@ const securityHeaders = [
     value: [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https:",
-      "font-src 'self'",
-      "connect-src 'self' ws: wss: https:",
+      "font-src 'self' https://fonts.gstatic.com",
+      "connect-src 'self' ws: wss: https: http:",
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'"


### PR DESCRIPTION
## Summary

- `connect-src`: added `http:` so deployments over plain HTTP (IP:port) work alongside `https:`
- `style-src`: added `https://fonts.googleapis.com` to unblock Google Fonts CSS
- `font-src`: added `https://fonts.gstatic.com` for the actual font binaries served by Google

## Test plan

- [ ] Verify no CSP errors in browser console when loading the app in dev (`http://localhost:*`)
- [ ] Verify Google Fonts (Roboto, JetBrains Mono) load correctly
- [ ] Verify API calls succeed when running against a plain-HTTP backend (IP:port)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security headers to better support loading resources from trusted external sources, including stylesheets and fonts
  * Expanded network connectivity permissions to include additional secure destinations for improved resource access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->