### PR TITLE
fix(csp): allow Cloudflare and PostHog scripts

### DIFF
--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -36,7 +36,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
+      "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://challenges.cloudflare.com https://eu-assets.i.posthog.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https:",
       "font-src 'self' https://fonts.gstatic.com",


### PR DESCRIPTION
## Summary

- `script-src`: add `https://static.cloudflareinsights.com` (Cloudflare Web Analytics beacon)
- `script-src`: add `https://challenges.cloudflare.com` (Cloudflare Turnstile CAPTCHA)
- `script-src`: add `https://eu-assets.i.posthog.com` (PostHog lazy-loaded scripts — session recorder, web vitals, dead-clicks, surveys)

## Test plan

- [ ] Verify no CSP errors in browser console on the auth page
- [ ] Verify Cloudflare Turnstile CAPTCHA widget loads correctly
- [ ] Verify PostHog session recording and analytics work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration to enable third-party service integrations for enhanced analytics and security monitoring. The allowlist of trusted external sources has been expanded to support advanced analytics tracking, real-time threat detection, comprehensive monitoring capabilities, and threat intelligence integration, providing improved visibility into application performance metrics and security events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->