### PR TITLE
fix(csp): add frame-src for Cloudflare Turnstile

### DIFF
--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -41,6 +41,7 @@ const securityHeaders = [
       "img-src 'self' data: blob: https:",
       "font-src 'self' https://fonts.gstatic.com",
       "connect-src 'self' ws: wss: https: http:",
+      'frame-src https://challenges.cloudflare.com',
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'"


### PR DESCRIPTION
## Summary

Cloudflare Turnstile renders its challenge inside an `<iframe>` loaded from `https://challenges.cloudflare.com`. Since `frame-src` was not explicitly set, `default-src 'self'` was used as a fallback and blocked the frame.

- `frame-src`: add `https://challenges.cloudflare.com`

## Test plan

- [ ] Verify Cloudflare Turnstile CAPTCHA widget renders on the auth page without CSP errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration to allow Cloudflare challenge content to be loaded within embedded frames on the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->