### PR TITLE
fix(csp): allow Turnstile worker-src and xr-spatial-tracking

### DIFF
--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -23,7 +23,8 @@ const securityHeaders = [
   // reduces attack surface; none of these are used by the Nixopus UI.
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()'
+    value:
+      'camera=(), microphone=(), geolocation=(), browsing-topics=(), xr-spatial-tracking=(self "https://challenges.cloudflare.com")'
   },
   // Disable legacy XSS auditor. OWASP recommends '0' because '1; mode=block'
   // can itself be exploited as an XSS vector in some browsers.
@@ -42,6 +43,7 @@ const securityHeaders = [
       "font-src 'self' https://fonts.gstatic.com",
       "connect-src 'self' ws: wss: https: http:",
       'frame-src https://challenges.cloudflare.com',
+      'worker-src blob: https://challenges.cloudflare.com',
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'"

--- a/view/next.config.ts
+++ b/view/next.config.ts
@@ -43,7 +43,7 @@ const securityHeaders = [
       "font-src 'self' https://fonts.gstatic.com",
       "connect-src 'self' ws: wss: https: http:",
       'frame-src https://challenges.cloudflare.com',
-      'worker-src blob: https://challenges.cloudflare.com',
+      "worker-src 'self' blob: https://challenges.cloudflare.com",
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'"


### PR DESCRIPTION
## Summary

Two remaining Cloudflare Turnstile CSP issues after the previous fixes:

- **`worker-src`**: Turnstile spawns a Web Worker from a `blob:https://challenges.cloudflare.com/...` URL. `worker-src` was not set, so it fell back to `script-src` which doesn't include `blob:` — blocking the worker entirely. Added `blob: https://challenges.cloudflare.com`.
- **`Permissions-Policy` / `xr-spatial-tracking`**: Turnstile's iframe probes available browser APIs including WebXR. Our policy was propagating into the iframe with no explicit `xr-spatial-tracking` allowance, causing repeated `[Violation]` logs. Added `xr-spatial-tracking=(self "https://challenges.cloudflare.com")`.

> **Note:** The `TrustedHTML` / `TrustedScript` / `TrustedScriptURL` errors and the `about:srcdoc` nonce violations seen in the console all originate *inside* Cloudflare's own iframe under Cloudflare's own CSP. They are not controllable from our `next.config.ts` and are a Cloudflare Turnstile internal issue.

## Test plan

- [ ] Verify Cloudflare Turnstile CAPTCHA completes successfully on the auth page
- [ ] Verify no `worker-src` CSP errors in the browser console
- [ ] Verify `xr-spatial-tracking` `[Violation]` logs are gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security headers to allow XR spatial tracking for the site itself and a specified trusted origin.
  * Updated Content Security Policy to explicitly permit web worker sources from the site, blob: protocol, and a specified trusted origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->