### PR TITLE
fix(view): always verify session on auth init

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,7 +18,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build
 
 FROM alpine:3.18
 ARG API_PORT
-RUN apk add --no-cache --no-scripts ca-certificates bash docker-cli
+RUN apk add --no-cache --no-scripts ca-certificates bash docker-cli git
 
 WORKDIR /app
 

--- a/api/internal/features/agent/controller/stream.go
+++ b/api/internal/features/agent/controller/stream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
@@ -39,6 +40,10 @@ func (c *AgentController) StreamChat(f fuego.ContextNoBody) (any, error) {
 	}
 
 	authToken := extractToken(r.Header.Get("Authorization"))
+
+	// Disable the server's WriteTimeout for this long-lived SSE connection.
+	rc := http.NewResponseController(w)
+	rc.SetWriteDeadline(time.Time{})
 
 	rw := unwrapFlusher(w)
 	rw.Header().Set("Content-Type", "text/event-stream")

--- a/api/internal/features/agent/controller/stream.go
+++ b/api/internal/features/agent/controller/stream.go
@@ -43,7 +43,10 @@ func (c *AgentController) StreamChat(f fuego.ContextNoBody) (any, error) {
 
 	// Disable the server's WriteTimeout for this long-lived SSE connection.
 	rc := http.NewResponseController(w)
-	rc.SetWriteDeadline(time.Time{})
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		c.logger.Log(logger.Error, "failed to disable SSE write deadline: "+err.Error(), "")
+		// Continue anyway; SSE may still work with timeouts.
+	}
 
 	rw := unwrapFlusher(w)
 	rw.Header().Set("Content-Type", "text/event-stream")

--- a/api/internal/features/agent/service/codebase/tools.go
+++ b/api/internal/features/agent/service/codebase/tools.go
@@ -352,7 +352,7 @@ func confidenceMessage(c codebase.Confidence) string {
 }
 
 func fetchDefaultConnectorID(ctx context.Context, client *http.Client, baseURL, authToken, orgID string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/github-connector", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/github-connector/all", nil)
 	if err != nil {
 		return "", err
 	}

--- a/api/internal/features/agent/service/codebase/tools_test.go
+++ b/api/internal/features/agent/service/codebase/tools_test.go
@@ -39,7 +39,7 @@ func TestAnalyzeRepositoryHandler_Success(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(connectorResponse)
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func TestAnalyzeRepositoryHandler_WithBranch(t *testing.T) {
 
 	var capturedBranch string
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "c1"}})
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {
@@ -108,7 +108,7 @@ func TestAnalyzeRepositoryHandler_MissingOwnerRepo(t *testing.T) {
 
 func TestAnalyzeRepositoryHandler_NoConnectors(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]interface{}{})
 	})
 
@@ -125,7 +125,7 @@ func TestAnalyzeRepositoryHandler_NoConnectors(t *testing.T) {
 
 func TestAnalyzeRepositoryHandler_TreeAPIError(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "c1"}})
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +154,7 @@ func TestAnalyzeRepositoryHandler_NoFiles(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "c1"}})
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {

--- a/view/redux/features/users/authSlice.ts
+++ b/view/redux/features/users/authSlice.ts
@@ -32,16 +32,10 @@ export const initializeAuth = createAsyncThunk<
   AuthPayload | null,
   { forceRefresh?: boolean } | void,
   { rejectValue: string }
->('auth/initialize', async (args, { dispatch, rejectWithValue, getState }) => {
-  const forceRefresh = args && typeof args === 'object' ? args.forceRefresh : false;
-  const state = getState() as { auth: AuthState };
-  if (!forceRefresh && state.auth.isInitialized && state.auth.isAuthenticated) {
-    return {
-      user: state.auth.user,
-      token: state.auth.token,
-      refreshToken: state.auth.refreshToken
-    };
-  }
+>('auth/initialize', async (_args, { dispatch, rejectWithValue }) => {
+  // Never trust persisted Redux as proof of session: always verify with Better Auth.
+  // Skipping getSession() caused stale isAuthenticated after localStorage rehydrate,
+  // e.g. /register redirecting to /chats until users cleared site data.
   try {
     const sessionResult = await authClient.getSession();
 
@@ -195,6 +189,13 @@ export const authSlice = createSlice({
         state.isLoading = false;
       })
       .addCase(initializeAuth.rejected, (state) => {
+        ensureTwoFactor(state);
+        state.user = null;
+        state.token = undefined;
+        state.refreshToken = undefined;
+        state.isAuthenticated = false;
+        state.twoFactor.isRequired = false;
+        state.twoFactor.tempToken = undefined;
         state.isInitialized = true;
         state.isLoading = false;
       })


### PR DESCRIPTION
## Summary
- Remove the `initializeAuth` short-circuit that trusted rehydrated Redux without calling `getSession()`, which left stale `isAuthenticated` and redirected users off `/register` (e.g. to `/chats`) until they cleared site data.
- On `initializeAuth` rejection, clear user, tokens, and auth flags instead of only setting `isInitialized` / `isLoading`.

## Test plan
- [ ] Fresh load with cleared storage: `/register` shows the form when admin is not registered.
- [ ] Logged-in session: still lands on app as before after `getSession()` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session verification and error handling to ensure more reliable sign-in state and consistent two-factor flag behavior.
  * Fixed long-lived chat streaming so connections remain stable during extended SSE streams.

* **Chores**
  * Updated runtime image to include git for improved build/runtime tooling.

* **Tests**
  * Updated connector discovery tests to match the new connector listing endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->