### PR TITLE
fix(agent): resolve deploy tool failures and SSE timeout

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,7 +18,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build
 
 FROM alpine:3.18
 ARG API_PORT
-RUN apk add --no-cache --no-scripts ca-certificates bash docker-cli
+RUN apk add --no-cache --no-scripts ca-certificates bash docker-cli git
 
 WORKDIR /app
 

--- a/api/internal/features/agent/controller/stream.go
+++ b/api/internal/features/agent/controller/stream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-fuego/fuego"
 	"github.com/google/uuid"
@@ -39,6 +40,10 @@ func (c *AgentController) StreamChat(f fuego.ContextNoBody) (any, error) {
 	}
 
 	authToken := extractToken(r.Header.Get("Authorization"))
+
+	// Disable the server's WriteTimeout for this long-lived SSE connection.
+	rc := http.NewResponseController(w)
+	rc.SetWriteDeadline(time.Time{})
 
 	rw := unwrapFlusher(w)
 	rw.Header().Set("Content-Type", "text/event-stream")

--- a/api/internal/features/agent/service/codebase/tools.go
+++ b/api/internal/features/agent/service/codebase/tools.go
@@ -352,7 +352,7 @@ func confidenceMessage(c codebase.Confidence) string {
 }
 
 func fetchDefaultConnectorID(ctx context.Context, client *http.Client, baseURL, authToken, orgID string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/github-connector", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/github-connector/all", nil)
 	if err != nil {
 		return "", err
 	}

--- a/api/internal/features/agent/service/codebase/tools_test.go
+++ b/api/internal/features/agent/service/codebase/tools_test.go
@@ -39,7 +39,7 @@ func TestAnalyzeRepositoryHandler_Success(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(connectorResponse)
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func TestAnalyzeRepositoryHandler_WithBranch(t *testing.T) {
 
 	var capturedBranch string
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "c1"}})
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {
@@ -108,7 +108,7 @@ func TestAnalyzeRepositoryHandler_MissingOwnerRepo(t *testing.T) {
 
 func TestAnalyzeRepositoryHandler_NoConnectors(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]interface{}{})
 	})
 
@@ -125,7 +125,7 @@ func TestAnalyzeRepositoryHandler_NoConnectors(t *testing.T) {
 
 func TestAnalyzeRepositoryHandler_TreeAPIError(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "c1"}})
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +154,7 @@ func TestAnalyzeRepositoryHandler_NoFiles(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/github-connector", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/github-connector/all", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "c1"}})
 	})
 	mux.HandleFunc("/api/v1/github-connector/repository/tree", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Fix analyze_repository tool returning 405 by correcting the connector list endpoint from /api/v1/github-connector to /api/v1/github-connector/all
- Fix load_remote_repository tool failing with git not found by adding git to the API runtime Docker image
- Fix SSE stream cutting off at 30s by disabling Fuego hardcoded WriteTimeout on the streaming endpoint via ResponseController

## Test plan

- [x] Existing unit tests updated and passing for connector URL fix
- [ ] Deploy agent on server, verify analyze_repository no longer returns 405
- [ ] Verify load_remote_repository can clone public repos inside the container
- [ ] Verify agent stream responses are no longer truncated at 30s