### PR TITLE
fix(installer): pass ADMIN_PASSWORD to auth container on first boot

### DIFF
--- a/installer/get.sh
+++ b/installer/get.sh
@@ -926,6 +926,15 @@ bootstrap_admin() {
                 fi
                 ;;
             400|403)
+                # 403 with "Registration is disabled" (no code field) means the
+                # self-hosted guard blocked sign-up because the auth service
+                # already seeded the admin account on startup. Treat as success.
+                if printf '%s' "$body" | grep -q '"Registration is disabled"'; then
+                    rm -f "$tmp"
+                    log_info "Admin account seeded by auth service — skipping HTTP bootstrap"
+                    ADMIN_BOOTSTRAPPED=true
+                    return 0
+                fi
                 case "$code" in
                     EMAIL_PASSWORD_SIGN_UP_DISABLED)
                         rm -f "$tmp"

--- a/installer/nixopus.sh
+++ b/installer/nixopus.sh
@@ -388,6 +388,13 @@ cmd_admin_bootstrap() {
                 fi
                 ;;
             400|403)
+                # "Registration is disabled" (no code) means the auth service
+                # seeded the admin on startup — the credential already exists.
+                if printf '%s' "$body" | grep -q '"Registration is disabled"'; then
+                    rm -f "$tmp"
+                    echo "Admin account seeded by auth service — nothing to do."
+                    return 0
+                fi
                 case "$code" in
                     EMAIL_PASSWORD_SIGN_UP_DISABLED|INVALID_ORIGIN|MISSING_OR_NULL_ORIGIN|CROSS_SITE_NAVIGATION_LOGIN_BLOCKED|PASSWORD_TOO_SHORT|PASSWORD_TOO_LONG|INVALID_PASSWORD|INVALID_EMAIL)
                         rm -f "$tmp"

--- a/installer/selfhost/docker-compose.yml
+++ b/installer/selfhost/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       AUTH_SECURE_COOKIES: "${AUTH_SECURE_COOKIES:-false}"
       SELF_HOSTED: "true"
       ADMIN_EMAIL: "${ADMIN_EMAIL:-}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD:-}"
       API_URL: "http://nixopus-api:8443"
       SECRET_MANAGER_ENABLED: "false"
       PASSWORD_LOGIN_ENABLED: "true"


### PR DESCRIPTION
## Summary

- The `nixopus-auth` container received `ADMIN_EMAIL` but not `ADMIN_PASSWORD`, so its startup seeder created a user record without an email/password credential in the `account` table
- The self-hosted guard then blocked every HTTP sign-up request (user already exists), causing the installer bootstrap to fail with `403 {"message":"Registration is disabled"}` — leaving the admin unable to sign in
- The bootstrap loops in `get.sh` and `nixopus.sh` didn't recognise this codeless 403 response, falling through to a 60-second retry + WARN instead of exiting cleanly

## Changes

- `installer/selfhost/docker-compose.yml` — add `ADMIN_PASSWORD: "${ADMIN_PASSWORD:-}"` to `nixopus-auth` environment so the seeder can create the credential on first boot
- `installer/get.sh` — detect `403 {"message":"Registration is disabled"}` as "admin already seeded by auth service" and treat it as success
- `installer/nixopus.sh` — same fix for `nixopus admin-bootstrap` CLI command

## Test plan

- [ ] Fresh install with `ADMIN_EMAIL` + `ADMIN_PASSWORD` set: auth service seeds user + credential, sign-in works immediately
- [ ] Re-run `nixopus admin-bootstrap` after seeding: exits cleanly with "Admin account seeded by auth service — nothing to do"
- [ ] Install without `ADMIN_EMAIL`: bootstrap is skipped as before (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced admin bootstrap process to gracefully handle scenarios where registration is disabled, improving installation reliability.
  * Added support for configuring the admin password via environment variable in Docker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->