### PR TITLE
fix(agent): persist tool calls and results across chat reload

### DIFF
--- a/api/internal/features/agent/service/chat.go
+++ b/api/internal/features/agent/service/chat.go
@@ -67,10 +67,8 @@ func (s *AgentService) Chat(ctx context.Context, req ChatRequest, authToken, use
 	latencyMs := int(time.Since(start).Milliseconds())
 
 	seq, _ := s.memory.GetMessageCount(ctx, threadID)
-	toStore := memory.MessagesFromLLM(threadID, []llm.Message{
-		{Role: llm.RoleUser, Content: req.Input},
-		{Role: llm.RoleAssistant, Content: result.Content},
-	}, seq)
+	newMessages := extractNewMessages(result.Messages, len(messages)+1, req.Input)
+	toStore := memory.MessagesFromLLM(threadID, newMessages, seq)
 	if err := s.memory.AppendMessages(ctx, threadID, toStore); err != nil {
 		s.logger.Log(logger.Error, "Failed to persist messages", err.Error())
 	}
@@ -157,10 +155,8 @@ func (s *AgentService) StreamChat(parentCtx context.Context, w http.ResponseWrit
 		bgCtx := context.Background()
 
 		seq, _ := s.memory.GetMessageCount(bgCtx, threadID)
-		toStore := memory.MessagesFromLLM(threadID, []llm.Message{
-			{Role: llm.RoleUser, Content: req.Input},
-			{Role: llm.RoleAssistant, Content: result.Content},
-		}, seq)
+		newMessages := extractNewMessages(result.Messages, len(messages)+1, req.Input)
+		toStore := memory.MessagesFromLLM(threadID, newMessages, seq)
 		_ = s.memory.AppendMessages(bgCtx, threadID, toStore)
 
 		latencyMs := int(time.Since(start).Milliseconds())
@@ -241,8 +237,9 @@ func storedToMessages(stored []memory.StoredMessage) []llm.Message {
 	messages := make([]llm.Message, 0, len(stored))
 	for _, m := range stored {
 		msg := llm.Message{
-			Role:    llm.Role(m.Role),
-			Content: m.Content,
+			Role:       llm.Role(m.Role),
+			Content:    m.Content,
+			ToolCallID: m.ToolCallID,
 		}
 		if len(m.ToolCalls) > 0 {
 			msg.ToolCalls = m.ToolCalls
@@ -250,6 +247,26 @@ func storedToMessages(stored []memory.StoredMessage) []llm.Message {
 		messages = append(messages, msg)
 	}
 	return messages
+}
+
+// extractNewMessages pulls out the new messages from a completed agent run.
+// buildMessages produces [system, ...history, user(augmented)], so everything
+// from index `offset` onward is new. The first new message is the user prompt
+// with the original (un-augmented) input text.
+func extractNewMessages(all []llm.Message, offset int, originalInput string) []llm.Message {
+	if offset >= len(all) {
+		return []llm.Message{
+			{Role: llm.RoleUser, Content: originalInput},
+		}
+	}
+
+	newMsgs := make([]llm.Message, 0, len(all)-offset+1)
+	newMsgs = append(newMsgs, llm.Message{Role: llm.RoleUser, Content: originalInput})
+
+	for _, m := range all[offset:] {
+		newMsgs = append(newMsgs, m)
+	}
+	return newMsgs
 }
 
 // buildContextPrefix assembles the preprocessed context blocks to prepend to user input.

--- a/view/packages/hooks/ai/use-agent-chat.ts
+++ b/view/packages/hooks/ai/use-agent-chat.ts
@@ -7,7 +7,8 @@ import {
   streamAgent,
   cancelStream,
   getThreadMessages,
-  type StreamChunk
+  type StreamChunk,
+  type RawThreadMessage
 } from '@/packages/lib/agent-client';
 import { type ChatContext, formatContextsForAgent } from './chat-context';
 import { v4 as uuid } from 'uuid';
@@ -116,6 +117,84 @@ export interface OmStatus {
   observationsText: string | null;
 }
 
+/**
+ * Merge raw DB rows back into ChatMessages with `parts`, matching what
+ * the streaming path produces.  A single agent turn in the DB may look like:
+ *   assistant (tool_calls) → tool → tool → assistant (tool_calls) → tool → assistant (final text)
+ * We collapse that whole sequence into one ChatMessage with interleaved parts.
+ */
+function rebuildChatMessages(rawMessages: RawThreadMessage[]): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  let i = 0;
+
+  while (i < rawMessages.length) {
+    const msg = rawMessages[i];
+
+    if (msg.role === 'user') {
+      result.push({
+        id: msg.id,
+        role: 'user',
+        content: msg.content || '',
+        timestamp: msg.created_at ? new Date(msg.created_at) : new Date()
+      });
+      i++;
+      continue;
+    }
+
+    if (msg.role === 'assistant') {
+      const parts: MessagePart[] = [];
+      let fullContent = '';
+      const firstId = msg.id;
+      const firstTs = msg.created_at;
+
+      while (i < rawMessages.length && rawMessages[i].role !== 'user') {
+        const cur = rawMessages[i];
+
+        if (cur.role === 'assistant') {
+          if (cur.content) {
+            parts.push({ type: 'text', content: cur.content });
+            fullContent += (fullContent ? '\n' : '') + cur.content;
+          }
+          for (const tc of cur.tool_calls ?? []) {
+            let args: unknown;
+            try {
+              args = tc.function.arguments ? JSON.parse(tc.function.arguments) : undefined;
+            } catch {
+              args = tc.function.arguments;
+            }
+            parts.push({
+              type: 'tool-call',
+              toolName: tc.function.name || 'tool',
+              toolCallId: tc.id,
+              args,
+              status: 'done' as const
+            });
+          }
+        }
+
+        i++;
+      }
+
+      if (!fullContent && parts.length === 0) continue;
+
+      const hasToolParts = parts.some((p) => p.type === 'tool-call');
+
+      result.push({
+        id: firstId,
+        role: 'assistant',
+        content: fullContent,
+        ...(hasToolParts ? { parts } : {}),
+        timestamp: firstTs ? new Date(firstTs) : new Date()
+      });
+      continue;
+    }
+
+    i++;
+  }
+
+  return result;
+}
+
 export function useAgentChat({
   threadId,
   resourceId,
@@ -179,20 +258,7 @@ export function useAgentChat({
         if (cancelled) return;
         if (chatStreamStore.hasActiveStream(threadId)) return;
 
-        const msgs: ChatMessage[] = [];
-        for (const msg of rawMessages) {
-          const role = msg.role === 'user' ? 'user' : msg.role === 'assistant' ? 'assistant' : null;
-          if (!role) continue;
-          const text = msg.content || '';
-          if (!text) continue;
-
-          msgs.push({
-            id: msg.id,
-            role,
-            content: text,
-            timestamp: msg.created_at ? new Date(msg.created_at) : new Date()
-          });
-        }
+        const msgs = rebuildChatMessages(rawMessages);
         chatStreamStore.setMessages(threadId, msgs);
       } catch {
         // thread may not exist on server yet

--- a/view/packages/lib/agent-client.ts
+++ b/view/packages/lib/agent-client.ts
@@ -182,20 +182,25 @@ export async function listThreads(headers: Record<string, string>): Promise<Agen
   return result.data ?? [];
 }
 
+export interface RawThreadMessage {
+  id: string;
+  thread_id: string;
+  role: string;
+  content: string;
+  tool_calls?: Array<{
+    id: string;
+    type: string;
+    function: { name: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+  created_at: string;
+  seq: number;
+}
+
 export async function getThreadMessages(
   threadId: string,
   headers: Record<string, string>
-): Promise<
-  Array<{
-    id: string;
-    thread_id: string;
-    role: string;
-    content: string;
-    tool_calls?: unknown[];
-    created_at: string;
-    seq: number;
-  }>
-> {
+): Promise<RawThreadMessage[]> {
   const response = await agentFetch(`/threads/${threadId}/messages`, {
     method: 'GET',
     headers


### PR DESCRIPTION
## Summary
- **Backend**: `OnDone` (both stream and non-stream) now saves the full message sequence (assistant tool_calls, tool results, intermediate steps) instead of collapsing to just user + final assistant text. Also sets `ToolCallID` on tool-role messages so server-side LLM replay is correct.
- **Frontend**: History loader (`use-agent-chat.ts`) reconstructs `parts` from stored `tool_calls` and merges multi-step assistant/tool sequences into single `ChatMessage` objects, matching what the streaming path produces. Added typed `RawThreadMessage` interface in `agent-client.ts`.

## Problem
Tool call indicators showed during a live chat session (via SSE events → `chatStreamStore` parts) but vanished after page refresh because:
1. The backend only persisted 2 rows per turn (user text + assistant text), discarding all intermediate tool_call and tool-result messages
2. The frontend history loader skipped `tool`-role rows entirely and never set `parts` on assistant messages

## Test plan
- [ ] Send a chat message that triggers tool calls (e.g. deploy intent)
- [ ] Verify tool call indicators appear during streaming
- [ ] Refresh the page and verify tool call indicators still appear in history
- [ ] Verify multi-step tool interactions (multiple tool calls in sequence) render correctly after reload
- [ ] Verify plain text-only conversations still load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent chat message persistence to accurately save conversation history.
  * Improved thread history reconstruction to properly handle assistant responses and tool interactions in conversations.

* **Refactor**
  * Strengthened internal message type definitions for improved data consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nixopus/nixopus/pull/1345)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->