### PR TITLE
fix(view): prevent wizard remount losing SSH key on machine create

### DIFF
--- a/view/packages/components/machines/machines-view.tsx
+++ b/view/packages/components/machines/machines-view.tsx
@@ -943,76 +943,75 @@ export function MachinesView({
     </>
   );
 
-  if (machines.length === 0) {
-    if (isProvisioning || isRetrying) {
-      return (
-        <div className={className}>
-          {headerContent}
-          <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
-            <ProvisioningMachineCard progress={provisioningProgress} />
-          </div>
+  const emptyContent = machines.length === 0 && (
+    <>
+      {isProvisioning || isRetrying ? (
+        <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+          <ProvisioningMachineCard progress={provisioningProgress} />
         </div>
-      );
-    }
-
-    return (
-      <div className={className}>
-        {headerContent}
-        <MachinesEmptyState
-          isProvisioning={false}
-          provisioningHasError={provisioningHasError}
-          onRetry={onRetryProvisioning}
-          canRetry={canRetry}
-          isRetrying={false}
-          retryCount={retryCount}
-          maxRetries={maxRetries}
-        />
-        {!provisioningHasError && (
-          <div className="flex justify-center mt-4">
-            <Button onClick={() => setIsWizardOpen(true)} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Add Machine
-            </Button>
-          </div>
-        )}
-        <AddMachineWizard open={isWizardOpen} onOpenChange={setIsWizardOpen} />
-      </div>
-    );
-  }
+      ) : (
+        <>
+          <MachinesEmptyState
+            isProvisioning={false}
+            provisioningHasError={provisioningHasError}
+            onRetry={onRetryProvisioning}
+            canRetry={canRetry}
+            isRetrying={false}
+            retryCount={retryCount}
+            maxRetries={maxRetries}
+          />
+          {!provisioningHasError && (
+            <div className="flex justify-center mt-4">
+              <Button onClick={() => setIsWizardOpen(true)} className="gap-2">
+                <Plus className="h-4 w-4" />
+                Add Machine
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
 
   return (
     <div className={className}>
       {headerContent}
-      {!showHeader && showSearch && (
-        <div className="mb-6">
-          <SearchBar
-            searchTerm={searchTerm}
-            handleSearchChange={handleSearchChange}
-            label={searchLabel}
-            isLoading={false}
-          />
-        </div>
-      )}
-
-      {viewMode === 'grid' ? (
-        <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
-          {paginatedMachines.map((machine) => (
-            <MachineCard key={machine.id} machine={machine} />
-          ))}
-          <AddMachineCard onClick={() => setIsWizardOpen(true)} />
-        </div>
+      {machines.length === 0 ? (
+        emptyContent
       ) : (
-        <MachinesTable machines={paginatedMachines} tableClassName={tableClassName} />
-      )}
+        <>
+          {!showHeader && showSearch && (
+            <div className="mb-6">
+              <SearchBar
+                searchTerm={searchTerm}
+                handleSearchChange={handleSearchChange}
+                label={searchLabel}
+                isLoading={false}
+              />
+            </div>
+          )}
 
-      {totalPages > 1 && (
-        <div className="mt-8 flex justify-center">
-          <PaginationWrapper
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
-          />
-        </div>
+          {viewMode === 'grid' ? (
+            <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+              {paginatedMachines.map((machine) => (
+                <MachineCard key={machine.id} machine={machine} />
+              ))}
+              <AddMachineCard onClick={() => setIsWizardOpen(true)} />
+            </div>
+          ) : (
+            <MachinesTable machines={paginatedMachines} tableClassName={tableClassName} />
+          )}
+
+          {totalPages > 1 && (
+            <div className="mt-8 flex justify-center">
+              <PaginationWrapper
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+              />
+            </div>
+          )}
+        </>
       )}
       <AddMachineWizard open={isWizardOpen} onOpenChange={setIsWizardOpen} />
     </div>

--- a/view/redux/services/servers/serversApi.ts
+++ b/view/redux/services/servers/serversApi.ts
@@ -45,8 +45,7 @@ export const machinesApi = createApi({
         url: SERVERURLS.CREATE_MACHINE,
         method: 'POST',
         body: data
-      }),
-      invalidatesTags: ['Server']
+      })
     }),
     verifyMachine: builder.mutation<MachineVerifyResponse, string>({
       query: (id) => ({


### PR DESCRIPTION
## Summary
- When adding a machine from an empty state (0 machines), `createMachine` invalidated the `Server` RTK tag, triggering a refetch that changed `machines.length` from 0→1. This caused `MachinesView` to switch conditional branches, unmounting and remounting `AddMachineWizard` — destroying the SSH public key state while the user was trying to copy it.
- Moved `AddMachineWizard` to a single render position outside the conditional branches so React preserves the component instance across list changes.
- Deferred `invalidatesTags` from `createMachine` to `verifyMachine` (which already has it), so the machine list only refreshes after the wizard completes.

## Test plan
- [ ] Add a machine from an empty state (no existing machines) — SSH key should remain visible on the copy-key step
- [ ] Add a machine when machines already exist — same behavior, key stays visible
- [ ] After copying the key and clicking "I've added the key", verification step should work as before
- [ ] On successful verification, machine list should refresh and show the new machine
- [ ] On failed verification, retry should still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Reorganized empty-state rendering logic in the machines view component to improve code structure, reduce complexity, and enhance maintainability while preserving all existing display scenarios
- Adjusted cache invalidation behavior for machine creation operations to optimize when related server data is automatically refreshed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nixopus/nixopus/pull/1347)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->