### PR TITLE
fix(apps): prevent indefinite skeleton loader on client-side navigation

### DIFF
--- a/view/packages/hooks/applications/use_get_deployed_applications.ts
+++ b/view/packages/hooks/applications/use_get_deployed_applications.ts
@@ -128,7 +128,9 @@ function useGetDeployedApplications() {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
   useEffect(() => {
-    getSelfHosted().then(setSelfHosted);
+    getSelfHosted()
+      .then(setSelfHosted)
+      .catch(() => setSelfHosted(false));
   }, []);
 
   useEffect(() => {

--- a/view/redux/conf.ts
+++ b/view/redux/conf.ts
@@ -56,6 +56,10 @@ async function fetchConfig() {
         }
         configPromise = null;
         throw new Error('Invalid config: missing baseUrl');
+      })
+      .catch((err) => {
+        configPromise = null;
+        throw err;
       });
   }
   return configPromise;


### PR DESCRIPTION
## Summary

Fixes #1349

The Apps page displays a skeleton loader indefinitely when navigated to from another page via client-side routing. The page only renders correctly on a full page refresh. This happens because `selfHosted` state stays `null` forever when `getSelfHosted()` fails during client-side navigation, and the skeleton condition (`selfHosted === null`) never transitions to false.

## Root Cause

In `use_get_deployed_applications.ts`, the `selfHosted` state is initialized to `null` and set via:

```ts
useEffect(() => {
    getSelfHosted().then(setSelfHosted);
}, []);
```

If `getSelfHosted()` rejects (e.g., `fetchConfig()` in `conf.ts` encounters a network error and leaves `configPromise` as a permanently rejected promise), `setSelfHosted` is never called. The page condition `selfHosted === null || isLoadingApplications || isLoading` remains true indefinitely, showing the skeleton forever.

Additionally, `fetchConfig()` in `conf.ts` has no error recovery — a failed fetch leaves `configPromise` in a permanently rejected state with no retry mechanism.

## Fix

Two changes:

1. **`use_get_deployed_applications.ts`**: Added `.catch(() => setSelfHosted(false))` to the `getSelfHosted()` promise chain. If the config fetch fails, the page defaults to managed mode (showing content) instead of showing an indefinite skeleton.

2. **`conf.ts`**: Added `.catch()` to reset `configPromise` to `null` on fetch failure, allowing subsequent `fetchConfig()` calls to retry instead of returning a permanently rejected promise.

## Changes

- `view/packages/hooks/applications/use_get_deployed_applications.ts`: Added error fallback to `getSelfHosted()` call (`+2 -1` lines)
- `view/redux/conf.ts`: Added catch handler to reset `configPromise` on fetch failure (`+4 -0` lines)

## Testing

- **Normal page load (happy path)**: `getSelfHosted()` resolves successfully, page renders normally ✅
- **Client-side navigation with config available**: `config` module variable already set, `getSelfHosted()` resolves immediately, page renders ✅
- **Client-side navigation with config fetch failure**: `getSelfHosted()` rejects, catch sets `selfHosted` to `false`, page renders managed-mode UI instead of infinite skeleton ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for application deployment status checks to prevent unresolved states.
  * Fixed configuration loading to properly retry after network or parsing failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nixopus/nixopus/pull/1350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->